### PR TITLE
[url_launcher] Make platform interface version constraint less tight

### DIFF
--- a/.github/workflows/dart.yml
+++ b/.github/workflows/dart.yml
@@ -9,14 +9,8 @@ on:
 jobs:
   analysis:
     runs-on: ubuntu-latest
-    container:
-      image: google/dart:2.10.0-110.3.beta
     steps:
       - uses: actions/checkout@v2
-      - name: Install missing dependencies for flutter-action
-        run: |
-          apt update
-          apt install xz-utils
       - uses: subosito/flutter-action@v1
         with:
           flutter-version: "1.22.0"
@@ -24,9 +18,7 @@ jobs:
         run: |
           for d in `pwd`/packages/*/; do
             cd $d
-            flutter pub get || true
+            flutter pub downgrade
           done
       - name: Verify formatting
-        run: dart format --output=none --set-exit-if-changed packages
-      - name: Analyze project source
-        run: dart analyze --fatal-infos packages
+        run: flutter format --set-exit-if-changed packages

--- a/packages/url_launcher/CHANGELOG.md
+++ b/packages/url_launcher/CHANGELOG.md
@@ -1,3 +1,7 @@
 ## 1.0.0
 
 * Initial release.
+
+## 1.0.1
+
+* Migrate to Tizen 4.0

--- a/packages/url_launcher/README.md
+++ b/packages/url_launcher/README.md
@@ -9,7 +9,7 @@ This package is not an _endorsed_ implementation of `url_launcher`. Therefore, y
 ```yaml
 dependencies:
   url_launcher: ^5.7.5
-  url_launcher_tizen: ^1.0.0
+  url_launcher_tizen: ^1.0.1
 ```
 
 Then you can import `url_launcher` in your Dart code:

--- a/packages/url_launcher/example/pubspec.yaml
+++ b/packages/url_launcher/example/pubspec.yaml
@@ -1,5 +1,6 @@
 name: url_launcher_example
 description: Demonstrates how to use the url_launcher_tizen plugin.
+publish_to: 'none'
 
 dependencies:
   flutter:
@@ -9,12 +10,11 @@ dependencies:
     path: ../
 
 dev_dependencies:
-  integration_test: ^0.9.2
+  integration_test: ^1.0.1
   integration_test_tizen:
     path: ../../integration_test/
   flutter_driver:
     sdk: flutter
-  pedantic: ^1.8.0
 
 flutter:
   uses-material-design: true

--- a/packages/url_launcher/example/tizen/Runner.csproj
+++ b/packages/url_launcher/example/tizen/Runner.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>tizen60</TargetFramework>
+    <TargetFramework>tizen40</TargetFramework>
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/packages/url_launcher/example/tizen/tizen-manifest.xml
+++ b/packages/url_launcher/example/tizen/tizen-manifest.xml
@@ -1,10 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest package="org.tizen.url_launcher_example" version="1.0.0" api-version="5.5" xmlns="http://tizen.org/ns/packages">
+<manifest package="org.tizen.url_launcher_example" version="1.0.0" api-version="4.0" xmlns="http://tizen.org/ns/packages">
     <profile name="common"/>
-    <ui-application appid="org.tizen.url_launcher_example" exec="Runner.dll" type="dotnet" multiple="false" taskmanage="true" nodisplay="false" api-version="6" launch_mode="single">
+    <ui-application appid="org.tizen.url_launcher_example" exec="Runner.dll" type="dotnet" multiple="false" taskmanage="true" nodisplay="false" api-version="4" launch_mode="single">
         <label>url_launcher_example</label>
         <icon>ic_launcher.png</icon>
         <metadata key="http://tizen.org/metadata/prefer_dotnet_aot" value="true"/>
+        <metadata key="http://tizen.org/metadata/direct-launch" value="yes"/>
     </ui-application>
     <feature name="http://tizen.org/feature/screen.size.all"/>
     <privileges>

--- a/packages/url_launcher/pubspec.yaml
+++ b/packages/url_launcher/pubspec.yaml
@@ -1,7 +1,7 @@
 name: url_launcher_tizen
 description: Tizen implementation of the url_launcher plugin
 homepage: https://github.com/flutter-tizen/plugins
-version: 1.0.0
+version: 1.0.1
 
 flutter:
   plugin:
@@ -13,7 +13,7 @@ flutter:
 dependencies:
   flutter:
     sdk: flutter
-  url_launcher_platform_interface: 1.0.8
+  url_launcher_platform_interface: ^1.0.8
   ffi: ^0.1.3
   meta: ^1.1.7
 
@@ -22,7 +22,6 @@ dev_dependencies:
   flutter_test:
     sdk: flutter
   mockito: ^4.1.1
-  pedantic: ^1.8.0
   url_launcher: ^5.7.5
 
 environment:


### PR DESCRIPTION
- Use the caret (^) syntax for platform interface version
- Migrate the example to Tizen 4.0
- Small changes to the CI script
  - Resolve to the oldest possible dependencies
  - Remove the meaningless "dart analyze" job