### PR TITLE
Add a workflow for static analysis of Dart code

### DIFF
--- a/.github/workflows/dart.yml
+++ b/.github/workflows/dart.yml
@@ -1,0 +1,32 @@
+name: Dart
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  analysis:
+    runs-on: ubuntu-latest
+    container:
+      image: google/dart:2.10.0-110.3.beta
+    steps:
+      - uses: actions/checkout@v2
+      - name: Install missing dependencies for flutter-action
+        run: |
+          apt update
+          apt install xz-utils
+      - uses: subosito/flutter-action@v1
+        with:
+          flutter-version: "1.22.0"
+      - name: Install pub dependencies
+        run: |
+          for d in `pwd`/packages/*/; do
+            cd $d
+            flutter pub get || true
+          done
+      - name: Verify formatting
+        run: dart format --output=none --set-exit-if-changed packages
+      - name: Analyze project source
+        run: dart analyze --fatal-infos packages

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -1,5 +1,4 @@
-# This file was copied from `flutter_tools/analysis_options.yaml` and should be
-# kept in sync.
+# This file was copied from flutter/analysis_options.yaml.
 
 analyzer:
   strong-mode:
@@ -20,11 +19,7 @@ analyzer:
     # Please see https://github.com/flutter/flutter/pull/24528 for details.
     sdk_version_async_exported_from_core: ignore
   exclude:
-    - "bin/cache/**"
-    # the following two are relative to the stocks example and the flutter package respectively
-    # see https://github.com/dart-lang/sdk/issues/28463
-    - "lib/i18n/messages_*.dart"
-    - "lib/src/http/**"
+    - "**/example/**"
 
 linter:
   rules:

--- a/packages/path_provider/pubspec.yaml
+++ b/packages/path_provider/pubspec.yaml
@@ -13,7 +13,7 @@ flutter:
 dependencies:
   flutter:
     sdk: flutter
-  path_provider_platform_interface: ^1.0.1
+  path_provider_platform_interface: 1.0.1
   ffi: ^0.1.3
 
 dev_dependencies:

--- a/packages/shared_preferences/lib/shared_preferences_tizen.dart
+++ b/packages/shared_preferences/lib/shared_preferences_tizen.dart
@@ -79,11 +79,12 @@ class SharedPreferencesPlugin extends SharedPreferencesStorePlatform {
     }
     _cachedPreferences = <String, Object>{};
 
-    if (bindings.foreachItem(
-            Pointer.fromFunction(_preferenceItemCallback, 0), nullptr) != 0) {
-      return <String, Object>{};
+    final int ret = bindings.foreachItem(
+        Pointer.fromFunction(_preferenceItemCallback, 0), nullptr);
+    if (ret == 0) {
+      return _cachedPreferences;
     }
-    return _cachedPreferences;
+    return <String, Object>{};
   }
 
   @override
@@ -119,7 +120,7 @@ class SharedPreferencesPlugin extends SharedPreferencesStorePlatform {
       ret = bindings.setString(pKey, Utf8.toUtf8(value as String));
     } else if (valueType == 'StringList') {
       // Tizen Preference API doesn't support arrays.
-      final List<String> list = value;
+      final List<String> list = value as List<String>;
       String joined;
       if (list.isEmpty) {
         joined = _separator;

--- a/packages/shared_preferences/pubspec.yaml
+++ b/packages/shared_preferences/pubspec.yaml
@@ -13,7 +13,7 @@ flutter:
 dependencies:
   flutter:
     sdk: flutter
-  shared_preferences_platform_interface: ^1.0.0
+  shared_preferences_platform_interface: 1.0.0
   ffi: ^0.1.3
 
 dev_dependencies:

--- a/packages/url_launcher/example/pubspec.yaml
+++ b/packages/url_launcher/example/pubspec.yaml
@@ -15,7 +15,6 @@ dev_dependencies:
   flutter_driver:
     sdk: flutter
   pedantic: ^1.8.0
-  plugin_platform_interface: ^1.0.0
 
 flutter:
   uses-material-design: true

--- a/packages/url_launcher/lib/url_launcher_tizen.dart
+++ b/packages/url_launcher/lib/url_launcher_tizen.dart
@@ -10,7 +10,7 @@ import 'package:url_launcher_platform_interface/url_launcher_platform_interface.
 import 'app_control.dart';
 
 class UrlLauncherPlugin extends UrlLauncherPlatform {
-  static final _supportedSchemes = {
+  static final Set<String> _supportedSchemes = <String>{
     'file',
     'http',
     'https',

--- a/packages/url_launcher/pubspec.yaml
+++ b/packages/url_launcher/pubspec.yaml
@@ -13,7 +13,7 @@ flutter:
 dependencies:
   flutter:
     sdk: flutter
-  url_launcher_platform_interface: ^1.0.8
+  url_launcher_platform_interface: 1.0.8
   ffi: ^0.1.3
   meta: ^1.1.7
 
@@ -22,10 +22,9 @@ dev_dependencies:
   flutter_test:
     sdk: flutter
   mockito: ^4.1.1
-  plugin_platform_interface: ^1.0.0
   pedantic: ^1.8.0
   url_launcher: ^5.7.5
 
 environment:
-  sdk: ">=2.1.0 <3.0.0"
+  sdk: ">=2.2.2 <3.0.0"
   flutter: ">=1.12.13+hotfix.5 <2.0.0"


### PR DESCRIPTION
- Use concrete version dependencies on platform interface packages (because platform interfaces are not necessarily backward compatible)
- Update analysis_options.yaml and resolve warnings
- Add a workflow (Dart)

The workflow verifies Dart code only. More checks will be added later for full analysis of other requirements.