### PR TITLE
Fix broken link in READMEs

### DIFF
--- a/packages/battery_plus/README.md
+++ b/packages/battery_plus/README.md
@@ -18,7 +18,7 @@ Then you can import `battery_plus` in your Dart code:
 import 'package:battery_plus/battery_plus.dart';
 ```
 
-For detailed usage, see https://pub.dev/packages/battery_plus#usage.
+For detailed usage, see https://github.com/fluttercommunity/plus_plugins/tree/main/packages/battery_plus/battery_plus#usage.
 
 ## Supported devices
 

--- a/packages/package_info_plus/README.md
+++ b/packages/package_info_plus/README.md
@@ -14,4 +14,4 @@ dependencies:
 
 Then you can import `package_info_plus` in your Dart code.
 
-For detailed usage, see https://github.com/fluttercommunity/plus_plugins/tree/main/packages/package_info_plus#usage.
+For detailed usage, see https://github.com/fluttercommunity/plus_plugins/tree/main/packages/package_info_plus/package_info_plus#usage.

--- a/packages/sensors_plus/README.md
+++ b/packages/sensors_plus/README.md
@@ -18,7 +18,7 @@ Then you can import `sensors_plus` in your Dart code:
 import 'package:sensors_plus/sensors_plus.dart';
 ```
 
-For detailed usage, see https://github.com/fluttercommunity/plus_plugins/tree/main/packages/sensors_plus#usage.
+For detailed usage, see https://github.com/fluttercommunity/plus_plugins/tree/main/packages/sensors_plus/sensors_plus#usage.
 
 ## Supported devices
 


### PR DESCRIPTION
Fixed broken links due to recent directory restructuring in plus repo: https://github.com/fluttercommunity/plus_plugins/pull/313.
Changed "#usage" link from pub.dev to Github for `battery_plus`.