### PR TITLE
[google_maps_flutter] Add APIs related to camera property

### DIFF
--- a/packages/google_maps_flutter/README.md
+++ b/packages/google_maps_flutter/README.md
@@ -22,10 +22,8 @@ dependencies:
   google_maps_flutter_tizen: ^0.0.1
 ```
 
-In addition, you need a Maps JavaScript API Key to use this plugin. Please refer to the site below to get the API key.
-```
-https://developers.google.com/maps/documentation/javascript/get-api-key
-```
+In addition, you need a Maps JavaScript API Key to use this plugin. Please refer to the site below to get the API key.  
+<https://developers.google.com/maps/documentation/javascript/get-api-key>
 
 To use 'newCameraPosition' API, please add 'v=beta' option in map.html as shown below:
 ```

--- a/packages/google_maps_flutter/README.md
+++ b/packages/google_maps_flutter/README.md
@@ -22,3 +22,14 @@ dependencies:
   google_maps_flutter_tizen: ^0.0.1
 ```
 
+In addition, you need a Maps JavaScript API Key to use this plugin. Please refer to the site below to get the API key.
+```
+https://developers.google.com/maps/documentation/javascript/get-api-key
+```
+
+To use 'newCameraPosition' API, please add 'v=beta' option in map.html as shown below:
+```
+<script async
+    src="https://maps.googleapis.com/maps/api/js?v=beta&key=YOUR_API_KEY&callback=initMap">
+</script>
+```

--- a/packages/google_maps_flutter/lib/src/convert.dart
+++ b/packages/google_maps_flutter/lib/src/convert.dart
@@ -22,7 +22,6 @@ String? _getCameraBounds(dynamic option) {
     return null;
   }
 
-  // ex: [[[-34.022631, 150.62068499999998], [-33.571835, 151.32595200000003]]]
   final List<Object> bound = option[0] as List<Object>;
   final LatLng? southwest = LatLng.fromJson(bound[0]);
   final LatLng? northeast = LatLng.fromJson(bound[1]);

--- a/packages/google_maps_flutter/lib/src/google_maps_controller.dart
+++ b/packages/google_maps_flutter/lib/src/google_maps_controller.dart
@@ -511,7 +511,8 @@ class GoogleMapController {
           zoomDelta = (json[1] as num) + 0.0;
         }
         // Web only supports integer changes...
-        int newZoomDelta = zoomDelta < 0 ? zoomDelta.floor() : zoomDelta.ceil();
+        final int newZoomDelta =
+            zoomDelta < 0 ? zoomDelta.floor() : zoomDelta.ceil();
         if (json.length == 3) {
           // With focus
           try {

--- a/packages/google_maps_flutter/lib/src/google_maps_controller.dart
+++ b/packages/google_maps_flutter/lib/src/google_maps_controller.dart
@@ -43,8 +43,7 @@ class GoogleMapController {
         initMap +
         html.substring(pos + 8, html.length);
 
-    final WebViewController mapView = await controller;
-    mapView.loadUrl(Uri.dataFromString(html,
+    (await controller).loadUrl(Uri.dataFromString(html,
             mimeType: 'text/html', encoding: Encoding.getByName('utf-8'))
         .toString());
   }
@@ -329,15 +328,15 @@ class GoogleMapController {
   }
 
   Future<String> _setOptions(String options) async {
-    print('setOptions: $options');
-    final WebViewController mapView = await controller;
-    final String value = await _callMethod(mapView, 'setOptions', [options]);
-    return value;
+    return await _callMethod(await controller, 'setOptions', [options]);
+  }
+
+  Future<void> _setZoom(String options) async {
+    await _callMethod(await controller, 'setZoom', [options]);
   }
 
   // Attaches/detaches a Traffic Layer on the `map` if `attach` is true/false.
   Future<void> _setTrafficLayer(bool attach) async {
-    final WebViewController mapView = await controller;
     final String command = '''
       var trafficLayer;
       if ($attach == true && trafficLayer == null) {
@@ -351,11 +350,28 @@ class GoogleMapController {
         console.log('trafficLayer detached!!');
       }
     ''';
-    await mapView.evaluateJavascript(command);
+    await (await controller).evaluateJavascript(command);
+  }
+
+  Future<void> _setMoveCamera(String options) async {
+    await _callMethod(await controller, 'moveCamera', [options]);
+  }
+
+  Future<void> _setPanTo(String options) async {
+    await _callMethod(await controller, 'panTo', [options]);
+  }
+
+  Future<void> _setPanBy(String options) async {
+    await _callMethod(await controller, 'panBy', [options]);
+  }
+
+  Future<void> _setFitBounds(String options) async {
+    await _callMethod(await controller, 'fitBounds', [options]);
   }
 
   Future<String> _callMethod(
       WebViewController mapView, String method, List<Object?> args) async {
+    print('callMethod: $method($args)');
     final String command = 'JSON.stringify(map.$method.apply(map, $args))';
     final String result = await mapView.evaluateJavascript(command);
     return result;
@@ -385,8 +401,9 @@ class GoogleMapController {
     try {
       final dynamic latlng = json.decode(value);
       if (latlng is Map<String, dynamic>) {
-        assert(latlng['lat'] is double && latlng['lng'] is double);
-        return LatLng(latlng['lat'] as double, latlng['lng'] as double);
+        assert(latlng['lat'] is num && latlng['lng'] is num);
+        return LatLng(
+            (latlng['lat'] as num) + 0.0, (latlng['lng'] as num) + 0.0);
       }
     } catch (e) {
       print('Javascript Error: $e');
@@ -459,11 +476,101 @@ class GoogleMapController {
 
   /// Applies a `cameraUpdate` to the current viewport.
   Future<void> moveCamera(CameraUpdate cameraUpdate) async {
-    // TODO : implement for google_map_tizen if necessary
-    // assert(_googleMap != null, 'Cannot update the camera of a null map.');
-    // return _applyCameraUpdate(_googleMap!, cameraUpdate);
-
     assert(_widget != null, 'Cannot update the camera of a null map.');
+    _applyCameraUpdate(cameraUpdate);
+  }
+
+  // Translates a [CameraUpdate] into operations on a [Javascript].
+  Future<void> _applyCameraUpdate(CameraUpdate update) async {
+    final List<dynamic> json = update.toJson() as List<dynamic>;
+    switch (json[0]) {
+      case 'newCameraPosition':
+        _setMoveCamera(
+            '{heading: ${json[1]['bearing']}, zoom: ${json[1]['zoom']}, tilt: ${json[1]['tilt']}}');
+        _setPanTo(
+            '{lat:${json[1]['target'][0]}, lng: ${json[1]['target'][1]}}');
+        break;
+      case 'newLatLng':
+        _setPanTo('{lat:${json[1][0]}, lng:${json[1][1]}}');
+        break;
+      case 'newLatLngZoom':
+        _setMoveCamera('{zoom: ${json[2]}}');
+        _setPanTo('{lat:${json[1][0]}, lng: ${json[1][1]}}');
+        break;
+      case 'newLatLngBounds':
+        _setFitBounds(
+            '{south:${json[1][0][0]}, west:${json[1][0][1]}, north:${json[1][1][0]}, east:${json[1][1][1]}}, ${json[2]}');
+        break;
+      case 'scrollBy':
+        _setPanBy('${json[1]}, ${json[2]}');
+        break;
+      case 'zoomBy':
+        String? focusLatLng;
+        double zoomDelta = 0.0;
+        if (json[1] != null) {
+          zoomDelta = (json[1] as num) + 0.0;
+        }
+        // Web only supports integer changes...
+        int newZoomDelta = zoomDelta < 0 ? zoomDelta.floor() : zoomDelta.ceil();
+        if (json.length == 3) {
+          // With focus
+          try {
+            focusLatLng = await _pixelToLatLng(
+                json[2][0] as double, json[2][1] as double);
+          } catch (e) {
+            print('Error computing focus LatLng. JS Error: ' + e.toString());
+          }
+        }
+        _setZoom('${(await getZoomLevel()) + newZoomDelta}');
+        if (focusLatLng != null) {
+          _setPanTo(focusLatLng);
+        }
+        break;
+      case 'zoomIn':
+        _setZoom('${(await getZoomLevel()) + 1}');
+        break;
+      case 'zoomOut':
+        _setZoom('${(await getZoomLevel()) - 1}');
+        break;
+      case 'zoomTo':
+        _setZoom('${json[1]}');
+        break;
+      default:
+        throw UnimplementedError('Unimplemented CameraMove: ${json[0]}.');
+    }
+  }
+
+  Future<String> _pixelToLatLng(double x, double y) async {
+    final String command = '''
+      function assert(condition, message) {
+        if (!condition) {
+          throw new Error(message || "Assertion failed");
+        }
+      }
+
+      function getPixelToLatLng() {
+        var bounds = map.getBounds();
+        var projection = map.getProjection();
+        var zoom = map.zoom;
+
+        assert(bounds != null, 'Map Bounds required to compute LatLng of screen x/y.');
+        assert(projection != null, 'Map Projection required to compute LatLng of screen x/y');
+        assert(zoom != null, 'Current map zoom level required to compute LatLng of screen x/y');
+
+        var ne = bounds.getNorthEast();
+        var sw = bounds.getSouthWest();
+        var topRight = projection.fromLatLngToPoint(ne);
+        var bottomLeft = projection.fromLatLngToPoint(sw);
+        var scale = 1 << parseInt(zoom); // 2 ^ zoom
+
+        var point = new google.maps.Point(topRight.x - ($x / scale), bottomLeft.y - ($y / scale));
+        return projection.fromPointToLatLng(point);
+      }
+
+      JSON.stringify(getPixelToLatLng());
+    ''';
+
+    return await (await controller).evaluateJavascript(command);
   }
 
   /// Returns the zoom level of the current viewport.


### PR DESCRIPTION
* Handle CameraUpdate class for AnimateCamera and MoveCamera API
* Note that AnimateCamera API is not supported in Web. Hence, as in
google_maps_flutter_web, it will run the same as MoveCamera API.

Signed-off-by: Seungsoo Lee <seungsoo47.lee@samsung.com>