### PR TITLE
[webview_flutter] Update webview to be focused

### DIFF
--- a/packages/webview_flutter/example/tizen/shared/res/input.html
+++ b/packages/webview_flutter/example/tizen/shared/res/input.html
@@ -3,7 +3,7 @@
  <head>
  </head>
 
- <body>
+ <body style="background-color: blue">
 	<input id="ip1" type="text" ></input>
 	<button onclick="a()">Click</button>
 	<input id="ip2" type="text" ></input>


### PR DESCRIPTION
* A webview has to act like a FocusNode. So, when it is clicked or released, a FocusCallback function should be called.

Signed-off-by: Seungsoo Lee <seungsoo47.lee@samsung.com>