### PR TITLE
Keep EventChannel in memory for the lifetime.

### DIFF
--- a/packages/battery/CHANGELOG.md
+++ b/packages/battery/CHANGELOG.md
@@ -13,3 +13,7 @@
 * Update example and integration_test
 * Update platform interface to 2.0.1
 * Organize dev_dependencies
+
+## 2.0.1
+
+* Fix bug with EventChannel

--- a/packages/battery/README.md
+++ b/packages/battery/README.md
@@ -9,7 +9,7 @@ This package is not an _endorsed_ implementation of `battery`. Therefore, you ha
 ```yaml
 dependencies:
   battery: ^2.0.1
-  battery_tizen: ^2.0.0
+  battery_tizen: ^2.0.1
 ```
 
 Then you can import `battery` in your Dart code:

--- a/packages/battery/pubspec.yaml
+++ b/packages/battery/pubspec.yaml
@@ -1,7 +1,7 @@
 name: battery_tizen
 description: Flutter plugin for accessing information about the battery state
   (full, charging, discharging) on Tizen.
-version: 2.0.0
+version: 2.0.1
 homepage: https://github.com/flutter-tizen/plugins
 
 flutter:

--- a/packages/battery_plus/CHANGELOG.md
+++ b/packages/battery_plus/CHANGELOG.md
@@ -1,3 +1,7 @@
 ## 1.0.0
 
 * Initial release
+
+## 1.0.1
+
+* Fix bug with EventChannel

--- a/packages/battery_plus/README.md
+++ b/packages/battery_plus/README.md
@@ -9,7 +9,7 @@ This package is not an _endorsed_ implementation of `battery_plus`. Therefore, y
 ```yaml
 dependencies:
   battery_plus: ^1.0.1
-  battery_plus_tizen: ^1.0.0
+  battery_plus_tizen: ^1.0.1
 ```
 
 Then you can import `battery_plus` in your Dart code:

--- a/packages/battery_plus/pubspec.yaml
+++ b/packages/battery_plus/pubspec.yaml
@@ -1,6 +1,6 @@
 name: battery_plus_tizen
 description: Tizen implementation of the battery_plus plugin
-version: 1.0.0
+version: 1.0.1
 homepage: https://github.com/flutter-tizen/plugins
 
 flutter:

--- a/packages/battery_plus/tizen/src/battery_plus_tizen_plugin.cc
+++ b/packages/battery_plus/tizen/src/battery_plus_tizen_plugin.cc
@@ -22,43 +22,8 @@ class BatteryPlusTizenPlugin : public flutter::Plugin {
  public:
   static void RegisterWithRegistrar(flutter::PluginRegistrar *registrar) {
     LOG_DEBUG("RegisterWithRegistrar for BatteryPlusTizenPlugin");
-    auto method_channel =
-        std::make_unique<flutter::MethodChannel<flutter::EncodableValue>>(
-            registrar->messenger(), "dev.fluttercommunity.plus/battery",
-            &flutter::StandardMethodCodec::GetInstance());
-    auto event_channel =
-        std::make_unique<flutter::EventChannel<flutter::EncodableValue>>(
-            registrar->messenger(), "dev.fluttercommunity.plus/charging",
-            &flutter::StandardMethodCodec::GetInstance());
-
     auto plugin = std::make_unique<BatteryPlusTizenPlugin>();
-
-    auto method_channel_handler = [plugin_pointer = plugin.get()](
-                                      const auto &call, auto result) {
-      LOG_DEBUG("HandleMethodCall call");
-      plugin_pointer->HandleMethodCall(call, std::move(result));
-    };
-    auto event_channel_handler =
-        std::make_unique<flutter::StreamHandlerFunctions<>>(
-            [plugin_pointer = plugin.get()](
-                const flutter::EncodableValue *arguments,
-                std::unique_ptr<flutter::EventSink<>> &&events)
-                -> std::unique_ptr<flutter::StreamHandlerError<>> {
-              LOG_DEBUG("OnListen");
-              plugin_pointer->RegisterObserver(std::move(events));
-              return nullptr;
-            },
-            [plugin_pointer =
-                 plugin.get()](const flutter::EncodableValue *arguments)
-                -> std::unique_ptr<flutter::StreamHandlerError<>> {
-              LOG_DEBUG("OnCancel");
-              plugin_pointer->UnregisterObserver();
-              return nullptr;
-            });
-
-    method_channel->SetMethodCallHandler(method_channel_handler);
-    event_channel->SetStreamHandler(std::move(event_channel_handler));
-
+    plugin->SetupChannels(registrar);
     registrar->AddPlugin(std::move(plugin));
   }
 
@@ -193,6 +158,43 @@ class BatteryPlusTizenPlugin : public flutter::Plugin {
     result->Success(flutter::EncodableValue(percentage));
   }
 
+ private:
+  void SetupChannels(flutter::PluginRegistrar *registrar) {
+    auto method_channel =
+        std::make_unique<flutter::MethodChannel<flutter::EncodableValue>>(
+            registrar->messenger(), "dev.fluttercommunity.plus/battery",
+            &flutter::StandardMethodCodec::GetInstance());
+    m_event_channel =
+        std::make_unique<flutter::EventChannel<flutter::EncodableValue>>(
+            registrar->messenger(), "dev.fluttercommunity.plus/charging",
+            &flutter::StandardMethodCodec::GetInstance());
+
+    auto method_channel_handler = [this](const auto &call, auto result) {
+      LOG_DEBUG("HandleMethodCall call");
+      this->HandleMethodCall(call, std::move(result));
+    };
+    auto event_channel_handler =
+        std::make_unique<flutter::StreamHandlerFunctions<>>(
+            [this](const flutter::EncodableValue *arguments,
+                   std::unique_ptr<flutter::EventSink<>> &&events)
+                -> std::unique_ptr<flutter::StreamHandlerError<>> {
+              LOG_DEBUG("OnListen");
+              this->RegisterObserver(std::move(events));
+              return nullptr;
+            },
+            [this](const flutter::EncodableValue *arguments)
+                -> std::unique_ptr<flutter::StreamHandlerError<>> {
+              LOG_DEBUG("OnCancel");
+              this->UnregisterObserver();
+              return nullptr;
+            });
+
+    method_channel->SetMethodCallHandler(method_channel_handler);
+    m_event_channel->SetStreamHandler(std::move(event_channel_handler));
+  }
+
+  std::unique_ptr<flutter::EventChannel<flutter::EncodableValue>>
+      m_event_channel;
   std::unique_ptr<flutter::EventSink<flutter::EncodableValue>> m_events;
   bool m_isFull;
 };

--- a/packages/connectivity/CHANGELOG.md
+++ b/packages/connectivity/CHANGELOG.md
@@ -10,3 +10,7 @@
 * Update platform interface to 2.0.1
 * Organize dev_dependencies
 * Replace pointer-based `Success()` with reference-based version
+
+## 2.0.1
+
+* Fix bug with EventChannel

--- a/packages/connectivity/README.md
+++ b/packages/connectivity/README.md
@@ -9,7 +9,7 @@ This package is not an _endorsed_ implementation of `connectivity`. Therefore, y
 ```yaml
 dependencies:
   connectivity: ^3.0.3
-  connectivity_tizen: ^2.0.0
+  connectivity_tizen: ^2.0.1
 ```
 
 Then you can import `connectivity` in your Dart code:

--- a/packages/connectivity/pubspec.yaml
+++ b/packages/connectivity/pubspec.yaml
@@ -1,6 +1,6 @@
 name: connectivity_tizen
 description: Flutter plugin for discovering the state of the network (WiFi) connectivity on Tizen.
-version: 2.0.0
+version: 2.0.1
 homepage: https://github.com/flutter-tizen/plugins
 
 flutter:

--- a/packages/connectivity/tizen/src/connectivity_tizen_plugin.cc
+++ b/packages/connectivity/tizen/src/connectivity_tizen_plugin.cc
@@ -24,38 +24,8 @@ class ConnectivityTizenPlugin : public flutter::Plugin {
  public:
   static void RegisterWithRegistrar(flutter::PluginRegistrar *registrar) {
     LOG_INFO("RegisterWithRegistrar");
-    auto method_channel =
-        std::make_unique<flutter::MethodChannel<flutter::EncodableValue>>(
-            registrar->messenger(), "plugins.flutter.io/connectivity",
-            &flutter::StandardMethodCodec::GetInstance());
-    auto event_channel =
-        std::make_unique<flutter::EventChannel<flutter::EncodableValue>>(
-            registrar->messenger(), "plugins.flutter.io/connectivity_status",
-            &flutter::StandardMethodCodec::GetInstance());
-
     auto plugin = std::make_unique<ConnectivityTizenPlugin>();
-    method_channel->SetMethodCallHandler(
-        [plugin_pointer = plugin.get()](const auto &call, auto result) {
-          plugin_pointer->HandleMethodCall(call, std::move(result));
-        });
-    auto event_channel_handler =
-        std::make_unique<flutter::StreamHandlerFunctions<>>(
-            [plugin_pointer = plugin.get()](
-                const flutter::EncodableValue *arguments,
-                std::unique_ptr<flutter::EventSink<>> &&events)
-                -> std::unique_ptr<flutter::StreamHandlerError<>> {
-              LOG_INFO("OnListen");
-              plugin_pointer->registerObsever(std::move(events));
-              return nullptr;
-            },
-            [plugin_pointer =
-                 plugin.get()](const flutter::EncodableValue *arguments)
-                -> std::unique_ptr<flutter::StreamHandlerError<>> {
-              LOG_INFO("OnCancel");
-              plugin_pointer->clearObserver();
-              return nullptr;
-            });
-    event_channel->SetStreamHandler(std::move(event_channel_handler));
+    plugin->SetupChannels(registrar);
     registrar->AddPlugin(std::move(plugin));
   }
 
@@ -152,6 +122,40 @@ class ConnectivityTizenPlugin : public flutter::Plugin {
     flutter::EncodableValue msg(replay);
     result->Success(msg);
   }
+
+  void SetupChannels(flutter::PluginRegistrar *registrar) {
+    auto method_channel =
+        std::make_unique<flutter::MethodChannel<flutter::EncodableValue>>(
+            registrar->messenger(), "plugins.flutter.io/connectivity",
+            &flutter::StandardMethodCodec::GetInstance());
+    m_event_channel =
+        std::make_unique<flutter::EventChannel<flutter::EncodableValue>>(
+            registrar->messenger(), "plugins.flutter.io/connectivity_status",
+            &flutter::StandardMethodCodec::GetInstance());
+    method_channel->SetMethodCallHandler([this](const auto &call, auto result) {
+      this->HandleMethodCall(call, std::move(result));
+    });
+
+    auto event_channel_handler =
+        std::make_unique<flutter::StreamHandlerFunctions<>>(
+            [this](const flutter::EncodableValue *arguments,
+                   std::unique_ptr<flutter::EventSink<>> &&events)
+                -> std::unique_ptr<flutter::StreamHandlerError<>> {
+              LOG_INFO("OnListen");
+              this->registerObsever(std::move(events));
+              return nullptr;
+            },
+            [this](const flutter::EncodableValue *arguments)
+                -> std::unique_ptr<flutter::StreamHandlerError<>> {
+              LOG_INFO("OnCancel");
+              this->clearObserver();
+              return nullptr;
+            });
+    m_event_channel->SetStreamHandler(std::move(event_channel_handler));
+  }
+
+  std::unique_ptr<flutter::EventChannel<flutter::EncodableValue>>
+      m_event_channel;
   connection_h m_connection;
   std::unique_ptr<flutter::EventSink<flutter::EncodableValue>> m_events;
 };

--- a/packages/sensors/CHANGELOG.md
+++ b/packages/sensors/CHANGELOG.md
@@ -13,3 +13,7 @@
 * Update Flutter copyright information
 * Update example and integration_test
 * Organize dev_dependencies
+
+## 2.0.1
+
+* Fix bug with EventChannel

--- a/packages/sensors/README.md
+++ b/packages/sensors/README.md
@@ -9,7 +9,7 @@ This package is not an _endorsed_ implementation of `sensors`. Therefore, you ha
 ```yaml
 dependencies:
   sensors: ^2.0.0
-  sensors_tizen: ^2.0.0
+  sensors_tizen: ^2.0.1
 ```
 
 Then you can import `sensors` in your Dart code:

--- a/packages/sensors/pubspec.yaml
+++ b/packages/sensors/pubspec.yaml
@@ -1,7 +1,7 @@
 name: sensors_tizen
 description: Tizen implementation of the sensors plugin
 homepage: https://github.com/flutter-tizen/plugins
-version: 2.0.0
+version: 2.0.1
 
 flutter:
   plugin:

--- a/packages/sensors/tizen/src/sensors_plugin.cc
+++ b/packages/sensors/tizen/src/sensors_plugin.cc
@@ -125,7 +125,7 @@ class SensorsPlugin : public flutter::Plugin {
 
  private:
   void setupEventChannels(flutter::PluginRegistrar *registrar) {
-    auto accelerometer_channel =
+    accelerometer_channel_ =
         std::make_unique<flutter::EventChannel<flutter::EncodableValue>>(
             registrar->messenger(), ACCELEROMETER_CHANNEL_NAME,
             &flutter::StandardMethodCodec::GetInstance());
@@ -151,10 +151,10 @@ class SensorsPlugin : public flutter::Plugin {
               }
               return nullptr;
             });
-    accelerometer_channel->SetStreamHandler(
+    accelerometer_channel_->SetStreamHandler(
         std::move(accelerometer_channel_handler));
 
-    auto gyroscope_channel =
+    gyroscope_channel_ =
         std::make_unique<flutter::EventChannel<flutter::EncodableValue>>(
             registrar->messenger(), GYROSCOPE_CHANNEL_NAME,
             &flutter::StandardMethodCodec::GetInstance());
@@ -180,9 +180,9 @@ class SensorsPlugin : public flutter::Plugin {
               }
               return nullptr;
             });
-    gyroscope_channel->SetStreamHandler(std::move(gyroscope_channel_handler));
+    gyroscope_channel_->SetStreamHandler(std::move(gyroscope_channel_handler));
 
-    auto user_accel_channel =
+    user_accel_channel_ =
         std::make_unique<flutter::EventChannel<flutter::EncodableValue>>(
             registrar->messenger(), USER_ACCELEROMETER_CHANNEL_NAME,
             &flutter::StandardMethodCodec::GetInstance());
@@ -208,9 +208,15 @@ class SensorsPlugin : public flutter::Plugin {
               }
               return nullptr;
             });
-    user_accel_channel->SetStreamHandler(std::move(user_accel_handler));
+    user_accel_channel_->SetStreamHandler(std::move(user_accel_handler));
   }
 
+  std::unique_ptr<flutter::EventChannel<flutter::EncodableValue>>
+      accelerometer_channel_;
+  std::unique_ptr<flutter::EventChannel<flutter::EncodableValue>>
+      gyroscope_channel_;
+  std::unique_ptr<flutter::EventChannel<flutter::EncodableValue>>
+      user_accel_channel_;
   std::unique_ptr<Listener> accelerometer_listener_;
   std::unique_ptr<Listener> gyroscope_listener_;
   std::unique_ptr<Listener> user_accel_listener_;

--- a/packages/sensors_plus/CHANGELOG.md
+++ b/packages/sensors_plus/CHANGELOG.md
@@ -1,3 +1,7 @@
 ## 1.0.0
 
 * Initial release
+
+## 1.0.1
+
+* Fix bug with EventChannel

--- a/packages/sensors_plus/README.md
+++ b/packages/sensors_plus/README.md
@@ -9,7 +9,7 @@ This package is not an _endorsed_ implementation of 'sensors_plus'. Therefore, y
 ```yaml
 dependencies:
   sensors_plus: ^1.0.0
-  sensors_plus_tizen: ^1.0.0
+  sensors_plus_tizen: ^1.0.1
 ```
 
 Then you can import `sensors_plus` in your Dart code:

--- a/packages/sensors_plus/pubspec.yaml
+++ b/packages/sensors_plus/pubspec.yaml
@@ -1,7 +1,7 @@
 name: sensors_plus_tizen
 description: Tizen implementation of the sensors plugin
 homepage: https://github.com/flutter-tizen/plugins
-version: 1.0.0
+version: 1.0.1
 
 flutter:
   plugin:

--- a/packages/sensors_plus/tizen/src/sensors_plus_plugin.cc
+++ b/packages/sensors_plus/tizen/src/sensors_plus_plugin.cc
@@ -127,7 +127,7 @@ class SensorsPlusPlugin : public flutter::Plugin {
 
  private:
   void setupEventChannels(flutter::PluginRegistrar *registrar) {
-    auto accelerometer_channel =
+    accelerometer_channel_ =
         std::make_unique<flutter::EventChannel<flutter::EncodableValue>>(
             registrar->messenger(), ACCELEROMETER_CHANNEL_NAME,
             &flutter::StandardMethodCodec::GetInstance());
@@ -153,10 +153,10 @@ class SensorsPlusPlugin : public flutter::Plugin {
               }
               return nullptr;
             });
-    accelerometer_channel->SetStreamHandler(
+    accelerometer_channel_->SetStreamHandler(
         std::move(accelerometer_channel_handler));
 
-    auto gyroscope_channel =
+    gyroscope_channel_ =
         std::make_unique<flutter::EventChannel<flutter::EncodableValue>>(
             registrar->messenger(), GYROSCOPE_CHANNEL_NAME,
             &flutter::StandardMethodCodec::GetInstance());
@@ -182,9 +182,9 @@ class SensorsPlusPlugin : public flutter::Plugin {
               }
               return nullptr;
             });
-    gyroscope_channel->SetStreamHandler(std::move(gyroscope_channel_handler));
+    gyroscope_channel_->SetStreamHandler(std::move(gyroscope_channel_handler));
 
-    auto user_accel_channel =
+    user_accel_channel_ =
         std::make_unique<flutter::EventChannel<flutter::EncodableValue>>(
             registrar->messenger(), USER_ACCELEROMETER_CHANNEL_NAME,
             &flutter::StandardMethodCodec::GetInstance());
@@ -210,9 +210,15 @@ class SensorsPlusPlugin : public flutter::Plugin {
               }
               return nullptr;
             });
-    user_accel_channel->SetStreamHandler(std::move(user_accel_handler));
+    user_accel_channel_->SetStreamHandler(std::move(user_accel_handler));
   }
 
+  std::unique_ptr<flutter::EventChannel<flutter::EncodableValue>>
+      accelerometer_channel_;
+  std::unique_ptr<flutter::EventChannel<flutter::EncodableValue>>
+      gyroscope_channel_;
+  std::unique_ptr<flutter::EventChannel<flutter::EncodableValue>>
+      user_accel_channel_;
   std::unique_ptr<Listener> accelerometer_listener_;
   std::unique_ptr<Listener> gyroscope_listener_;
   std::unique_ptr<Listener> user_accel_listener_;

--- a/packages/wearable_rotary/CHANGELOG.md
+++ b/packages/wearable_rotary/CHANGELOG.md
@@ -1,3 +1,7 @@
 ## 1.0.0
 
 * Initial release
+
+## 1.0.1
+
+* Fix bug with EventChannel

--- a/packages/wearable_rotary/README.md
+++ b/packages/wearable_rotary/README.md
@@ -8,7 +8,7 @@ To use this plugin, add wearable_rotary as a dependency in your pubspec.yaml fil
 
 ```yaml
 dependencies:
-  wearable_rotary: ^1.0.0
+  wearable_rotary: ^1.0.1
 ```
 
 ## Example

--- a/packages/wearable_rotary/pubspec.yaml
+++ b/packages/wearable_rotary/pubspec.yaml
@@ -1,6 +1,6 @@
 name: wearable_rotary
 description: Flutter plugin that can listen to rotary events on Galaxy watch devices.
-version: 1.0.0
+version: 1.0.1
 homepage: https://github.com/flutter-tizen/plugins
 
 environment:

--- a/packages/wearable_rotary/tizen/src/wearable_rotary_plugin.cc
+++ b/packages/wearable_rotary/tizen/src/wearable_rotary_plugin.cc
@@ -29,7 +29,7 @@ class WearableRotaryPlugin : public flutter::Plugin {
 
  private:
   void SetupEventChannel(flutter::PluginRegistrar *registrar) {
-    auto channel =
+    event_channel_ =
         std::make_unique<flutter::EventChannel<flutter::EncodableValue>>(
             registrar->messenger(), kChannelName,
             &flutter::StandardMethodCodec::GetInstance());
@@ -55,7 +55,8 @@ class WearableRotaryPlugin : public flutter::Plugin {
               events_ = nullptr;
               return nullptr;
             });
-    channel->SetStreamHandler(std::move(wearable_rotary_channel_handler));
+    event_channel_->SetStreamHandler(
+        std::move(wearable_rotary_channel_handler));
   }
 
   static Eina_Bool RotaryEventCallBack(void *data,
@@ -66,6 +67,9 @@ class WearableRotaryPlugin : public flutter::Plugin {
     return EINA_TRUE;
   }
 
+ private:
+  std::unique_ptr<flutter::EventChannel<flutter::EncodableValue>>
+      event_channel_;
   std::unique_ptr<flutter::EventSink<flutter::EncodableValue>> events_;
 };
 


### PR DESCRIPTION
EventChannels have to be preserved in memory in order to work properly.
I tested modified plugins, no issues occurred.

It fixes #131 

Signed-off-by: Rafal Walczyna <r.walczyna@samsung.com>