### PR TITLE
Increase the Flutter SDK requirement

### DIFF
--- a/packages/integration_test/example/pubspec.yaml
+++ b/packages/integration_test/example/pubspec.yaml
@@ -2,10 +2,6 @@ name: integration_test_example
 description: Demonstrates how to use the integration_test plugin.
 publish_to: 'none'
 
-environment:
-  sdk: ">=2.1.0 <3.0.0"
-  flutter: ">=1.6.7 <2.0.0"
-
 dependencies:
   flutter:
     sdk: flutter
@@ -24,3 +20,7 @@ dev_dependencies:
 
 flutter:
   uses-material-design: true
+
+environment:
+  sdk: ">=2.2.2 <3.0.0"
+  flutter: ">=1.20.0 <2.0.0"

--- a/packages/integration_test/pubspec.yaml
+++ b/packages/integration_test/pubspec.yaml
@@ -24,4 +24,4 @@ dev_dependencies:
 
 environment:
   sdk: ">=2.2.2 <3.0.0"
-  flutter: ">=1.12.13+hotfix.5 <2.0.0"
+  flutter: ">=1.20.0 <2.0.0"

--- a/packages/path_provider/example/pubspec.yaml
+++ b/packages/path_provider/example/pubspec.yaml
@@ -25,5 +25,5 @@ flutter:
   uses-material-design: true
 
 environment:
-  sdk: ">=2.1.0 <3.0.0"
-  flutter: ">=1.12.13+hotfix.5 <2.0.0"
+  sdk: ">=2.2.2 <3.0.0"
+  flutter: ">=1.20.0 <2.0.0"

--- a/packages/path_provider/pubspec.yaml
+++ b/packages/path_provider/pubspec.yaml
@@ -22,5 +22,5 @@ dev_dependencies:
   pedantic: ^1.8.0
 
 environment:
-  sdk: ">=2.1.0 <3.0.0"
-  flutter: ">=1.12.13+hotfix.5 <2.0.0"
+  sdk: ">=2.2.2 <3.0.0"
+  flutter: ">=1.20.0 <2.0.0"

--- a/packages/sensors/example/pubspec.yaml
+++ b/packages/sensors/example/pubspec.yaml
@@ -20,5 +20,5 @@ flutter:
   uses-material-design: true
 
 environment:
-  sdk: ">=2.0.0-dev.28.0 <3.0.0"
-  flutter: ">=1.9.1+hotfix.2 <2.0.0"
+  sdk: ">=2.2.2 <3.0.0"
+  flutter: ">=1.20.0 <2.0.0"

--- a/packages/sensors/pubspec.yaml
+++ b/packages/sensors/pubspec.yaml
@@ -25,5 +25,5 @@ dev_dependencies:
   sensors: ^0.4.0
 
 environment:
-  sdk: ">=2.1.0<3.0.0"
-  flutter: ">=1.12.13+hotfix.5 <2.0.0"
+  sdk: ">=2.2.2 <3.0.0"
+  flutter: ">=1.20.0 <2.0.0"

--- a/packages/shared_preferences/example/pubspec.yaml
+++ b/packages/shared_preferences/example/pubspec.yaml
@@ -21,5 +21,5 @@ flutter:
   uses-material-design: true
 
 environment:
-  sdk: ">=2.0.0-dev.28.0 <3.0.0"
-  flutter: ">=1.9.1+hotfix.2 <2.0.0"
+  sdk: ">=2.2.2 <3.0.0"
+  flutter: ">=1.20.0 <2.0.0"

--- a/packages/shared_preferences/pubspec.yaml
+++ b/packages/shared_preferences/pubspec.yaml
@@ -22,5 +22,5 @@ dev_dependencies:
   pedantic: ^1.8.0
 
 environment:
-  sdk: ">=2.1.0 <3.0.0"
-  flutter: ">=1.12.13+hotfix.5 <2.0.0"
+  sdk: ">=2.2.2 <3.0.0"
+  flutter: ">=1.20.0 <2.0.0"

--- a/packages/url_launcher/example/pubspec.yaml
+++ b/packages/url_launcher/example/pubspec.yaml
@@ -20,5 +20,5 @@ flutter:
   uses-material-design: true
 
 environment:
-  sdk: ">=2.1.0 <3.0.0"
-  flutter: ">=1.12.13+hotfix.5 <2.0.0"
+  sdk: ">=2.2.2 <3.0.0"
+  flutter: ">=1.20.0 <2.0.0"

--- a/packages/url_launcher/pubspec.yaml
+++ b/packages/url_launcher/pubspec.yaml
@@ -27,4 +27,4 @@ dev_dependencies:
 
 environment:
   sdk: ">=2.2.2 <3.0.0"
-  flutter: ">=1.12.13+hotfix.5 <2.0.0"
+  flutter: ">=1.20.0 <2.0.0"


### PR DESCRIPTION
To upload the packages to pub.dev, `flutter>=1.20.0` is required.

```
pubspec.yaml allows Flutter SDK version prior to 1.20.0, which does not support having no `ios/` folder.
Please consider increasing the Flutter SDK requirement to ^1.20.0 or higher (environment.sdk.flutter) or create an `ios/` folder.

See https://flutter.dev/docs/development/packages-and-plugins/developing-packages#plugin
```