### PR TITLE
Use get_error_message() whenever possible

### DIFF
--- a/packages/audioplayers/tizen/src/log.h
+++ b/packages/audioplayers/tizen/src/log.h
@@ -9,8 +9,7 @@
 #define LOG_TAG "AudioplayersTizenPlugin"
 
 #ifndef __MODULE__
-#define __MODULE__ \
-  (strrchr(__FILE__, '/') ? strrchr(__FILE__, '/') + 1 : __FILE__)
+#define __MODULE__ strrchr("/" __FILE__, '/') + 1
 #endif
 
 #define LOG(prio, fmt, arg...)                                         \

--- a/packages/audioplayers/tizen/src/log.h
+++ b/packages/audioplayers/tizen/src/log.h
@@ -8,9 +8,14 @@
 #endif
 #define LOG_TAG "AudioplayersTizenPlugin"
 
-#define LOG(prio, fmt, arg...)                                                 \
-  dlog_print(prio, LOG_TAG, "%s: %s(%d) > " fmt, __FILE__, __func__, __LINE__, \
-             ##arg)
+#ifndef __MODULE__
+#define __MODULE__ \
+  (strrchr(__FILE__, '/') ? strrchr(__FILE__, '/') + 1 : __FILE__)
+#endif
+
+#define LOG(prio, fmt, arg...)                                         \
+  dlog_print(prio, LOG_TAG, "%s: %s(%d) > " fmt, __MODULE__, __func__, \
+             __LINE__, ##arg)
 
 #define LOG_DEBUG(fmt, args...) LOG(DLOG_DEBUG, fmt, ##args)
 #define LOG_INFO(fmt, args...) LOG(DLOG_INFO, fmt, ##args)

--- a/packages/battery/tizen/src/battery_tizen_plugin.cc
+++ b/packages/battery/tizen/src/battery_tizen_plugin.cc
@@ -18,29 +18,6 @@
 
 #include "log.h"
 
-static std::string DeviceErrorToString(int error) {
-  switch (error) {
-    case DEVICE_ERROR_NONE:
-      return "Device - Successful";
-    case DEVICE_ERROR_OPERATION_FAILED:
-      return "Device - Operation not permitted";
-    case DEVICE_ERROR_PERMISSION_DENIED:
-      return "Device - Permission denied";
-    case DEVICE_ERROR_INVALID_PARAMETER:
-      return "Device - Invalid parameter";
-    case DEVICE_ERROR_ALREADY_IN_PROGRESS:
-      return "Device - Operation already in progress";
-    case DEVICE_ERROR_NOT_SUPPORTED:
-      return "Device - Not supported on this device";
-    case DEVICE_ERROR_RESOURCE_BUSY:
-      return "Device - Device or resource busy";
-    case DEVICE_ERROR_NOT_INITIALIZED:
-      return "Device - Not initialized";
-    default:
-      return "Device - Unknown Error";
-  }
-}
-
 class BatteryTizenPlugin : public flutter::Plugin {
  public:
   static void RegisterWithRegistrar(flutter::PluginRegistrar *registrar) {
@@ -105,14 +82,14 @@ class BatteryTizenPlugin : public flutter::Plugin {
     int ret = device_add_callback(DEVICE_CALLBACK_BATTERY_CHARGING,
                                   BatteryChangedCB, this);
     if (ret != DEVICE_ERROR_NONE) {
-      m_events->Error("failed_to_add_callback", DeviceErrorToString(ret));
+      m_events->Error("failed_to_add_callback", get_error_message(ret));
       return;
     }
 
     ret = device_add_callback(DEVICE_CALLBACK_BATTERY_LEVEL, BatteryChangedCB,
                               this);
     if (ret != DEVICE_ERROR_NONE) {
-      m_events->Error("failed_to_add_callback", DeviceErrorToString(ret));
+      m_events->Error("failed_to_add_callback", get_error_message(ret));
       return;
     }
 
@@ -129,13 +106,13 @@ class BatteryTizenPlugin : public flutter::Plugin {
                                      BatteryChangedCB);
     if (ret != DEVICE_ERROR_NONE) {
       LOG_ERROR("Failed to run device_remove_callback (%d: %s)", ret,
-                DeviceErrorToString(ret).c_str());
+                get_error_message(ret));
     }
     ret =
         device_remove_callback(DEVICE_CALLBACK_BATTERY_LEVEL, BatteryChangedCB);
     if (ret != DEVICE_ERROR_NONE) {
       LOG_ERROR("Failed to run device_remove_callback (%d: %s)", ret,
-                DeviceErrorToString(ret).c_str());
+                get_error_message(ret));
     }
 
     m_events = nullptr;
@@ -146,7 +123,7 @@ class BatteryTizenPlugin : public flutter::Plugin {
     int ret = device_battery_get_status(&status);
     if (ret != DEVICE_ERROR_NONE) {
       LOG_ERROR("Failed to run device_battery_get_status (%d: %s)", ret,
-                DeviceErrorToString(ret).c_str());
+                get_error_message(ret));
       return "";
     }
 
@@ -209,7 +186,7 @@ class BatteryTizenPlugin : public flutter::Plugin {
     int ret, percentage;
     ret = device_battery_get_percent(&percentage);
     if (ret != DEVICE_ERROR_NONE) {
-      result->Error("failed_to_get_percentage", DeviceErrorToString(ret));
+      result->Error("failed_to_get_percentage", get_error_message(ret));
     }
     LOG_INFO("battery percentage [%d]", percentage);
     result->Success(flutter::EncodableValue(percentage));

--- a/packages/battery/tizen/src/log.h
+++ b/packages/battery/tizen/src/log.h
@@ -9,8 +9,7 @@
 #define LOG_TAG "BatteryTizenPlugin"
 
 #ifndef __MODULE__
-#define __MODULE__ \
-  (strrchr(__FILE__, '/') ? strrchr(__FILE__, '/') + 1 : __FILE__)
+#define __MODULE__ strrchr("/" __FILE__, '/') + 1
 #endif
 
 #define LOG(prio, fmt, arg...)                                         \

--- a/packages/battery/tizen/src/log.h
+++ b/packages/battery/tizen/src/log.h
@@ -8,9 +8,14 @@
 #endif
 #define LOG_TAG "BatteryTizenPlugin"
 
-#define LOG(prio, fmt, arg...)                                                 \
-  dlog_print(prio, LOG_TAG, "%s: %s(%d) > " fmt, __FILE__, __func__, __LINE__, \
-             ##arg)
+#ifndef __MODULE__
+#define __MODULE__ \
+  (strrchr(__FILE__, '/') ? strrchr(__FILE__, '/') + 1 : __FILE__)
+#endif
+
+#define LOG(prio, fmt, arg...)                                         \
+  dlog_print(prio, LOG_TAG, "%s: %s(%d) > " fmt, __MODULE__, __func__, \
+             __LINE__, ##arg)
 
 #define LOG_DEBUG(fmt, args...) LOG(DLOG_DEBUG, fmt, ##args)
 #define LOG_INFO(fmt, args...) LOG(DLOG_INFO, fmt, ##args)

--- a/packages/camera/tizen/src/log.h
+++ b/packages/camera/tizen/src/log.h
@@ -9,8 +9,7 @@
 #define LOG_TAG "CameraPlugin"
 
 #ifndef __MODULE__
-#define __MODULE__ \
-  (strrchr(__FILE__, '/') ? strrchr(__FILE__, '/') + 1 : __FILE__)
+#define __MODULE__ strrchr("/" __FILE__, '/') + 1
 #endif
 
 #define LOG(prio, fmt, arg...)                                         \

--- a/packages/connectivity/tizen/src/log.h
+++ b/packages/connectivity/tizen/src/log.h
@@ -8,9 +8,14 @@
 #endif
 #define LOG_TAG "ConnectivityTizenPlugin"
 
-#define LOG(prio, fmt, arg...)                                                 \
-  dlog_print(prio, LOG_TAG, "%s: %s(%d) > " fmt, __FILE__, __func__, __LINE__, \
-             ##arg)
+#ifndef __MODULE__
+#define __MODULE__ \
+  (strrchr(__FILE__, '/') ? strrchr(__FILE__, '/') + 1 : __FILE__)
+#endif
+
+#define LOG(prio, fmt, arg...)                                         \
+  dlog_print(prio, LOG_TAG, "%s: %s(%d) > " fmt, __MODULE__, __func__, \
+             __LINE__, ##arg)
 
 #define LOG_DEBUG(fmt, args...) LOG(DLOG_DEBUG, fmt, ##args)
 #define LOG_INFO(fmt, args...) LOG(DLOG_INFO, fmt, ##args)

--- a/packages/connectivity/tizen/src/log.h
+++ b/packages/connectivity/tizen/src/log.h
@@ -9,8 +9,7 @@
 #define LOG_TAG "ConnectivityTizenPlugin"
 
 #ifndef __MODULE__
-#define __MODULE__ \
-  (strrchr(__FILE__, '/') ? strrchr(__FILE__, '/') + 1 : __FILE__)
+#define __MODULE__ strrchr("/" __FILE__, '/') + 1
 #endif
 
 #define LOG(prio, fmt, arg...)                                         \

--- a/packages/device_info/tizen/src/device_info_tizen_plugin.cc
+++ b/packages/device_info/tizen/src/device_info_tizen_plugin.cc
@@ -19,23 +19,6 @@
 
 #include "log.h"
 
-static std::string systemInfoErrorToString(int error) {
-  switch (error) {
-    case SYSTEM_INFO_ERROR_NONE:
-      return "SystemInfo - Successful";
-    case SYSTEM_INFO_ERROR_INVALID_PARAMETER:
-      return "SystemInfo - Invalid parameter";
-    case SYSTEM_INFO_ERROR_OUT_OF_MEMORY:
-      return "SystemInfo - Out of Memory";
-    case SYSTEM_INFO_ERROR_IO_ERROR:
-      return "SystemInfo - IO Error";
-    case SYSTEM_INFO_ERROR_PERMISSION_DENIED:
-      return "SystemInfo - Permission denied";
-    default:
-      return "SystemInfo - Unknown Error";
-  }
-}
-
 class DeviceInfoTizenPlugin : public flutter::Plugin {
  public:
   static void RegisterWithRegistrar(flutter::PluginRegistrar *registrar) {
@@ -75,7 +58,7 @@ class DeviceInfoTizenPlugin : public flutter::Plugin {
     ret = system_info_get_platform_string("http://tizen.org/system/model_name",
                                           &value);
     if (ret != SYSTEM_INFO_ERROR_NONE) {
-      resultStr = systemInfoErrorToString(ret);
+      resultStr = get_error_message(ret);
       errorStr.append(" Failed to get model name: ");
       errorStr.append(resultStr);
     } else {
@@ -91,7 +74,7 @@ class DeviceInfoTizenPlugin : public flutter::Plugin {
     ret = system_info_get_platform_string(
         "http://tizen.org/feature/platform.core.cpu.arch", &value);
     if (ret != SYSTEM_INFO_ERROR_NONE) {
-      resultStr = systemInfoErrorToString(ret);
+      resultStr = get_error_message(ret);
       errorStr.append(" Failed to get cpu arch: ");
       errorStr.append(resultStr);
     } else {
@@ -107,7 +90,7 @@ class DeviceInfoTizenPlugin : public flutter::Plugin {
     ret = system_info_get_platform_string(
         "http://tizen.org/feature/platform.native.api.version", &value);
     if (ret != SYSTEM_INFO_ERROR_NONE) {
-      resultStr = systemInfoErrorToString(ret);
+      resultStr = get_error_message(ret);
       errorStr.append(" Failed to get native api version: ");
       errorStr.append(resultStr);
     } else {
@@ -123,7 +106,7 @@ class DeviceInfoTizenPlugin : public flutter::Plugin {
     ret = system_info_get_platform_string(
         "http://tizen.org/feature/platform.version", &value);
     if (ret != SYSTEM_INFO_ERROR_NONE) {
-      resultStr = systemInfoErrorToString(ret);
+      resultStr = get_error_message(ret);
       errorStr.append(" Failed to get platform version: ");
       errorStr.append(resultStr);
     } else {
@@ -139,7 +122,7 @@ class DeviceInfoTizenPlugin : public flutter::Plugin {
     ret = system_info_get_platform_string(
         "http://tizen.org/feature/platform.web.api.version", &value);
     if (ret != SYSTEM_INFO_ERROR_NONE) {
-      resultStr = systemInfoErrorToString(ret);
+      resultStr = get_error_message(ret);
       errorStr.append(" Failed to get web api version: ");
       errorStr.append(resultStr);
     } else {
@@ -155,7 +138,7 @@ class DeviceInfoTizenPlugin : public flutter::Plugin {
     ret = system_info_get_platform_string("http://tizen.org/system/build.date",
                                           &value);
     if (ret != SYSTEM_INFO_ERROR_NONE) {
-      resultStr = systemInfoErrorToString(ret);
+      resultStr = get_error_message(ret);
       errorStr.append(" Failed to get build date: ");
       errorStr.append(resultStr);
     } else {
@@ -171,7 +154,7 @@ class DeviceInfoTizenPlugin : public flutter::Plugin {
     ret = system_info_get_platform_string("http://tizen.org/system/build.id",
                                           &value);
     if (ret != SYSTEM_INFO_ERROR_NONE) {
-      resultStr = systemInfoErrorToString(ret);
+      resultStr = get_error_message(ret);
       errorStr.append(" Failed to get build id: ");
       errorStr.append(resultStr);
     } else {
@@ -187,7 +170,7 @@ class DeviceInfoTizenPlugin : public flutter::Plugin {
     ret = system_info_get_platform_string(
         "http://tizen.org/system/build.string", &value);
     if (ret != SYSTEM_INFO_ERROR_NONE) {
-      resultStr = systemInfoErrorToString(ret);
+      resultStr = get_error_message(ret);
       errorStr.append(" Failed to get build string: ");
       errorStr.append(resultStr);
     } else {
@@ -203,7 +186,7 @@ class DeviceInfoTizenPlugin : public flutter::Plugin {
     ret = system_info_get_platform_string("http://tizen.org/system/build.time",
                                           &value);
     if (ret != SYSTEM_INFO_ERROR_NONE) {
-      resultStr = systemInfoErrorToString(ret);
+      resultStr = get_error_message(ret);
       errorStr.append(" Failed to get build time: ");
       errorStr.append(resultStr);
     } else {
@@ -219,7 +202,7 @@ class DeviceInfoTizenPlugin : public flutter::Plugin {
     ret = system_info_get_platform_string("http://tizen.org/system/build.type",
                                           &value);
     if (ret != SYSTEM_INFO_ERROR_NONE) {
-      resultStr = systemInfoErrorToString(ret);
+      resultStr = get_error_message(ret);
       errorStr.append(" Failed to get build type: ");
       errorStr.append(resultStr);
     } else {
@@ -235,7 +218,7 @@ class DeviceInfoTizenPlugin : public flutter::Plugin {
     ret = system_info_get_platform_string(
         "http://tizen.org/system/build.variant", &value);
     if (ret != SYSTEM_INFO_ERROR_NONE) {
-      resultStr = systemInfoErrorToString(ret);
+      resultStr = get_error_message(ret);
       errorStr.append(" Failed to get build variant: ");
       errorStr.append(resultStr);
     } else {
@@ -251,7 +234,7 @@ class DeviceInfoTizenPlugin : public flutter::Plugin {
     ret = system_info_get_platform_string(
         "http://tizen.org/system/build.release", &value);
     if (ret != SYSTEM_INFO_ERROR_NONE) {
-      resultStr = systemInfoErrorToString(ret);
+      resultStr = get_error_message(ret);
       errorStr.append(" Failed to get build release: ");
       errorStr.append(resultStr);
     } else {
@@ -267,7 +250,7 @@ class DeviceInfoTizenPlugin : public flutter::Plugin {
     ret = system_info_get_platform_string("http://tizen.org/system/device_type",
                                           &value);
     if (ret != SYSTEM_INFO_ERROR_NONE) {
-      resultStr = systemInfoErrorToString(ret);
+      resultStr = get_error_message(ret);
       errorStr.append(" Failed to get device type: ");
       errorStr.append(resultStr);
     } else {
@@ -283,7 +266,7 @@ class DeviceInfoTizenPlugin : public flutter::Plugin {
     ret = system_info_get_platform_string(
         "http://tizen.org/system/manufacturer", &value);
     if (ret != SYSTEM_INFO_ERROR_NONE) {
-      resultStr = systemInfoErrorToString(ret);
+      resultStr = get_error_message(ret);
       errorStr.append(" Failed to get manufacturer: ");
       errorStr.append(resultStr);
     } else {

--- a/packages/device_info/tizen/src/log.h
+++ b/packages/device_info/tizen/src/log.h
@@ -9,8 +9,7 @@
 #define LOG_TAG "DeviceInfoTizenPlugin"
 
 #ifndef __MODULE__
-#define __MODULE__ \
-  (strrchr(__FILE__, '/') ? strrchr(__FILE__, '/') + 1 : __FILE__)
+#define __MODULE__ strrchr("/" __FILE__, '/') + 1
 #endif
 
 #define LOG(prio, fmt, arg...)                                         \

--- a/packages/device_info/tizen/src/log.h
+++ b/packages/device_info/tizen/src/log.h
@@ -8,9 +8,14 @@
 #endif
 #define LOG_TAG "DeviceInfoTizenPlugin"
 
-#define LOG(prio, fmt, arg...)                                                 \
-  dlog_print(prio, LOG_TAG, "%s: %s(%d) > " fmt, __FILE__, __func__, __LINE__, \
-             ##arg)
+#ifndef __MODULE__
+#define __MODULE__ \
+  (strrchr(__FILE__, '/') ? strrchr(__FILE__, '/') + 1 : __FILE__)
+#endif
+
+#define LOG(prio, fmt, arg...)                                         \
+  dlog_print(prio, LOG_TAG, "%s: %s(%d) > " fmt, __MODULE__, __func__, \
+             __LINE__, ##arg)
 
 #define LOG_DEBUG(fmt, args...) LOG(DLOG_DEBUG, fmt, ##args)
 #define LOG_INFO(fmt, args...) LOG(DLOG_INFO, fmt, ##args)

--- a/packages/flutter_tts/tizen/src/log.h
+++ b/packages/flutter_tts/tizen/src/log.h
@@ -9,8 +9,7 @@
 #define LOG_TAG "FlutterTtsTizenPlugin"
 
 #ifndef __MODULE__
-#define __MODULE__ \
-  (strrchr(__FILE__, '/') ? strrchr(__FILE__, '/') + 1 : __FILE__)
+#define __MODULE__ strrchr("/" __FILE__, '/') + 1
 #endif
 
 #define LOG(prio, fmt, arg...)                                         \

--- a/packages/flutter_tts/tizen/src/log.h
+++ b/packages/flutter_tts/tizen/src/log.h
@@ -8,9 +8,14 @@
 #endif
 #define LOG_TAG "FlutterTtsTizenPlugin"
 
-#define LOG(prio, fmt, arg...)                                                 \
-  dlog_print(prio, LOG_TAG, "%s: %s(%d) > " fmt, __FILE__, __func__, __LINE__, \
-             ##arg)
+#ifndef __MODULE__
+#define __MODULE__ \
+  (strrchr(__FILE__, '/') ? strrchr(__FILE__, '/') + 1 : __FILE__)
+#endif
+
+#define LOG(prio, fmt, arg...)                                         \
+  dlog_print(prio, LOG_TAG, "%s: %s(%d) > " fmt, __MODULE__, __func__, \
+             __LINE__, ##arg)
 
 #define LOG_DEBUG(fmt, args...) LOG(DLOG_DEBUG, fmt, ##args)
 #define LOG_INFO(fmt, args...) LOG(DLOG_INFO, fmt, ##args)

--- a/packages/image_picker/tizen/src/image_picker_tizen_plugin.cc
+++ b/packages/image_picker/tizen/src/image_picker_tizen_plugin.cc
@@ -30,42 +30,11 @@ enum class ImageSource {
   GALLERY,
 };
 
-static std::string appControlErrorToString(int error) {
-  switch (error) {
-    case APP_CONTROL_ERROR_NONE:
-      return "APP_CONTROL - Successful";
-    case APP_CONTROL_ERROR_INVALID_PARAMETER:
-      return "APP_CONTROL - Invalid parameter";
-    case APP_CONTROL_ERROR_OUT_OF_MEMORY:
-      return "APP_CONTROL - Out of Memory";
-    case APP_CONTROL_ERROR_APP_NOT_FOUND:
-      return "APP_CONTROL - The application is not found";
-    case APP_CONTROL_ERROR_KEY_NOT_FOUND:
-      return "APP_CONTROL - Specified key is not found";
-    case APP_CONTROL_ERROR_KEY_REJECTED:
-      return "APP_CONTROL - Key is not available";
-    case APP_CONTROL_ERROR_INVALID_DATA_TYPE:
-      return "APP_CONTROL - Invalid data type";
-    case APP_CONTROL_ERROR_LAUNCH_REJECTED:
-      return "APP_CONTROL - The application cannot be launched now";
-    case APP_CONTROL_ERROR_PERMISSION_DENIED:
-      return "APP_CONTROL - Permission denied";
-    case APP_CONTROL_ERROR_LAUNCH_FAILED:
-      return "APP_CONTROL - Internal launch error";
-    case APP_CONTROL_ERROR_TIMED_OUT:
-      return "APP_CONTROL - Time out";
-    case APP_CONTROL_ERROR_IO_ERROR:
-      return "APP_CONTROL - IO error";
-    default:
-      return "APP_CONTROL - Unknown Error";
-  }
-}
-
-#define RET_IF_ERROR(ret)                                                   \
-  if (ret != APP_CONTROL_ERROR_NONE) {                                      \
-    SendResultWithError(std::to_string(ret), appControlErrorToString(ret)); \
-    if (handle) app_control_destroy(handle);                                \
-    return;                                                                 \
+#define RET_IF_ERROR(ret)                                             \
+  if (ret != APP_CONTROL_ERROR_NONE) {                                \
+    SendResultWithError(std::to_string(ret), get_error_message(ret)); \
+    if (handle) app_control_destroy(handle);                          \
+    return;                                                           \
   }
 
 class ImagePickerTizenPlugin : public flutter::Plugin {
@@ -260,8 +229,7 @@ class ImagePickerTizenPlugin : public flutter::Plugin {
     int ret = app_control_get_extra_data_array(reply, APP_CONTROL_DATA_SELECTED,
                                                &value, &count);
     if (ret != APP_CONTROL_ERROR_NONE) {
-      plugin->SendResultWithError(std::to_string(ret),
-                                  appControlErrorToString(ret));
+      plugin->SendResultWithError(std::to_string(ret), get_error_message(ret));
       return;
     }
 

--- a/packages/image_picker/tizen/src/image_resize.cc
+++ b/packages/image_picker/tizen/src/image_resize.cc
@@ -11,29 +11,6 @@
 
 #include "log.h"
 
-static std::string imageUitlErrorToString(int error) {
-  switch (error) {
-    case IMAGE_UTIL_ERROR_NONE:
-      return "IMAGE_UTIL - Successful";
-    case IMAGE_UTIL_ERROR_INVALID_PARAMETER:
-      return "IMAGE_UTIL - Invalid parameter";
-    case IMAGE_UTIL_ERROR_OUT_OF_MEMORY:
-      return "IMAGE_UTIL - Out of Memory";
-    case IMAGE_UTIL_ERROR_NO_SUCH_FILE:
-      return "IMAGE_UTIL - No such file";
-    case IMAGE_UTIL_ERROR_INVALID_OPERATION:
-      return "IMAGE_UTIL - Internal error";
-    case IMAGE_UTIL_ERROR_NOT_SUPPORTED_FORMAT:
-      return "IMAGE_UTIL - Not supported format";
-    case IMAGE_UTIL_ERROR_PERMISSION_DENIED:
-      return "IMAGE_UTIL - Permission denied";
-    case IMAGE_UTIL_ERROR_NOT_SUPPORTED:
-      return "IMAGE_UTIL - Not supported";
-    default:
-      return "IMAGE_UTIL - Unknown Error";
-  }
-}
-
 void ImageResize::SetSize(unsigned int w, unsigned int h, int q) {
   max_width_ = w;
   max_height_ = h;
@@ -46,7 +23,7 @@ bool ImageResize::DecodeImage(image_util_decode_h decode_h,
   int ret = image_util_decode_set_input_path(decode_h, src_file.c_str());
   if (ret != IMAGE_UTIL_ERROR_NONE) {
     LOG_ERROR("image_util_decode_set_input_path fail! [%s]",
-              imageUitlErrorToString(ret).c_str());
+              get_error_message(ret));
     return false;
   }
 
@@ -55,8 +32,7 @@ bool ImageResize::DecodeImage(image_util_decode_h decode_h,
 
   ret = image_util_decode_run2(decode_h, &src_image);
   if (ret != IMAGE_UTIL_ERROR_NONE) {
-    LOG_ERROR("image_util_decode_run2 fail! [%s]",
-              imageUitlErrorToString(ret).c_str());
+    LOG_ERROR("image_util_decode_run2 fail! [%s]", get_error_message(ret));
     return false;
   }
 
@@ -71,8 +47,7 @@ bool ImageResize::TransformImage(transformation_h transform_h,
   int ret = image_util_get_image(src_image, &org_width, &org_height, NULL, NULL,
                                  NULL);
   if (ret != IMAGE_UTIL_ERROR_NONE) {
-    LOG_ERROR("image_util_get_image fail! [%s]",
-              imageUitlErrorToString(ret).c_str());
+    LOG_ERROR("image_util_get_image fail! [%s]", get_error_message(ret));
     return false;
   }
 
@@ -116,13 +91,12 @@ bool ImageResize::TransformImage(transformation_h transform_h,
   ret = image_util_transform_set_resolution(transform_h, width, height);
   if (ret != IMAGE_UTIL_ERROR_NONE) {
     LOG_ERROR("image_util_transform_set_resolution fail! [%s]",
-              imageUitlErrorToString(ret).c_str());
+              get_error_message(ret));
     return false;
   }
   ret = image_util_transform_run2(transform_h, src_image, &dst_image);
   if (ret != IMAGE_UTIL_ERROR_NONE) {
-    LOG_ERROR("image_util_transform_run2 fail! [%s]",
-              imageUitlErrorToString(ret).c_str());
+    LOG_ERROR("image_util_transform_run2 fail! [%s]", get_error_message(ret));
     return false;
   }
 
@@ -139,7 +113,7 @@ bool ImageResize::EncodeImage(image_util_encode_h encode_h,
       int ret = image_util_encode_set_quality(encode_h, quality_);
       if (ret != IMAGE_UTIL_ERROR_NONE) {
         LOG_ERROR("image_util_encode_set_quality fail! [%s]",
-                  imageUitlErrorToString(ret).c_str());
+                  get_error_message(ret));
         return false;
       }
     }
@@ -154,7 +128,7 @@ bool ImageResize::EncodeImage(image_util_encode_h encode_h,
       image_util_encode_run_to_file(encode_h, dst_image, dst_file.c_str());
   if (ret != IMAGE_UTIL_ERROR_NONE) {
     LOG_ERROR("image_util_encode_run_to_file fail! [%s]",
-              imageUitlErrorToString(ret).c_str());
+              get_error_message(ret));
     return false;
   }
 
@@ -176,8 +150,7 @@ bool ImageResize::Resize(const std::string& src_file, std::string& dst_file) {
 
   int ret = image_util_decode_create(&decode_h);
   if (ret != IMAGE_UTIL_ERROR_NONE) {
-    LOG_ERROR("image_util_decode_create fail! [%s]",
-              imageUitlErrorToString(ret).c_str());
+    LOG_ERROR("image_util_decode_create fail! [%s]", get_error_message(ret));
     return false;
   }
   bool is_decoded = DecodeImage(decode_h, src_image, src_file);
@@ -193,8 +166,7 @@ bool ImageResize::Resize(const std::string& src_file, std::string& dst_file) {
   transformation_h transform_h = NULL;
   ret = image_util_transform_create(&transform_h);
   if (ret != IMAGE_UTIL_ERROR_NONE) {
-    LOG_ERROR("image_util_transform_create fail! [%s]",
-              imageUitlErrorToString(ret).c_str());
+    LOG_ERROR("image_util_transform_create fail! [%s]", get_error_message(ret));
     if (src_image) {
       image_util_destroy_image(src_image);
     }
@@ -249,8 +221,7 @@ bool ImageResize::Resize(const std::string& src_file, std::string& dst_file) {
   image_util_encode_h encode_h = NULL;
   ret = image_util_encode_create(encoder_type, &encode_h);
   if (ret != IMAGE_UTIL_ERROR_NONE) {
-    LOG_ERROR("image_util_encode_create fail! [%s]",
-              imageUitlErrorToString(ret).c_str());
+    LOG_ERROR("image_util_encode_create fail! [%s]", get_error_message(ret));
     if (dst_image) {
       image_util_destroy_image(dst_image);
     }

--- a/packages/image_picker/tizen/src/log.h
+++ b/packages/image_picker/tizen/src/log.h
@@ -9,8 +9,7 @@
 #define LOG_TAG "ImagePickerTizenPlugin"
 
 #ifndef __MODULE__
-#define __MODULE__ \
-  (strrchr(__FILE__, '/') ? strrchr(__FILE__, '/') + 1 : __FILE__)
+#define __MODULE__ strrchr("/" __FILE__, '/') + 1
 #endif
 
 #define LOG(prio, fmt, arg...)                                         \

--- a/packages/image_picker/tizen/src/log.h
+++ b/packages/image_picker/tizen/src/log.h
@@ -8,9 +8,14 @@
 #endif
 #define LOG_TAG "ImagePickerTizenPlugin"
 
-#define LOG(prio, fmt, arg...)                                                 \
-  dlog_print(prio, LOG_TAG, "%s: %s(%d) > " fmt, __FILE__, __func__, __LINE__, \
-             ##arg)
+#ifndef __MODULE__
+#define __MODULE__ \
+  (strrchr(__FILE__, '/') ? strrchr(__FILE__, '/') + 1 : __FILE__)
+#endif
+
+#define LOG(prio, fmt, arg...)                                         \
+  dlog_print(prio, LOG_TAG, "%s: %s(%d) > " fmt, __MODULE__, __func__, \
+             __LINE__, ##arg)
 
 #define LOG_DEBUG(fmt, args...) LOG(DLOG_DEBUG, fmt, ##args)
 #define LOG_INFO(fmt, args...) LOG(DLOG_INFO, fmt, ##args)

--- a/packages/integration_test/tizen/src/log.h
+++ b/packages/integration_test/tizen/src/log.h
@@ -8,9 +8,14 @@
 #endif
 #define LOG_TAG "IntegrationTestPlugin"
 
-#define LOG(prio, fmt, arg...)                                                 \
-  dlog_print(prio, LOG_TAG, "%s: %s(%d) > " fmt, __FILE__, __func__, __LINE__, \
-             ##arg)
+#ifndef __MODULE__
+#define __MODULE__ \
+  (strrchr(__FILE__, '/') ? strrchr(__FILE__, '/') + 1 : __FILE__)
+#endif
+
+#define LOG(prio, fmt, arg...)                                         \
+  dlog_print(prio, LOG_TAG, "%s: %s(%d) > " fmt, __MODULE__, __func__, \
+             __LINE__, ##arg)
 
 #define LOG_DEBUG(fmt, args...) LOG(DLOG_DEBUG, fmt, ##args)
 #define LOG_INFO(fmt, args...) LOG(DLOG_INFO, fmt, ##args)

--- a/packages/integration_test/tizen/src/log.h
+++ b/packages/integration_test/tizen/src/log.h
@@ -9,8 +9,7 @@
 #define LOG_TAG "IntegrationTestPlugin"
 
 #ifndef __MODULE__
-#define __MODULE__ \
-  (strrchr(__FILE__, '/') ? strrchr(__FILE__, '/') + 1 : __FILE__)
+#define __MODULE__ strrchr("/" __FILE__, '/') + 1
 #endif
 
 #define LOG(prio, fmt, arg...)                                         \

--- a/packages/package_info/tizen/src/log.h
+++ b/packages/package_info/tizen/src/log.h
@@ -8,9 +8,14 @@
 #endif
 #define LOG_TAG "PackageInfoTizenPlugin"
 
-#define LOG(prio, fmt, arg...)                                                 \
-  dlog_print(prio, LOG_TAG, "%s: %s(%d) > " fmt, __FILE__, __func__, __LINE__, \
-             ##arg)
+#ifndef __MODULE__
+#define __MODULE__ \
+  (strrchr(__FILE__, '/') ? strrchr(__FILE__, '/') + 1 : __FILE__)
+#endif
+
+#define LOG(prio, fmt, arg...)                                         \
+  dlog_print(prio, LOG_TAG, "%s: %s(%d) > " fmt, __MODULE__, __func__, \
+             __LINE__, ##arg)
 
 #define LOG_DEBUG(fmt, args...) LOG(DLOG_DEBUG, fmt, ##args)
 #define LOG_INFO(fmt, args...) LOG(DLOG_INFO, fmt, ##args)

--- a/packages/package_info/tizen/src/log.h
+++ b/packages/package_info/tizen/src/log.h
@@ -9,8 +9,7 @@
 #define LOG_TAG "PackageInfoTizenPlugin"
 
 #ifndef __MODULE__
-#define __MODULE__ \
-  (strrchr(__FILE__, '/') ? strrchr(__FILE__, '/') + 1 : __FILE__)
+#define __MODULE__ strrchr("/" __FILE__, '/') + 1
 #endif
 
 #define LOG(prio, fmt, arg...)                                         \

--- a/packages/package_info/tizen/src/package_info_tizen_plugin.cc
+++ b/packages/package_info/tizen/src/package_info_tizen_plugin.cc
@@ -20,50 +20,6 @@
 
 #include "log.h"
 
-static std::string appErrorToString(int error) {
-  switch (error) {
-    case APP_ERROR_NONE:
-      return "APP - Successful";
-    case APP_ERROR_INVALID_PARAMETER:
-      return "APP - Invalid parameter";
-    case APP_ERROR_OUT_OF_MEMORY:
-      return "APP - Out of Memory";
-    case APP_ERROR_INVALID_CONTEXT:
-      return "APP - Invalid application context";
-    case APP_ERROR_NO_SUCH_FILE:
-      return "APP - No such file or directory";
-    case APP_ERROR_NOT_SUPPORTED:
-      return "APP - Not supported";
-    case APP_ERROR_ALREADY_RUNNING:
-      return "APP - Application is already running";
-    case APP_ERROR_PERMISSION_DENIED:
-      return "APP - Permission denied";
-    default:
-      return "APP - Unknown Error";
-  }
-}
-
-static std::string packageErrorToString(int error) {
-  switch (error) {
-    case PACKAGE_MANAGER_ERROR_NONE:
-      return "PackageManager - Successful";
-    case PACKAGE_MANAGER_ERROR_INVALID_PARAMETER:
-      return "PackageManager - Invalid parameter";
-    case PACKAGE_MANAGER_ERROR_OUT_OF_MEMORY:
-      return "PackageManager - Out of Memory";
-    case PACKAGE_MANAGER_ERROR_IO_ERROR:
-      return "PackageManager - Internal I/O error";
-    case PACKAGE_MANAGER_ERROR_NO_SUCH_PACKAGE:
-      return "PackageManager - No such package";
-    case PACKAGE_MANAGER_ERROR_SYSTEM_ERROR:
-      return "PackageManager - Severe system error";
-    case PACKAGE_MANAGER_ERROR_PERMISSION_DENIED:
-      return "PackageManager - Permission denied";
-    default:
-      return "PackageManager - Unknown Error";
-  }
-}
-
 class PackageInfoTizenPlugin : public flutter::Plugin {
  public:
   static void RegisterWithRegistrar(flutter::PluginRegistrar *registrar) {
@@ -108,7 +64,7 @@ class PackageInfoTizenPlugin : public flutter::Plugin {
     int ret = app_get_id(&app_id);
     if (ret != APP_ERROR_NONE || app_id == NULL) {
       result->Error(std::to_string(ret), "Failed to get app_id",
-                    flutter::EncodableValue(appErrorToString(ret)));
+                    flutter::EncodableValue(get_error_message(ret)));
       goto cleanup;
     }
     LOG_INFO("app id : %s\n", app_id);
@@ -116,14 +72,14 @@ class PackageInfoTizenPlugin : public flutter::Plugin {
     ret = package_info_create(app_id, &package_info);
     if (ret != PACKAGE_MANAGER_ERROR_NONE || package_info == NULL) {
       result->Error(std::to_string(ret), "Failed to create package_info",
-                    flutter::EncodableValue(packageErrorToString(ret)));
+                    flutter::EncodableValue(get_error_message(ret)));
       goto cleanup;
     }
 
     ret = package_info_get_label(package_info, &label);
     if (ret != PACKAGE_MANAGER_ERROR_NONE || label == NULL) {
       result->Error(std::to_string(ret), "Failed to get app name",
-                    flutter::EncodableValue(packageErrorToString(ret)));
+                    flutter::EncodableValue(get_error_message(ret)));
       goto cleanup;
     }
     LOG_INFO("package label : %s\n", label);
@@ -131,7 +87,7 @@ class PackageInfoTizenPlugin : public flutter::Plugin {
     ret = package_info_get_package(package_info, &pkg_name);
     if (ret != PACKAGE_MANAGER_ERROR_NONE || pkg_name == NULL) {
       result->Error(std::to_string(ret), "Failed to get package name",
-                    flutter::EncodableValue(packageErrorToString(ret)));
+                    flutter::EncodableValue(get_error_message(ret)));
       goto cleanup;
     }
     LOG_INFO("package name : %s\n", pkg_name);
@@ -139,7 +95,7 @@ class PackageInfoTizenPlugin : public flutter::Plugin {
     ret = package_info_get_version(package_info, &version);
     if (ret != PACKAGE_MANAGER_ERROR_NONE || version == NULL) {
       result->Error(std::to_string(ret), "Failed to get version",
-                    flutter::EncodableValue(packageErrorToString(ret)));
+                    flutter::EncodableValue(get_error_message(ret)));
       goto cleanup;
     }
     LOG_INFO("package version : %s\n", version);

--- a/packages/permission_handler/tizen/src/app_settings_manager.cc
+++ b/packages/permission_handler/tizen/src/app_settings_manager.cc
@@ -4,19 +4,6 @@
 
 #include "log.h"
 
-static std::string ErrorToString(int error) {
-  switch (error) {
-    case APP_CONTROL_ERROR_NONE:
-      return "AppControl - Successful";
-    case APP_CONTROL_ERROR_INVALID_PARAMETER:
-      return "AppControl - Invalid parameter";
-    case APP_CONTROL_ERROR_OUT_OF_MEMORY:
-      return "AppControl - Out of memory";
-    default:
-      return "AppControl - Unknown error";
-  }
-}
-
 AppSettingsManager::AppSettingsManager() {}
 
 AppSettingsManager::~AppSettingsManager() {}
@@ -26,7 +13,7 @@ void AppSettingsManager::OpenAppSettings(OnAppSettingsOpened success_callback,
   app_control_h service = nullptr;
   int result = app_control_create(&service);
   if (result != APP_CONTROL_ERROR_NONE) {
-    error_callback(ErrorToString(result),
+    error_callback(get_error_message(result),
                    "An error occurred when call app_control_create()");
   }
 

--- a/packages/permission_handler/tizen/src/log.h
+++ b/packages/permission_handler/tizen/src/log.h
@@ -8,9 +8,14 @@
 #endif
 #define LOG_TAG "PermissionHandlerTizenPlugin"
 
-#define LOG(prio, fmt, arg...)                                                 \
-  dlog_print(prio, LOG_TAG, "%s: %s(%d) > " fmt, __FILE__, __func__, __LINE__, \
-             ##arg)
+#ifndef __MODULE__
+#define __MODULE__ \
+  (strrchr(__FILE__, '/') ? strrchr(__FILE__, '/') + 1 : __FILE__)
+#endif
+
+#define LOG(prio, fmt, arg...)                                         \
+  dlog_print(prio, LOG_TAG, "%s: %s(%d) > " fmt, __MODULE__, __func__, \
+             __LINE__, ##arg)
 
 #define LOG_DEBUG(fmt, args...) LOG(DLOG_DEBUG, fmt, ##args)
 #define LOG_INFO(fmt, args...) LOG(DLOG_INFO, fmt, ##args)

--- a/packages/permission_handler/tizen/src/log.h
+++ b/packages/permission_handler/tizen/src/log.h
@@ -9,8 +9,7 @@
 #define LOG_TAG "PermissionHandlerTizenPlugin"
 
 #ifndef __MODULE__
-#define __MODULE__ \
-  (strrchr(__FILE__, '/') ? strrchr(__FILE__, '/') + 1 : __FILE__)
+#define __MODULE__ strrchr("/" __FILE__, '/') + 1
 #endif
 
 #define LOG(prio, fmt, arg...)                                         \

--- a/packages/permission_handler/tizen/src/permission_manager.cc
+++ b/packages/permission_handler/tizen/src/permission_manager.cc
@@ -24,23 +24,6 @@ const char* PRIVILEGE_EXTERNAL_STORAGE =
     "http://tizen.org/privilege/externalstorage";
 const char* PRIVILEGE_MEDIA_STORAGE = "http://tizen.org/privilege/mediastorage";
 
-static std::string PPMErrorToString(int error) {
-  switch (error) {
-    case PRIVACY_PRIVILEGE_MANAGER_ERROR_NONE:
-      return "PrivacyPrivilegeManager - Successful";
-    case PRIVACY_PRIVILEGE_MANAGER_ERROR_IO_ERROR:
-      return "PrivacyPrivilegeManager - IO error";
-    case PRIVACY_PRIVILEGE_MANAGER_ERROR_INVALID_PARAMETER:
-      return "PrivacyPrivilegeManager - Invalid parameter";
-    case PRIVACY_PRIVILEGE_MANAGER_ERROR_ALREADY_IN_PROGRESS:
-      return "PrivacyPrivilegeManager - Operation already in progress";
-    case PRIVACY_PRIVILEGE_MANAGER_ERROR_OUT_OF_MEMORY:
-      return "PrivacyPrivilegeManager - Out of memory";
-    default:
-      return "PrivacyPrivilegeManager - Unknown error";
-  }
-}
-
 static std::string CheckResultToString(int result) {
   switch (result) {
     case PRIVACY_PRIVILEGE_MANAGER_CHECK_RESULT_ALLOW:
@@ -79,7 +62,7 @@ void PermissionManager::CheckPermissionStatus(
   int status;
   int result = DeterminePermissionStatus(permission, &status);
   if (result != PRIVACY_PRIVILEGE_MANAGER_ERROR_NONE) {
-    error_callback(PPMErrorToString(result),
+    error_callback(get_error_message(result),
                    "An error occurred when call ppm_check_permission()");
   } else {
     success_callback(status);
@@ -101,7 +84,7 @@ void PermissionManager::RequestPermissions(
   for (auto permission : permissions) {
     result = DeterminePermissionStatus(permission, &status);
     if (result != PRIVACY_PRIVILEGE_MANAGER_ERROR_NONE) {
-      error_callback(PPMErrorToString(result),
+      error_callback(get_error_message(result),
                      "An error occurred when call ppm_check_permission()");
       return;
     }
@@ -131,7 +114,7 @@ void PermissionManager::RequestPermissions(
                                    permissions_to_request.size(),
                                    OnRequestPermissionsResponse, this);
   if (result != PRIVACY_PRIVILEGE_MANAGER_ERROR_NONE) {
-    error_callback(PPMErrorToString(result),
+    error_callback(get_error_message(result),
                    "An error occurred when call ppm_request_permissions()");
     on_going_ = false;
   }
@@ -228,7 +211,7 @@ int PermissionManager::DeterminePermissionStatus(int permission, int* status) {
     result = ppm_check_permission(iter, &check_result);
     if (result != PRIVACY_PRIVILEGE_MANAGER_ERROR_NONE) {
       LOG_ERROR("ppm_check_permission (%s) error: %s", iter,
-                PPMErrorToString(result).c_str());
+                get_error_message(result));
       return result;
     } else {
       LOG_DEBUG("ppm_check_permission (%s) result: %s", iter,

--- a/packages/sensors/tizen/src/log.h
+++ b/packages/sensors/tizen/src/log.h
@@ -9,8 +9,7 @@
 #define LOG_TAG "SensorsPlugin"
 
 #ifndef __MODULE__
-#define __MODULE__ \
-  (strrchr(__FILE__, '/') ? strrchr(__FILE__, '/') + 1 : __FILE__)
+#define __MODULE__ strrchr("/" __FILE__, '/') + 1
 #endif
 
 #define LOG(prio, fmt, arg...)                                         \

--- a/packages/sensors/tizen/src/log.h
+++ b/packages/sensors/tizen/src/log.h
@@ -8,9 +8,14 @@
 #endif
 #define LOG_TAG "SensorsPlugin"
 
-#define LOG(prio, fmt, arg...)                                                 \
-  dlog_print(prio, LOG_TAG, "%s: %s(%d) > " fmt, __FILE__, __func__, __LINE__, \
-             ##arg)
+#ifndef __MODULE__
+#define __MODULE__ \
+  (strrchr(__FILE__, '/') ? strrchr(__FILE__, '/') + 1 : __FILE__)
+#endif
+
+#define LOG(prio, fmt, arg...)                                         \
+  dlog_print(prio, LOG_TAG, "%s: %s(%d) > " fmt, __MODULE__, __func__, \
+             __LINE__, ##arg)
 
 #define LOG_DEBUG(fmt, args...) LOG(DLOG_DEBUG, fmt, ##args)
 #define LOG_INFO(fmt, args...) LOG(DLOG_INFO, fmt, ##args)

--- a/packages/sensors/tizen/src/sensors_plugin.cc
+++ b/packages/sensors/tizen/src/sensors_plugin.cc
@@ -125,7 +125,7 @@ class SensorsPlugin : public flutter::Plugin {
 
  private:
   void setupEventChannels(flutter::PluginRegistrar *registrar) {
-    accelerometer_channel_ =
+    auto accelerometer_channel =
         std::make_unique<flutter::EventChannel<flutter::EncodableValue>>(
             registrar->messenger(), ACCELEROMETER_CHANNEL_NAME,
             &flutter::StandardMethodCodec::GetInstance());
@@ -151,10 +151,10 @@ class SensorsPlugin : public flutter::Plugin {
               }
               return nullptr;
             });
-    accelerometer_channel_->SetStreamHandler(
+    accelerometer_channel->SetStreamHandler(
         std::move(accelerometer_channel_handler));
 
-    gyroscope_channel_ =
+    auto gyroscope_channel =
         std::make_unique<flutter::EventChannel<flutter::EncodableValue>>(
             registrar->messenger(), GYROSCOPE_CHANNEL_NAME,
             &flutter::StandardMethodCodec::GetInstance());
@@ -180,9 +180,9 @@ class SensorsPlugin : public flutter::Plugin {
               }
               return nullptr;
             });
-    gyroscope_channel_->SetStreamHandler(std::move(gyroscope_channel_handler));
+    gyroscope_channel->SetStreamHandler(std::move(gyroscope_channel_handler));
 
-    user_accel_channel_ =
+    auto user_accel_channel =
         std::make_unique<flutter::EventChannel<flutter::EncodableValue>>(
             registrar->messenger(), USER_ACCELEROMETER_CHANNEL_NAME,
             &flutter::StandardMethodCodec::GetInstance());
@@ -208,17 +208,11 @@ class SensorsPlugin : public flutter::Plugin {
               }
               return nullptr;
             });
-    user_accel_channel_->SetStreamHandler(std::move(user_accel_handler));
+    user_accel_channel->SetStreamHandler(std::move(user_accel_handler));
   }
 
-  std::unique_ptr<flutter::EventChannel<flutter::EncodableValue>>
-      accelerometer_channel_;
   std::unique_ptr<Listener> accelerometer_listener_;
-  std::unique_ptr<flutter::EventChannel<flutter::EncodableValue>>
-      gyroscope_channel_;
   std::unique_ptr<Listener> gyroscope_listener_;
-  std::unique_ptr<flutter::EventChannel<flutter::EncodableValue>>
-      user_accel_channel_;
   std::unique_ptr<Listener> user_accel_listener_;
 };
 

--- a/packages/share/tizen/src/log.h
+++ b/packages/share/tizen/src/log.h
@@ -9,8 +9,7 @@
 #define LOG_TAG "ShareTizenPlugin"
 
 #ifndef __MODULE__
-#define __MODULE__ \
-  (strrchr(__FILE__, '/') ? strrchr(__FILE__, '/') + 1 : __FILE__)
+#define __MODULE__ strrchr("/" __FILE__, '/') + 1
 #endif
 
 #define LOG(prio, fmt, arg...)                                         \

--- a/packages/share/tizen/src/log.h
+++ b/packages/share/tizen/src/log.h
@@ -8,9 +8,14 @@
 #endif
 #define LOG_TAG "ShareTizenPlugin"
 
-#define LOG(prio, fmt, arg...)                                                 \
-  dlog_print(prio, LOG_TAG, "%s: %s(%d) > " fmt, __FILE__, __func__, __LINE__, \
-             ##arg)
+#ifndef __MODULE__
+#define __MODULE__ \
+  (strrchr(__FILE__, '/') ? strrchr(__FILE__, '/') + 1 : __FILE__)
+#endif
+
+#define LOG(prio, fmt, arg...)                                         \
+  dlog_print(prio, LOG_TAG, "%s: %s(%d) > " fmt, __MODULE__, __func__, \
+             __LINE__, ##arg)
 
 #define LOG_DEBUG(fmt, args...) LOG(DLOG_DEBUG, fmt, ##args)
 #define LOG_INFO(fmt, args...) LOG(DLOG_INFO, fmt, ##args)

--- a/packages/share/tizen/src/share_tizen_plugin.cc
+++ b/packages/share/tizen/src/share_tizen_plugin.cc
@@ -17,44 +17,13 @@
 
 #include "log.h"
 
-static std::string appControlErrorToString(int error) {
-  switch (error) {
-    case APP_CONTROL_ERROR_NONE:
-      return "APP_CONTROL - Successful";
-    case APP_CONTROL_ERROR_INVALID_PARAMETER:
-      return "APP_CONTROL - Invalid parameter";
-    case APP_CONTROL_ERROR_OUT_OF_MEMORY:
-      return "APP_CONTROL - Out of Memory";
-    case APP_CONTROL_ERROR_APP_NOT_FOUND:
-      return "APP_CONTROL - The application is not found";
-    case APP_CONTROL_ERROR_KEY_NOT_FOUND:
-      return "APP_CONTROL - Specified key is not found";
-    case APP_CONTROL_ERROR_KEY_REJECTED:
-      return "APP_CONTROL - Key is not available";
-    case APP_CONTROL_ERROR_INVALID_DATA_TYPE:
-      return "APP_CONTROL - Invalid data type";
-    case APP_CONTROL_ERROR_LAUNCH_REJECTED:
-      return "APP_CONTROL - The application cannot be launched now";
-    case APP_CONTROL_ERROR_PERMISSION_DENIED:
-      return "APP_CONTROL - Permission denied";
-    case APP_CONTROL_ERROR_LAUNCH_FAILED:
-      return "APP_CONTROL - Internal launch error";
-    case APP_CONTROL_ERROR_TIMED_OUT:
-      return "APP_CONTROL - Time out";
-    case APP_CONTROL_ERROR_IO_ERROR:
-      return "APP_CONTROL - IO error";
-    default:
-      return "APP_CONTROL - Unknown Error";
-  }
-}
-
-#define RET_IF_ERROR(ret)                                             \
-  if (ret != APP_CONTROL_ERROR_NONE) {                                \
-    result->Error(std::to_string(ret), appControlErrorToString(ret)); \
-    if (handle) {                                                     \
-      app_control_destroy(handle);                                    \
-    }                                                                 \
-    return;                                                           \
+#define RET_IF_ERROR(ret)                                       \
+  if (ret != APP_CONTROL_ERROR_NONE) {                          \
+    result->Error(std::to_string(ret), get_error_message(ret)); \
+    if (handle) {                                               \
+      app_control_destroy(handle);                              \
+    }                                                           \
+    return;                                                     \
   }
 
 class ShareTizenPlugin : public flutter::Plugin {

--- a/packages/video_player/tizen/src/log.h
+++ b/packages/video_player/tizen/src/log.h
@@ -9,8 +9,7 @@
 #define LOG_TAG "VideoPlayerTizenPlugin"
 
 #ifndef __MODULE__
-#define __MODULE__ \
-  (strrchr(__FILE__, '/') ? strrchr(__FILE__, '/') + 1 : __FILE__)
+#define __MODULE__ strrchr("/" __FILE__, '/') + 1
 #endif
 
 #define LOG(prio, fmt, arg...)                                         \

--- a/packages/video_player/tizen/src/log.h
+++ b/packages/video_player/tizen/src/log.h
@@ -8,9 +8,14 @@
 #endif
 #define LOG_TAG "VideoPlayerTizenPlugin"
 
-#define LOG(prio, fmt, arg...)                                                 \
-  dlog_print(prio, LOG_TAG, "%s: %s(%d) > " fmt, __FILE__, __func__, __LINE__, \
-             ##arg)
+#ifndef __MODULE__
+#define __MODULE__ \
+  (strrchr(__FILE__, '/') ? strrchr(__FILE__, '/') + 1 : __FILE__)
+#endif
+
+#define LOG(prio, fmt, arg...)                                         \
+  dlog_print(prio, LOG_TAG, "%s: %s(%d) > " fmt, __MODULE__, __func__, \
+             __LINE__, ##arg)
 
 #define LOG_DEBUG(fmt, args...) LOG(DLOG_DEBUG, fmt, ##args)
 #define LOG_INFO(fmt, args...) LOG(DLOG_INFO, fmt, ##args)

--- a/packages/video_player/tizen/src/video_player.cc
+++ b/packages/video_player/tizen/src/video_player.cc
@@ -49,70 +49,6 @@ static std::string StateToString(player_state_e state) {
   return ret;
 }
 
-static std::string ErrorToString(int code) {
-  std::string ret;
-  switch (code) {
-    case PLAYER_ERROR_NONE:
-      ret = "PLAYER_ERROR_NONE";
-      break;
-    case PLAYER_ERROR_INVALID_PARAMETER:
-      ret = "PLAYER_ERROR_INVALID_PARAMETER";
-      break;
-    case PLAYER_ERROR_OUT_OF_MEMORY:
-      ret = "PLAYER_ERROR_OUT_OF_MEMORY";
-      break;
-    case PLAYER_ERROR_INVALID_OPERATION:
-      ret = "PLAYER_ERROR_INVALID_OPERATION";
-      break;
-    case PLAYER_ERROR_RESOURCE_LIMIT:
-      ret = "PLAYER_ERROR_RESOURCE_LIMIT";
-      break;
-    case PLAYER_ERROR_FILE_NO_SPACE_ON_DEVICE:
-      ret = "PLAYER_ERROR_FILE_NO_SPACE_ON_DEVICE";
-      break;
-    case PLAYER_ERROR_INVALID_STATE:
-      ret = "PLAYER_ERROR_INVALID_STATE";
-      break;
-    case PLAYER_ERROR_INVALID_URI:
-      ret = "PLAYER_ERROR_INVALID_URI";
-      break;
-    case PLAYER_ERROR_NO_SUCH_FILE:
-      ret = "PLAYER_ERROR_NO_SUCH_FILE";
-      break;
-    case PLAYER_ERROR_NOT_SUPPORTED_FILE:
-      ret = "PLAYER_ERROR_NOT_SUPPORTED_FILE";
-      break;
-    case PLAYER_ERROR_CONNECTION_FAILED:
-      ret = "PLAYER_ERROR_CONNECTION_FAILED";
-      break;
-    case PLAYER_ERROR_SEEK_FAILED:
-      ret = "PLAYER_ERROR_SEEK_FAILED";
-      break;
-    case PLAYER_ERROR_FEATURE_NOT_SUPPORTED_ON_DEVICE:
-      ret = "PLAYER_ERROR_FEATURE_NOT_SUPPORTED_ON_DEVICE";
-      break;
-    case PLAYER_ERROR_DRM_NOT_PERMITTED:
-      ret = "PLAYER_ERROR_DRM_NOT_PERMITTED";
-      break;
-    case PLAYER_ERROR_SERVICE_DISCONNECTED:
-      ret = "PLAYER_ERROR_SERVICE_DISCONNECTED";
-      break;
-    case PLAYER_ERROR_NOT_SUPPORTED_SUBTITLE:
-      ret = "PLAYER_ERROR_NOT_SUPPORTED_SUBTITLE";
-      break;
-    case PLAYER_ERROR_NOT_SUPPORTED_AUDIO_CODEC:
-      ret = "PLAYER_ERROR_NOT_SUPPORTED_AUDIO_CODEC";
-      break;
-    case PLAYER_ERROR_NOT_SUPPORTED_VIDEO_CODEC:
-      ret = "PLAYER_ERROR_NOT_SUPPORTED_VIDEO_CODEC";
-      break;
-    default:
-      ret = "PLAYER_ERROR_UNKNOWN";
-      break;
-  }
-  return ret;
-}
-
 VideoPlayer::VideoPlayer(flutter::PluginRegistrar *pluginRegistrar,
                          FlutterTextureRegistrar *textureRegistrar,
                          const std::string &uri, VideoPlayerOptions &options) {
@@ -125,9 +61,8 @@ VideoPlayer::VideoPlayer(flutter::PluginRegistrar *pluginRegistrar,
   LOG_DEBUG("[VideoPlayer] call player_create to create player");
   int ret = player_create(&player_);
   if (ret != PLAYER_ERROR_NONE) {
-    LOG_ERROR("[VideoPlayer] player_create failed: %s",
-              ErrorToString(ret).c_str());
-    throw VideoPlayerError("player_create failed", ErrorToString(ret));
+    LOG_ERROR("[VideoPlayer] player_create failed: %s", get_error_message(ret));
+    throw VideoPlayerError("player_create failed", get_error_message(ret));
   }
 
   LOG_DEBUG("[VideoPlayer] call player_set_uri to set video path (%s)",
@@ -136,8 +71,8 @@ VideoPlayer::VideoPlayer(flutter::PluginRegistrar *pluginRegistrar,
   if (ret != PLAYER_ERROR_NONE) {
     player_destroy(player_);
     LOG_ERROR("[VideoPlayer] player_set_uri failed: %s",
-              ErrorToString(ret).c_str());
-    throw VideoPlayerError("player_set_uri failed", ErrorToString(ret));
+              get_error_message(ret));
+    throw VideoPlayerError("player_set_uri failed", get_error_message(ret));
   }
 
   LOG_DEBUG(
@@ -149,10 +84,10 @@ VideoPlayer::VideoPlayer(flutter::PluginRegistrar *pluginRegistrar,
     LOG_ERROR(
         "[VideoPlayer] player_set_media_packet_video_frame_decoded_cb "
         "failed: %s",
-        ErrorToString(ret).c_str());
+        get_error_message(ret));
     throw VideoPlayerError(
         "player_set_media_packet_video_frame_decoded_cb failed",
-        ErrorToString(ret));
+        get_error_message(ret));
   }
 
   LOG_DEBUG("[VideoPlayer] call player_set_buffering_cb");
@@ -160,9 +95,9 @@ VideoPlayer::VideoPlayer(flutter::PluginRegistrar *pluginRegistrar,
   if (ret != PLAYER_ERROR_NONE) {
     player_destroy(player_);
     LOG_ERROR("[VideoPlayer] player_set_buffering_cb failed: %s",
-              ErrorToString(ret).c_str());
+              get_error_message(ret));
     throw VideoPlayerError("player_set_buffering_cb failed",
-                           ErrorToString(ret));
+                           get_error_message(ret));
   }
 
   LOG_DEBUG("[VideoPlayer] call player_set_completed_cb");
@@ -170,9 +105,9 @@ VideoPlayer::VideoPlayer(flutter::PluginRegistrar *pluginRegistrar,
   if (ret != PLAYER_ERROR_NONE) {
     player_destroy(player_);
     LOG_ERROR("[VideoPlayer] player_set_completed_cb failed: %s",
-              ErrorToString(ret).c_str());
+              get_error_message(ret));
     throw VideoPlayerError("player_set_completed_cb failed",
-                           ErrorToString(ret));
+                           get_error_message(ret));
   }
 
   LOG_DEBUG("[VideoPlayer] call player_set_interrupted_cb");
@@ -180,9 +115,9 @@ VideoPlayer::VideoPlayer(flutter::PluginRegistrar *pluginRegistrar,
   if (ret != PLAYER_ERROR_NONE) {
     player_destroy(player_);
     LOG_ERROR("[VideoPlayer] player_set_interrupted_cb failed: %s",
-              ErrorToString(ret).c_str());
+              get_error_message(ret));
     throw VideoPlayerError("player_set_interrupted_cb failed",
-                           ErrorToString(ret));
+                           get_error_message(ret));
   }
 
   LOG_DEBUG("[VideoPlayer] call player_set_error_cb");
@@ -190,8 +125,9 @@ VideoPlayer::VideoPlayer(flutter::PluginRegistrar *pluginRegistrar,
   if (ret != PLAYER_ERROR_NONE) {
     player_destroy(player_);
     LOG_ERROR("[VideoPlayer] player_set_error_cb failed: %s",
-              ErrorToString(ret).c_str());
-    throw VideoPlayerError("player_set_error_cb failed", ErrorToString(ret));
+              get_error_message(ret));
+    throw VideoPlayerError("player_set_error_cb failed",
+                           get_error_message(ret));
   }
 
   LOG_DEBUG("[VideoPlayer] call player_prepare_async");
@@ -199,8 +135,9 @@ VideoPlayer::VideoPlayer(flutter::PluginRegistrar *pluginRegistrar,
   if (ret != PLAYER_ERROR_NONE) {
     player_destroy(player_);
     LOG_ERROR("[VideoPlayer] player_prepare_async failed: %s",
-              ErrorToString(ret).c_str());
-    throw VideoPlayerError("player_prepare_async failed", ErrorToString(ret));
+              get_error_message(ret));
+    throw VideoPlayerError("player_prepare_async failed",
+                           get_error_message(ret));
   }
 
   setupEventChannel(pluginRegistrar->messenger());
@@ -228,8 +165,8 @@ void VideoPlayer::play() {
   ret = player_start(player_);
   if (ret != PLAYER_ERROR_NONE) {
     LOG_ERROR("[VideoPlayer.play] player_start failed: %s",
-              ErrorToString(ret).c_str());
-    throw VideoPlayerError("player_start failed", ErrorToString(ret));
+              get_error_message(ret));
+    throw VideoPlayerError("player_start failed", get_error_message(ret));
   }
 }
 
@@ -248,8 +185,8 @@ void VideoPlayer::pause() {
   ret = player_pause(player_);
   if (ret != PLAYER_ERROR_NONE) {
     LOG_ERROR("[VideoPlayer.pause] player_pause failed: %s",
-              ErrorToString(ret).c_str());
-    throw VideoPlayerError("player_pause failed", ErrorToString(ret));
+              get_error_message(ret));
+    throw VideoPlayerError("player_pause failed", get_error_message(ret));
   }
 }
 
@@ -258,8 +195,8 @@ void VideoPlayer::setLooping(bool isLooping) {
   int ret = player_set_looping(player_, isLooping);
   if (ret != PLAYER_ERROR_NONE) {
     LOG_ERROR("[VideoPlayer.setLooping] player_set_looping failed: %s",
-              ErrorToString(ret).c_str());
-    throw VideoPlayerError("player_set_looping failed", ErrorToString(ret));
+              get_error_message(ret));
+    throw VideoPlayerError("player_set_looping failed", get_error_message(ret));
   }
 }
 
@@ -268,8 +205,8 @@ void VideoPlayer::setVolume(double volume) {
   int ret = player_set_volume(player_, volume, volume);
   if (ret != PLAYER_ERROR_NONE) {
     LOG_ERROR("[VideoPlayer.setVolume] player_set_volume failed: %s",
-              ErrorToString(ret).c_str());
-    throw VideoPlayerError("player_set_volume failed", ErrorToString(ret));
+              get_error_message(ret));
+    throw VideoPlayerError("player_set_volume failed", get_error_message(ret));
   }
 }
 
@@ -279,9 +216,9 @@ void VideoPlayer::setPlaybackSpeed(double speed) {
   if (ret != PLAYER_ERROR_NONE) {
     LOG_ERROR(
         "[VideoPlayer.setPlaybackSpeed] player_set_playback_rate failed: %s",
-        ErrorToString(ret).c_str());
+        get_error_message(ret));
     throw VideoPlayerError("player_set_playback_rate failed",
-                           ErrorToString(ret));
+                           get_error_message(ret));
   }
 }
 
@@ -290,9 +227,9 @@ void VideoPlayer::seekTo(int position) {
   int ret = player_set_play_position(player_, position, true, nullptr, nullptr);
   if (ret != PLAYER_ERROR_NONE) {
     LOG_ERROR("[VideoPlayer.seekTo] player_set_play_position failed: %s",
-              ErrorToString(ret).c_str());
+              get_error_message(ret));
     throw VideoPlayerError("player_set_play_position failed",
-                           ErrorToString(ret));
+                           get_error_message(ret));
   }
 }
 
@@ -302,9 +239,9 @@ int VideoPlayer::getPosition() {
   int ret = player_get_play_position(player_, &position);
   if (ret != PLAYER_ERROR_NONE) {
     LOG_ERROR("[VideoPlayer.getPosition] player_get_play_position failed: %s",
-              ErrorToString(ret).c_str());
+              get_error_message(ret));
     throw VideoPlayerError("player_get_play_position failed",
-                           ErrorToString(ret));
+                           get_error_message(ret));
   }
 
   LOG_DEBUG("[VideoPlayer.getPosition] position: %d", position);
@@ -378,7 +315,7 @@ void VideoPlayer::initialize() {
     }
   } else {
     LOG_ERROR("[VideoPlayer.initialize] player_get_state failed: %s",
-              ErrorToString(ret).c_str());
+              get_error_message(ret));
   }
 }
 
@@ -388,8 +325,8 @@ void VideoPlayer::sendInitialized() {
     int ret = player_get_duration(player_, &duration);
     if (ret != PLAYER_ERROR_NONE) {
       LOG_ERROR("[VideoPlayer.sendInitialized] player_get_duration failed: %s",
-                ErrorToString(ret).c_str());
-      eventSink_->Error(ErrorToString(ret), "player_get_duration failed");
+                get_error_message(ret));
+      eventSink_->Error("player_get_duration failed", get_error_message(ret));
       return;
     }
     LOG_DEBUG("[VideoPlayer.sendInitialized] video duration: %d", duration);
@@ -399,8 +336,8 @@ void VideoPlayer::sendInitialized() {
     if (ret != PLAYER_ERROR_NONE) {
       LOG_ERROR(
           "[VideoPlayer.sendInitialized] player_get_video_size failed: %s",
-          ErrorToString(ret).c_str());
-      eventSink_->Error(ErrorToString(ret), "player_get_video_size failed");
+          get_error_message(ret));
+      eventSink_->Error("player_get_video_size failed", get_error_message(ret));
       return;
     }
     LOG_DEBUG("[VideoPlayer.sendInitialized] video width: %d, height: %d",
@@ -412,7 +349,7 @@ void VideoPlayer::sendInitialized() {
       LOG_ERROR(
           "[VideoPlayer.sendInitialized] player_get_display_rotation "
           "failed: %s",
-          ErrorToString(ret).c_str());
+          get_error_message(ret));
     } else {
       LOG_DEBUG("[VideoPlayer.sendInitialized] rotation: %s",
                 RotationToString(rotation).c_str());
@@ -509,19 +446,19 @@ void VideoPlayer::onInterrupted(player_interrupted_code_e code, void *data) {
 
   if (player->eventSink_) {
     LOG_INFO("[VideoPlayer.onInterrupted] send error event");
-    player->eventSink_->Error("VideoInterrupted",
-                              "Video player is interrupted");
+    player->eventSink_->Error("Video player is interrupted", "");
   }
 }
 
 void VideoPlayer::onErrorOccurred(int code, void *data) {
   VideoPlayer *player = (VideoPlayer *)data;
   LOG_DEBUG("[VideoPlayer.onErrorOccurred] error code: %s",
-            ErrorToString(code).c_str());
+            get_error_message(code));
 
   if (player->eventSink_) {
     LOG_INFO("[VideoPlayer.onErrorOccurred] send error event");
-    player->eventSink_->Error(ErrorToString(code), "Video player had error");
+    player->eventSink_->Error("Video player had error",
+                              get_error_message(code));
   }
 }
 

--- a/packages/video_player/tizen/src/video_player_error.h
+++ b/packages/video_player/tizen/src/video_player_error.h
@@ -5,26 +5,26 @@
 
 class VideoPlayerError {
  public:
-  VideoPlayerError(const std::string &message, const std::string &code)
-      : message_(message), code_(code) {}
+  VideoPlayerError(const std::string &code, const std::string &message)
+      : code_(code), message_(message) {}
   ~VideoPlayerError() = default;
 
   VideoPlayerError(const VideoPlayerError &other) {
-    this->message_ = other.message_;
     this->code_ = other.code_;
+    this->message_ = other.message_;
   }
   VideoPlayerError &operator=(const VideoPlayerError &other) {
-    this->message_ = other.message_;
     this->code_ = other.code_;
+    this->message_ = other.message_;
     return *this;
   }
 
-  std::string getMessage() const { return message_; }
   std::string getCode() const { return code_; }
+  std::string getMessage() const { return message_; }
 
  private:
-  std::string message_;
   std::string code_;
+  std::string message_;
 };
 
 #endif  // VIDEO_PLAYER_ERROR_H_

--- a/packages/video_player/tizen/src/video_player_tizen_plugin.cc
+++ b/packages/video_player/tizen/src/video_player_tizen_plugin.cc
@@ -100,8 +100,7 @@ TextureMessage VideoPlayerTizenPlugin::create(const CreateMessage &createMsg) {
       LOG_DEBUG(
           "[VideoPlayerTizenPlugin.create] failed to get resource path "
           "of package");
-      throw VideoPlayerError("failed to get resource path",
-                             "PLAYER_ERROR_INVALID_RESOURCE_PATH");
+      throw VideoPlayerError("failed to get resource path", "");
     }
   }
   LOG_DEBUG("[VideoPlayerTizenPlugin.create] uri of video player: %s",

--- a/packages/wakelock/tizen/src/log.h
+++ b/packages/wakelock/tizen/src/log.h
@@ -8,9 +8,14 @@
 #endif
 #define LOG_TAG "WakelockTizenPlugin"
 
-#define LOG(prio, fmt, arg...)                                                 \
-  dlog_print(prio, LOG_TAG, "%s: %s(%d) > " fmt, __FILE__, __func__, __LINE__, \
-             ##arg)
+#ifndef __MODULE__
+#define __MODULE__ \
+  (strrchr(__FILE__, '/') ? strrchr(__FILE__, '/') + 1 : __FILE__)
+#endif
+
+#define LOG(prio, fmt, arg...)                                         \
+  dlog_print(prio, LOG_TAG, "%s: %s(%d) > " fmt, __MODULE__, __func__, \
+             __LINE__, ##arg)
 
 #define LOG_DEBUG(fmt, args...) LOG(DLOG_DEBUG, fmt, ##args)
 #define LOG_INFO(fmt, args...) LOG(DLOG_INFO, fmt, ##args)

--- a/packages/wakelock/tizen/src/log.h
+++ b/packages/wakelock/tizen/src/log.h
@@ -9,8 +9,7 @@
 #define LOG_TAG "WakelockTizenPlugin"
 
 #ifndef __MODULE__
-#define __MODULE__ \
-  (strrchr(__FILE__, '/') ? strrchr(__FILE__, '/') + 1 : __FILE__)
+#define __MODULE__ strrchr("/" __FILE__, '/') + 1
 #endif
 
 #define LOG(prio, fmt, arg...)                                         \

--- a/packages/webview_flutter/tizen/src/log.h
+++ b/packages/webview_flutter/tizen/src/log.h
@@ -8,9 +8,14 @@
 #endif
 #define LOG_TAG "WebviewFlutterTizenPlugin"
 
-#define LOG(prio, fmt, arg...)                                                 \
-  dlog_print(prio, LOG_TAG, "%s: %s(%d) > " fmt, __FILE__, __func__, __LINE__, \
-             ##arg)
+#ifndef __MODULE__
+#define __MODULE__ \
+  (strrchr(__FILE__, '/') ? strrchr(__FILE__, '/') + 1 : __FILE__)
+#endif
+
+#define LOG(prio, fmt, arg...)                                         \
+  dlog_print(prio, LOG_TAG, "%s: %s(%d) > " fmt, __MODULE__, __func__, \
+             __LINE__, ##arg)
 
 #define LOG_DEBUG(fmt, args...) LOG(DLOG_DEBUG, fmt, ##args)
 #define LOG_INFO(fmt, args...) LOG(DLOG_INFO, fmt, ##args)

--- a/packages/webview_flutter/tizen/src/log.h
+++ b/packages/webview_flutter/tizen/src/log.h
@@ -9,8 +9,7 @@
 #define LOG_TAG "WebviewFlutterTizenPlugin"
 
 #ifndef __MODULE__
-#define __MODULE__ \
-  (strrchr(__FILE__, '/') ? strrchr(__FILE__, '/') + 1 : __FILE__)
+#define __MODULE__ strrchr("/" __FILE__, '/') + 1
 #endif
 
 #define LOG(prio, fmt, arg...)                                         \

--- a/packages/wifi_info_flutter/tizen/src/log.h
+++ b/packages/wifi_info_flutter/tizen/src/log.h
@@ -8,9 +8,14 @@
 #endif
 #define LOG_TAG "WifiInfoFlutterTizenPlugin"
 
-#define LOG(prio, fmt, arg...)                                                 \
-  dlog_print(prio, LOG_TAG, "%s: %s(%d) > " fmt, __FILE__, __func__, __LINE__, \
-             ##arg)
+#ifndef __MODULE__
+#define __MODULE__ \
+  (strrchr(__FILE__, '/') ? strrchr(__FILE__, '/') + 1 : __FILE__)
+#endif
+
+#define LOG(prio, fmt, arg...)                                         \
+  dlog_print(prio, LOG_TAG, "%s: %s(%d) > " fmt, __MODULE__, __func__, \
+             __LINE__, ##arg)
 
 #define LOG_DEBUG(fmt, args...) LOG(DLOG_DEBUG, fmt, ##args)
 #define LOG_INFO(fmt, args...) LOG(DLOG_INFO, fmt, ##args)

--- a/packages/wifi_info_flutter/tizen/src/log.h
+++ b/packages/wifi_info_flutter/tizen/src/log.h
@@ -9,8 +9,7 @@
 #define LOG_TAG "WifiInfoFlutterTizenPlugin"
 
 #ifndef __MODULE__
-#define __MODULE__ \
-  (strrchr(__FILE__, '/') ? strrchr(__FILE__, '/') + 1 : __FILE__)
+#define __MODULE__ strrchr("/" __FILE__, '/') + 1
 #endif
 
 #define LOG(prio, fmt, arg...)                                         \


### PR DESCRIPTION
- Avoid the error converter function and use `get_error_message()` instead.
- Use the new log.h template (`__FILE__` to `__MODULE__`).