### PR TITLE
[webview_flutter] Add NavigationDelegate and onWebResourceError

### DIFF
--- a/packages/webview_flutter/tizen/src/webview.h
+++ b/packages/webview_flutter/tizen/src/webview.h
@@ -37,6 +37,8 @@ class WebView : public PlatformView {
 
   virtual void SetSoftwareKeyboardContext(Ecore_IMF_Context* context) override;
 
+  LWE::WebContainer* GetWebViewInstance() { return webViewInstance_; }
+
  private:
   void HandleMethodCall(
       const flutter::MethodCall<flutter::EncodableValue>& method_call,
@@ -46,6 +48,7 @@ class WebView : public PlatformView {
   void InitWebView();
 
   void RegisterJavaScriptChannelName(const std::string& name);
+  void ApplySettings(flutter::EncodableMap);
 
   FlutterTextureRegistrar* textureRegistrar_;
   LWE::WebContainer* webViewInstance_;
@@ -54,6 +57,7 @@ class WebView : public PlatformView {
   double height_;
   tbm_surface_h tbmSurface_;
   bool isMouseLButtonDown_;
+  bool hasNavigationDelegate_;
   std::unique_ptr<flutter::MethodChannel<flutter::EncodableValue>> channel_;
 };
 

--- a/packages/webview_flutter/tizen/src/webview_factory.cc
+++ b/packages/webview_flutter/tizen/src/webview_factory.cc
@@ -36,8 +36,14 @@ PlatformView* WebViewFactory::Create(int viewId, double width, double height,
   if (std::holds_alternative<flutter::EncodableMap>(decodedValue)) {
     params = std::get<flutter::EncodableMap>(decodedValue);
   }
-  return new WebView(GetPluginRegistrar(), viewId, textureRegistrar_, width,
-                     height, params);
+
+  try {
+    return new WebView(GetPluginRegistrar(), viewId, textureRegistrar_, width,
+                       height, params);
+  } catch (const std::invalid_argument& ex) {
+    LOG_ERROR("[Exception] %s\n", ex.what());
+    return nullptr;
+  }
 }
 
 void WebViewFactory::Dispose() { LWE::LWE::Finalize(); }


### PR DESCRIPTION
* The NavigationDelegate handler decides how to handle navigation actions
* When the handler is null, all navigation actions are allowed
* Implement the onWebResourceError callback to report web resource loading error
* The callback's error codes use ones provided by lightweight-web-engine on tizen

Signed-off-by: Seungsoo Lee <seungsoo47.lee@samsung.com>