### PR TITLE
[camera] Send focusPointSupported as a true

### DIFF
--- a/packages/camera/tizen/src/camera_device.cc
+++ b/packages/camera/tizen/src/camera_device.cc
@@ -544,9 +544,8 @@ bool CameraDevice::Open(std::string image_format_group) {
   map[flutter::EncodableValue("exposureMode")] =
       flutter::EncodableValue(exposure_mode);
 
-  // TODO
   map[flutter::EncodableValue("focusPointSupported")] =
-      flutter::EncodableValue(false);
+      flutter::EncodableValue(true);
 
   // exposurePoint is unsupported on Tizen
   map[flutter::EncodableValue("exposurePointSupported")] =


### PR DESCRIPTION
* Even if I send this to false when opening camera,
  the focus point request arrived to method handler normally

Signed-off-by: Boram Bae <boram21.bae@samsung.com>