### PR TITLE
[WebView] Added implementation of rotation of webview

### DIFF
--- a/packages/webview_flutter/tizen/src/webview.h
+++ b/packages/webview_flutter/tizen/src/webview.h
@@ -55,6 +55,16 @@ class WebView : public PlatformView {
       std::unique_ptr<flutter::MethodResult<flutter::EncodableValue>> result);
   std::string GetChannelName();
   void InitWebView();
+  void InitFlutterChannels();
+  void InitWebViewCallbacks();
+
+  void ReinitializeWebView();
+
+  // web view properties
+  std::string webview_url_;
+  flutter::EncodableMap webview_settings_;
+  flutter::EncodableList webview_javascript_channel_names_list_;
+  std::optional<std::string> webview_user_agent_;
 
   void RegisterJavaScriptChannelName(const std::string& name);
   void ApplySettings(flutter::EncodableMap);


### PR DESCRIPTION
Replaced a "// NOTE: Not supported by LWE on Tizen." with a working implementation

Before: rotation of application was causing a problem with rescalling
web view content.

After: webview is being recreated properly and looks good after rotation
event.

Observed issue: because of recretation of WebView object, browsing
history managed by webView is erased after rotation of application.
Probably it is not crucial.

Signed-off-by: Piotr Kosko/Tizen API (PLT) /SRPOL/Engineer/Samsung Electronics <p.kosko@samsung.com>