### PR TITLE
[url_launcher] Update platform interface to 1.0.9

### DIFF
--- a/packages/url_launcher/CHANGELOG.md
+++ b/packages/url_launcher/CHANGELOG.md
@@ -5,3 +5,9 @@
 ## 1.0.1
 
 * Migrate to Tizen 4.0
+
+## 1.0.2
+
+* Update url_launcher to 5.7.10
+* Update platform interface to 1.0.9
+* Increase the minimum framework requirement to 1.22.0

--- a/packages/url_launcher/README.md
+++ b/packages/url_launcher/README.md
@@ -8,8 +8,8 @@ This package is not an _endorsed_ implementation of `url_launcher`. Therefore, y
 
 ```yaml
 dependencies:
-  url_launcher: ^5.7.5
-  url_launcher_tizen: ^1.0.1
+  url_launcher: ^5.7.10
+  url_launcher_tizen: ^1.0.2
 ```
 
 Then you can import `url_launcher` in your Dart code:

--- a/packages/url_launcher/example/pubspec.yaml
+++ b/packages/url_launcher/example/pubspec.yaml
@@ -5,7 +5,7 @@ publish_to: 'none'
 dependencies:
   flutter:
     sdk: flutter
-  url_launcher: ^5.7.5
+  url_launcher: ^5.7.10
   url_launcher_tizen:
     path: ../
 
@@ -21,4 +21,4 @@ flutter:
 
 environment:
   sdk: ">=2.2.2 <3.0.0"
-  flutter: ">=1.20.0 <2.0.0"
+  flutter: ">=1.22.0 <2.0.0"

--- a/packages/url_launcher/lib/url_launcher_tizen.dart
+++ b/packages/url_launcher/lib/url_launcher_tizen.dart
@@ -5,6 +5,7 @@
 import 'dart:async';
 
 import 'package:meta/meta.dart';
+import 'package:url_launcher_platform_interface/link.dart';
 import 'package:url_launcher_platform_interface/url_launcher_platform_interface.dart';
 
 import 'app_control.dart';
@@ -20,6 +21,9 @@ class UrlLauncherPlugin extends UrlLauncherPlatform {
   static void register() {
     UrlLauncherPlatform.instance = UrlLauncherPlugin();
   }
+
+  @override
+  final LinkDelegate linkDelegate = null;
 
   String _getUrlScheme(String url) => Uri.tryParse(url)?.scheme;
 

--- a/packages/url_launcher/pubspec.yaml
+++ b/packages/url_launcher/pubspec.yaml
@@ -1,7 +1,7 @@
 name: url_launcher_tizen
 description: Tizen implementation of the url_launcher plugin
 homepage: https://github.com/flutter-tizen/plugins
-version: 1.0.1
+version: 1.0.2
 
 flutter:
   plugin:
@@ -13,7 +13,7 @@ flutter:
 dependencies:
   flutter:
     sdk: flutter
-  url_launcher_platform_interface: ^1.0.8
+  url_launcher_platform_interface: ^1.0.9
   ffi: ^0.1.3
   meta: ^1.1.7
 
@@ -22,8 +22,8 @@ dev_dependencies:
   flutter_test:
     sdk: flutter
   mockito: ^4.1.1
-  url_launcher: ^5.7.5
+  url_launcher: ^5.7.10
 
 environment:
   sdk: ">=2.2.2 <3.0.0"
-  flutter: ">=1.20.0 <2.0.0"
+  flutter: ">=1.22.0 <2.0.0"


### PR DESCRIPTION
The `linkDelegate` property has been added in 1.0.9 to support the newly proposed Link widget. For more information on it, see the relevant changes (#3154, #3177) in the [flutter/plugins](https://github.com/flutter/plugins) repo and the [source code](https://github.com/flutter/plugins/blob/master/packages/url_launcher/url_launcher/lib/src/link.dart).

`null` can be returned to enable a fallback to `DefaultLinkDelegate` on non-web platforms.