### PR TITLE
[flutter_tts] Always send valid values instead of Error

### DIFF
--- a/packages/flutter_tts/CHANGELOG.md
+++ b/packages/flutter_tts/CHANGELOG.md
@@ -5,3 +5,7 @@
 ## 1.0.1
 
 * Stabilize a speaking states management.
+
+## 1.1.0
+
+* All APIs now return valid values.(0 or 1, empty list, etc.)

--- a/packages/flutter_tts/README.md
+++ b/packages/flutter_tts/README.md
@@ -9,7 +9,7 @@ This package is not an _endorsed_ implementation of `flutter_tts`. Therefore, yo
 ```yaml
 dependencies:
   flutter_tts: ^3.0.0
-  flutter_tts_tizen: ^1.0.1
+  flutter_tts_tizen: ^1.1.0
 ```
 
 Then you can import `flutter_tts` in your Dart code:

--- a/packages/flutter_tts/example/integration_test/flutter_tts_test.dart
+++ b/packages/flutter_tts/example/integration_test/flutter_tts_test.dart
@@ -12,5 +12,5 @@ void main() {
     final FlutterTts flutterTts = FlutterTts();
     var result = await flutterTts.speak("Hello World");
     expect(result, 1);
-  }, skip: true);
+  });
 }

--- a/packages/flutter_tts/pubspec.yaml
+++ b/packages/flutter_tts/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_tts_tizen
 description: The tizen implementation of flutter_tts plugin.
-version: 1.0.1
+version: 1.1.0
 homepage: https://github.com/flutter-tizen/plugins
 
 dependencies:
@@ -15,5 +15,5 @@ flutter:
         fileName: flutter_tts_tizen_plugin.h
 
 environment:
-  sdk: '>=2.12.0 <3.0.0'
+  sdk: ">=2.12.0 <3.0.0"
   flutter: ">=2.0.0"

--- a/packages/flutter_tts/tizen/src/flutter_tts_tizen_plugin.cc
+++ b/packages/flutter_tts/tizen/src/flutter_tts_tizen_plugin.cc
@@ -123,10 +123,16 @@ class FlutterTtsTizenPlugin : public flutter::Plugin {
       const flutter::MethodCall<flutter::EncodableValue> &method_call,
       std::unique_ptr<flutter::MethodResult<flutter::EncodableValue>> result) {
     if (!EnsureTtsHandle()) {
-      LOG_ERROR("[TTS] EnsureTtsHandle() failed: %s", "EnsureTtsHandle failed");
-      result->Error("Invalid Operation", "Invalid Operation");
+      LOG_ERROR("[TTS] Failed to ensure native tts APIs handle.");
+      result->Error("Platform Error",
+                    "Failed to ensure native tts APIs handle.");
       return;
     }
+
+    // Keep in sync with the return values implemented in:
+    // https://github.com/dlutton/flutter_tts/blob/master/android/src/main/java/com/tundralabs/fluttertts/FlutterTtsPlugin.java
+    // The API specification is vague, and there is no detailed description of
+    // the return value, so I mimic the Android implementation.
 
     const auto method_name = method_call.method_name();
     const auto &arguments = *method_call.arguments();


### PR DESCRIPTION
* The implementation of this plugin expects to return a valid value such as 1,0.
So I mimicked other platform implementations.

Signed-off-by: Boram Bae <boram21.bae@samsung.com>