### PR TITLE
[url_launcher] Use get_error_message() for error message conversion

### DIFF
--- a/packages/url_launcher/CHANGELOG.md
+++ b/packages/url_launcher/CHANGELOG.md
@@ -4,26 +4,36 @@
 
 ## 1.0.1
 
-* Migrate to Tizen 4.0
+* Migrate to Tizen 4.0.
 
 ## 1.0.2
 
-* Update url_launcher to 5.7.10
-* Update platform interface to 1.0.9
-* Increase the minimum framework requirement to 1.22.0
+* Update url_launcher to 5.7.10.
+* Update platform interface to 1.0.9.
+* Increase the minimum framework requirement to 1.22.0.
 
 ## 1.0.3
 
 * Use `PlatformException` instead of a plugin-specific exception type
-  (`AppControlException`)
-* Move `app_control.dart` to the implementation directory
+  (`AppControlException`).
+* Move `app_control.dart` to `src` directory.
 
 ## 2.0.0
 
-* Update Dart and Flutter SDK constraints
-* Update Flutter copyright information
-* Update example and integration_test
-* Update platform interface to 2.0.2
-* Organize dev_dependencies
-* Migrate to ffi 1.0.0
-* Migrate to null safety
+* Increase Dart and Flutter SDK constraints to 2.12.0 and 2.0.0.
+* Update Flutter copyright information.
+* Update example and integration_test.
+* Update platform interface to 2.0.2.
+* Organize dev_dependencies.
+* Migrate to ffi 1.0.0.
+* Migrate to null safety.
+
+## 2.0.1
+
+* Increase Dart and Flutter SDK constraints to 2.13.0 and 2.2.0.
+* Use `get_error_message()` for error message conversion.
+* Use more typedefs.
+* Update url_launcher to 6.0.9.
+* Update platform interface to 2.0.4.
+* Remove `@dart=2.9` from test files.
+* Sync the example code.

--- a/packages/url_launcher/README.md
+++ b/packages/url_launcher/README.md
@@ -8,8 +8,8 @@ This package is not an _endorsed_ implementation of `url_launcher`. Therefore, y
 
 ```yaml
 dependencies:
-  url_launcher: ^6.0.2
-  url_launcher_tizen: ^2.0.0
+  url_launcher: ^6.0.9
+  url_launcher_tizen: ^2.0.1
 ```
 
 Then you can import `url_launcher` in your Dart code:

--- a/packages/url_launcher/example/integration_test/url_launcher_test.dart
+++ b/packages/url_launcher/example/integration_test/url_launcher_test.dart
@@ -2,9 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// TODO(egarciad): Remove once integration_test is migrated to null safety.
-// @dart = 2.9
-
 import 'dart:io' show Platform;
 
 import 'package:flutter/foundation.dart' show kIsWeb;

--- a/packages/url_launcher/example/lib/main.dart
+++ b/packages/url_launcher/example/lib/main.dart
@@ -7,6 +7,7 @@
 import 'dart:async';
 
 import 'package:flutter/material.dart';
+import 'package:url_launcher/link.dart';
 import 'package:url_launcher/url_launcher.dart';
 
 void main() {
@@ -21,13 +22,13 @@ class MyApp extends StatelessWidget {
       theme: ThemeData(
         primarySwatch: Colors.blue,
       ),
-      home: const MyHomePage(title: 'URL Launcher'),
+      home: MyHomePage(title: 'URL Launcher'),
     );
   }
 }
 
 class MyHomePage extends StatefulWidget {
-  const MyHomePage({Key? key, required this.title}) : super(key: key);
+  MyHomePage({Key? key, required this.title}) : super(key: key);
   final String title;
 
   @override
@@ -194,6 +195,19 @@ class _MyHomePageState extends State<MyHomePage> {
                   });
                 }),
                 child: const Text('Launch in app + close after 5 seconds'),
+              ),
+              const Padding(padding: EdgeInsets.all(16.0)),
+              Link(
+                uri: Uri.parse(
+                    'https://pub.dev/documentation/url_launcher/latest/link/link-library.html'),
+                target: LinkTarget.blank,
+                builder: (ctx, openLink) {
+                  return TextButton.icon(
+                    onPressed: openLink,
+                    label: Text('Link Widget documentation'),
+                    icon: Icon(Icons.read_more),
+                  );
+                },
               ),
               const Padding(padding: EdgeInsets.all(16.0)),
               FutureBuilder<void>(future: _launched, builder: _launchStatus),

--- a/packages/url_launcher/example/pubspec.yaml
+++ b/packages/url_launcher/example/pubspec.yaml
@@ -5,7 +5,7 @@ publish_to: "none"
 dependencies:
   flutter:
     sdk: flutter
-  url_launcher: ^6.0.2
+  url_launcher: ^6.0.9
   url_launcher_tizen:
     path: ../
 
@@ -23,5 +23,5 @@ flutter:
   uses-material-design: true
 
 environment:
-  sdk: ">=2.12.0 <3.0.0"
-  flutter: ">=2.0.0"
+  sdk: ">=2.13.0 <3.0.0"
+  flutter: ">=2.2.0"

--- a/packages/url_launcher/example/test_driver/integration_test.dart
+++ b/packages/url_launcher/example/test_driver/integration_test.dart
@@ -1,5 +1,3 @@
-// @dart=2.9
-
 import 'package:integration_test/integration_test_driver.dart';
 
 Future<void> main() => integrationDriver();

--- a/packages/url_launcher/lib/src/app_control.dart
+++ b/packages/url_launcher/lib/src/app_control.dart
@@ -76,13 +76,19 @@ class AppControl {
   /// Corresponds to `app_control_set_operation()`.
   void setOperation(String operation) {
     assert(_handle != nullptr);
-    _throwOnError(_appControlSetOperation(_handle, operation.toNativeUtf8()));
+    final Pointer<Utf8> operationNative = operation.toNativeUtf8();
+    final int ret = _appControlSetOperation(_handle, operationNative);
+    malloc.free(operationNative);
+    _throwOnError(ret);
   }
 
   /// Corresponds to `app_control_set_uri()`.
   void setUri(String uri) {
     assert(_handle != nullptr);
-    _throwOnError(_appControlSetUri(_handle, uri.toNativeUtf8()));
+    final Pointer<Utf8> uriNative = uri.toNativeUtf8();
+    final int ret = _appControlSetUri(_handle, uriNative);
+    malloc.free(uriNative);
+    _throwOnError(ret);
   }
 
   /// Corresponds to `app_control_send_launch_request()`.

--- a/packages/url_launcher/lib/src/app_control.dart
+++ b/packages/url_launcher/lib/src/app_control.dart
@@ -2,158 +2,100 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// ignore_for_file: public_member_api_docs
-
 import 'dart:ffi';
+
 import 'package:ffi/ffi.dart';
 import 'package:flutter/services.dart';
 
-typedef _app_control_create = Int32 Function(Pointer<Pointer<_AppControl>>);
-typedef _app_control_set_operation = Int32 Function(
-    Pointer<_AppControl>, Pointer<Utf8>);
-typedef _app_control_set_uri = Int32 Function(
-    Pointer<_AppControl>, Pointer<Utf8>);
-typedef _app_control_send_launch_request = Int32 Function(
-    Pointer<_AppControl>, Pointer<Void>, Pointer<Void>);
-typedef _app_control_destroy = Int32 Function(Pointer<_AppControl>);
+import 'types.dart';
 
-// Corresponds to `app_control_result_e` in `app_control.h`
-const int APP_CONTROL_RESULT_APP_STARTED = 1;
-const int APP_CONTROL_RESULT_SUCCEEDED = 0;
-const int APP_CONTROL_RESULT_FAILED = -1;
-const int APP_CONTROL_RESULT_CANCELED = -2;
-
-// Corresponds to constants defined in `app_control.h`
+/// Defined in `app_control.h`.
 const String APP_CONTROL_OPERATION_VIEW =
     'http://tizen.org/appcontrol/operation/view';
-
-// Corresponds to constants defined in `tizen_error.h`
-const int TIZEN_ERROR_NONE = 0;
-const int TIZEN_ERROR_INVALID_PARAMETER = -22;
-const int TIZEN_ERROR_OUT_OF_MEMORY = -12;
-const int TIZEN_ERROR_APPLICATION = -0x01100000;
-const int TIZEN_ERROR_KEY_NOT_AVAILABLE = -126;
-const int TIZEN_ERROR_KEY_REJECTED = -129;
-const int TIZEN_ERROR_PERMISSION_DENIED = -13;
-const int TIZEN_ERROR_TIMED_OUT = -1073741824 + 1;
-const int TIZEN_ERROR_IO_ERROR = -5;
-
-class _AppControl extends Opaque {}
-
-/// Corresponds to `app_control_error_e` in `app_control.h`
-const Map<int, String> _errorCodes = <int, String>{
-  TIZEN_ERROR_NONE: 'APP_CONTROL_ERROR_NONE',
-  TIZEN_ERROR_INVALID_PARAMETER: 'APP_CONTROL_ERROR_INVALID_PARAMETER',
-  TIZEN_ERROR_OUT_OF_MEMORY: 'APP_CONTROL_ERROR_OUT_OF_MEMORY',
-  TIZEN_ERROR_APPLICATION | 0x21: 'APP_CONTROL_ERROR_APP_NOT_FOUND',
-  TIZEN_ERROR_KEY_NOT_AVAILABLE: 'APP_CONTROL_ERROR_KEY_NOT_FOUND',
-  TIZEN_ERROR_KEY_REJECTED: 'APP_CONTROL_ERROR_KEY_REJECTED',
-  TIZEN_ERROR_APPLICATION | 0x22: 'APP_CONTROL_ERROR_INVALID_DATA_TYPE',
-  TIZEN_ERROR_APPLICATION | 0x23: 'APP_CONTROL_ERROR_LAUNCH_REJECTED',
-  TIZEN_ERROR_PERMISSION_DENIED: 'APP_CONTROL_ERROR_PERMISSION_DENIED',
-  TIZEN_ERROR_APPLICATION | 0x24: 'APP_CONTROL_ERROR_LAUNCH_FAILED',
-  TIZEN_ERROR_TIMED_OUT: 'APP_CONTROL_ERROR_TIMED_OUT',
-  TIZEN_ERROR_IO_ERROR: 'APP_CONTROL_ERROR_IO_ERROR',
-};
-
-String _getErrorCode(int returnCode) => _errorCodes.containsKey(returnCode)
-    ? _errorCodes[returnCode]!
-    : '$returnCode';
 
 /// Dart wrapper of Tizen's `app_control`.
 ///
 /// See: https://docs.tizen.org/application/native/api/wearable/latest/group__CAPI__APP__CONTROL__MODULE.html
 class AppControl {
   AppControl() {
-    final DynamicLibrary lib =
+    final DynamicLibrary libAppControl =
         DynamicLibrary.open('libcapi-appfw-app-control.so.0');
-    _create = lib
-        .lookup<NativeFunction<_app_control_create>>('app_control_create')
+    _appControlCreate = libAppControl
+        .lookup<NativeFunction<AppControlCreateFunc>>('app_control_create')
         .asFunction();
-    _setOperation = lib
-        .lookup<NativeFunction<_app_control_set_operation>>(
+    _appControlSetOperation = libAppControl
+        .lookup<NativeFunction<AppControlSetOperationFunc>>(
             'app_control_set_operation')
         .asFunction();
-    _setUri = lib
-        .lookup<NativeFunction<_app_control_set_uri>>('app_control_set_uri')
+    _appControlSetUri = libAppControl
+        .lookup<NativeFunction<AppControlSetUriFunc>>('app_control_set_uri')
         .asFunction();
-    _sendLaunchRequest = lib
-        .lookup<NativeFunction<_app_control_send_launch_request>>(
+    _appControlSendLaunchRequest = libAppControl
+        .lookup<NativeFunction<AppControlSendLaunchRequestFunc>>(
             'app_control_send_launch_request')
         .asFunction();
-    _destroy = lib
-        .lookup<NativeFunction<_app_control_destroy>>('app_control_destroy')
+    _appControlDestroy = libAppControl
+        .lookup<NativeFunction<AppControlDestroyFunc>>('app_control_destroy')
+        .asFunction();
+
+    final DynamicLibrary libBaseCommon =
+        DynamicLibrary.open('libcapi-base-common.so.0');
+    _getErrorMessage = libBaseCommon
+        .lookup<NativeFunction<GetErrorMessageFunc>>('get_error_message')
         .asFunction();
   }
 
-  late int Function(Pointer<Pointer<_AppControl>>) _create;
-  late int Function(Pointer<_AppControl>, Pointer<Utf8>) _setOperation;
-  late int Function(Pointer<_AppControl>, Pointer<Utf8>) _setUri;
-  late int Function(Pointer<_AppControl>, Pointer<Void>, Pointer<Void>)
-      _sendLaunchRequest;
-  late int Function(Pointer<_AppControl>) _destroy;
+  late AppControlCreate _appControlCreate;
+  late AppControlSetOperation _appControlSetOperation;
+  late AppControlSetUri _appControlSetUri;
+  late AppControlSendLaunchRequest _appControlSendLaunchRequest;
+  late AppControlDestroy _appControlDestroy;
+  late GetErrorMessage _getErrorMessage;
 
-  Pointer<_AppControl> _handle = nullptr;
+  AppControlHandle _handle = nullptr;
+
+  void _throwOnError(int ret) {
+    if (ret != 0) {
+      final Pointer<Utf8> message = _getErrorMessage(ret);
+      throw PlatformException(
+        code: ret.toString(),
+        message: message.toDartString(),
+      );
+    }
+  }
 
   /// Corresponds to `app_control_create()`.
   void create() {
-    final Pointer<Pointer<_AppControl>> pHandle = malloc();
-    final int ret = _create(pHandle);
+    final Pointer<AppControlHandle> pHandle = malloc();
+    final int ret = _appControlCreate(pHandle);
     _handle = pHandle.value;
     malloc.free(pHandle);
-
-    if (ret != 0) {
-      throw PlatformException(
-        code: _getErrorCode(ret),
-        message: 'Failed to execute app_control_create.',
-      );
-    }
+    _throwOnError(ret);
   }
 
   /// Corresponds to `app_control_set_operation()`.
   void setOperation(String operation) {
     assert(_handle != nullptr);
-
-    final int ret = _setOperation(_handle, operation.toNativeUtf8());
-    if (ret != 0) {
-      throw PlatformException(
-        code: _getErrorCode(ret),
-        message: 'Failed to execute app_control_set_operation.',
-      );
-    }
+    _throwOnError(_appControlSetOperation(_handle, operation.toNativeUtf8()));
   }
 
   /// Corresponds to `app_control_set_uri()`.
   void setUri(String uri) {
     assert(_handle != nullptr);
-
-    final int ret = _setUri(_handle, uri.toNativeUtf8());
-    if (ret != 0) {
-      throw PlatformException(
-        code: _getErrorCode(ret),
-        message: 'Failed to execute app_control_set_uri.',
-      );
-    }
+    _throwOnError(_appControlSetUri(_handle, uri.toNativeUtf8()));
   }
 
   /// Corresponds to `app_control_send_launch_request()`.
   void sendLaunchRequest() {
     assert(_handle != nullptr);
-
-    final int ret = _sendLaunchRequest(_handle, nullptr, nullptr);
-    if (ret != 0) {
-      throw PlatformException(
-        code: _getErrorCode(ret),
-        message: 'Failed to execute app_control_send_launch_request.',
-      );
-    }
+    _throwOnError(_appControlSendLaunchRequest(_handle, nullptr, nullptr));
   }
 
   /// Corresponds to `app_control_destroy()`.
   void destroy() {
-    if (_handle != nullptr) {
-      _destroy(_handle);
-      _handle = nullptr;
-    }
+    assert(_handle != nullptr);
+    final int ret = _appControlDestroy(_handle);
+    _handle = nullptr;
+    _throwOnError(ret);
   }
 }

--- a/packages/url_launcher/lib/src/types.dart
+++ b/packages/url_launcher/lib/src/types.dart
@@ -1,0 +1,30 @@
+// Copyright 2021 Samsung Electronics Co., Ltd. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:ffi';
+
+import 'package:ffi/ffi.dart';
+
+class AppControlStruct extends Opaque {}
+
+typedef AppControlHandle = Pointer<AppControlStruct>;
+
+// Native functions.
+typedef AppControlCreateFunc = Int32 Function(Pointer<AppControlHandle>);
+typedef AppControlSetOperationFunc = Int32 Function(
+    AppControlHandle, Pointer<Utf8>);
+typedef AppControlSetUriFunc = Int32 Function(AppControlHandle, Pointer<Utf8>);
+typedef AppControlSendLaunchRequestFunc = Int32 Function(
+    AppControlHandle, Pointer<Void>, Pointer<Void>);
+typedef AppControlDestroyFunc = Int32 Function(AppControlHandle);
+typedef GetErrorMessageFunc = Pointer<Utf8> Function(Int32);
+
+// Dart functions.
+typedef AppControlCreate = int Function(Pointer<AppControlHandle>);
+typedef AppControlSetOperation = int Function(AppControlHandle, Pointer<Utf8>);
+typedef AppControlSetUri = int Function(AppControlHandle, Pointer<Utf8>);
+typedef AppControlSendLaunchRequest = int Function(
+    AppControlHandle, Pointer<Void>, Pointer<Void>);
+typedef AppControlDestroy = int Function(AppControlHandle);
+typedef GetErrorMessage = Pointer<Utf8> Function(int);

--- a/packages/url_launcher/pubspec.yaml
+++ b/packages/url_launcher/pubspec.yaml
@@ -1,7 +1,7 @@
 name: url_launcher_tizen
 description: Tizen implementation of the url_launcher plugin
 homepage: https://github.com/flutter-tizen/plugins
-version: 2.0.0
+version: 2.0.1
 
 flutter:
   plugin:
@@ -11,11 +11,11 @@ flutter:
         fileName: url_launcher_tizen.dart
 
 dependencies:
-  ffi: ^1.0.0
+  ffi: ^1.1.2
   flutter:
     sdk: flutter
-  url_launcher_platform_interface: ^2.0.2
+  url_launcher_platform_interface: ^2.0.4
 
 environment:
-  sdk: '>=2.12.0 <3.0.0'
-  flutter: ">=2.0.0"
+  sdk: '>=2.13.0 <3.0.0'
+  flutter: ">=2.2.0"


### PR DESCRIPTION
- Use `get_error_message()` for error message conversion.
- Also minor changes as indicated in the CHANGELOG file. The minimum Dart SDK version has been increased to 2.13.0 to use the new type alias feature.
