### PR TITLE
[shared_preferences] Fix memory leaks

### DIFF
--- a/packages/shared_preferences/example/integration_test/shared_preferences_test.dart
+++ b/packages/shared_preferences/example/integration_test/shared_preferences_test.dart
@@ -101,13 +101,13 @@ void main() {
 
     testWidgets('simultaneous writes', (WidgetTester _) async {
       final List<Future<bool>> writes = <Future<bool>>[];
-      final int writeCount = 100;
+      const int writeCount = 100;
       for (int i = 1; i <= writeCount; i++) {
         writes.add(preferences.setInt('int', i));
       }
-      List<bool> result = await Future.wait(writes, eagerError: true);
+      final List<bool> result = await Future.wait(writes, eagerError: true);
       // All writes should succeed.
-      expect(result.where((element) => !element), isEmpty);
+      expect(result.where((bool element) => !element), isEmpty);
       // The last write should win.
       expect(preferences.getInt('int'), writeCount);
     });

--- a/packages/shared_preferences/example/lib/main.dart
+++ b/packages/shared_preferences/example/lib/main.dart
@@ -16,7 +16,7 @@ void main() {
 class MyApp extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
-    return MaterialApp(
+    return const MaterialApp(
       title: 'SharedPreferences Demo',
       home: SharedPreferencesDemo(),
     );
@@ -24,14 +24,14 @@ class MyApp extends StatelessWidget {
 }
 
 class SharedPreferencesDemo extends StatefulWidget {
-  SharedPreferencesDemo({Key? key}) : super(key: key);
+  const SharedPreferencesDemo({Key? key}) : super(key: key);
 
   @override
   SharedPreferencesDemoState createState() => SharedPreferencesDemoState();
 }
 
 class SharedPreferencesDemoState extends State<SharedPreferencesDemo> {
-  Future<SharedPreferences> _prefs = SharedPreferences.getInstance();
+  final Future<SharedPreferences> _prefs = SharedPreferences.getInstance();
   late Future<int> _counter;
 
   Future<void> _incrementCounter() async {
@@ -39,7 +39,7 @@ class SharedPreferencesDemoState extends State<SharedPreferencesDemo> {
     final int counter = (prefs.getInt('counter') ?? 0) + 1;
 
     setState(() {
-      _counter = prefs.setInt("counter", counter).then((bool success) {
+      _counter = prefs.setInt('counter', counter).then((bool success) {
         return counter;
       });
     });
@@ -49,7 +49,7 @@ class SharedPreferencesDemoState extends State<SharedPreferencesDemo> {
   void initState() {
     super.initState();
     _counter = _prefs.then((SharedPreferences prefs) {
-      return (prefs.getInt('counter') ?? 0);
+      return prefs.getInt('counter') ?? 0;
     });
   }
 
@@ -57,7 +57,7 @@ class SharedPreferencesDemoState extends State<SharedPreferencesDemo> {
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(
-        title: const Text("SharedPreferences Demo"),
+        title: const Text('SharedPreferences Demo'),
       ),
       body: Center(
           child: FutureBuilder<int>(

--- a/packages/shared_preferences/lib/shared_preferences_tizen.dart
+++ b/packages/shared_preferences/lib/shared_preferences_tizen.dart
@@ -102,40 +102,36 @@ class SharedPreferencesPlugin extends SharedPreferencesStorePlatform {
 
   @override
   Future<bool> setValue(String valueType, String key, Object value) async {
-    _preferences[key] = value;
-
-    return using((Arena arena) {
-      int ret;
+    final int ret = using((Arena arena) {
       final Pointer<Utf8> pKey = key.toNativeUtf8(allocator: arena);
       switch (valueType) {
         case 'Bool':
-          ret = bindings.setBoolean(pKey, (value as bool) ? 1 : 0);
-          break;
+          return bindings.setBoolean(pKey, (value as bool) ? 1 : 0);
         case 'Double':
-          ret = bindings.setDouble(pKey, value as double);
-          break;
+          return bindings.setDouble(pKey, value as double);
         case 'Int':
-          ret = bindings.setInt(pKey, value as int);
-          break;
+          return bindings.setInt(pKey, value as int);
         case 'String':
-          ret = bindings.setString(
+          return bindings.setString(
             pKey,
             (value as String).toNativeUtf8(allocator: arena),
           );
-          break;
         case 'StringList':
-          ret = bindings.setString(
+          return bindings.setString(
             pKey,
             _joinStringList(value as List<String>)
                 .toNativeUtf8(allocator: arena),
           );
-          break;
         default:
           print('Not implemented : valueType[' + valueType + ']');
-          ret = -1;
+          return -1;
       }
-      return ret == 0;
     });
+    if (ret == 0) {
+      _preferences[key] = value;
+      return true;
+    }
+    return false;
   }
 
   String _joinStringList(List<String> list) {

--- a/packages/shared_preferences/lib/shared_preferences_tizen.dart
+++ b/packages/shared_preferences/lib/shared_preferences_tizen.dart
@@ -24,7 +24,6 @@ class SharedPreferencesPlugin extends SharedPreferencesStorePlatform {
 
   static int _preferenceItemCallback(Pointer<Utf8> pKey, Pointer<Void> data) {
     final String key = pKey.toDartString();
-    int ret;
 
     using((Arena arena) {
       final Pointer<Int8> pBool = arena();

--- a/packages/shared_preferences/lib/shared_preferences_tizen.dart
+++ b/packages/shared_preferences/lib/shared_preferences_tizen.dart
@@ -27,35 +27,27 @@ class SharedPreferencesPlugin extends SharedPreferencesStorePlatform {
     int ret;
 
     using((Arena arena) {
-      // Try as boolean type
       final Pointer<Int8> pBool = arena();
-      ret = bindings.getBoolean(pKey, pBool);
-      final bool boolValue = pBool.value == 1;
-      if (ret == 0) {
-        _cachedPreferences![key] = boolValue;
+      if (bindings.getBoolean(pKey, pBool) == 0) {
+        _cachedPreferences![key] = pBool.value == 1;
         return;
       }
 
       final Pointer<Double> pDouble = arena();
-      ret = bindings.getDouble(pKey, pDouble);
-      final double doubleValue = pDouble.value;
-      if (ret == 0) {
-        _cachedPreferences![key] = doubleValue;
+      if (bindings.getDouble(pKey, pDouble) == 0) {
+        _cachedPreferences![key] = pDouble.value;
         return;
       }
 
       final Pointer<Int32> pInt = arena();
-      ret = bindings.getInt(pKey, pInt);
-      final int intValue = pInt.value;
-      if (ret == 0) {
-        _cachedPreferences![key] = intValue;
+      if (bindings.getInt(pKey, pInt) == 0) {
+        _cachedPreferences![key] = pInt.value;
         return;
       }
 
       final Pointer<Pointer<Utf8>> ppString = arena();
-      ret = bindings.getString(pKey, ppString);
-      final Pointer<Utf8> pString = ppString.value;
-      if (ret == 0) {
+      if (bindings.getString(pKey, ppString) == 0) {
+        final Pointer<Utf8> pString = ppString.value;
         final String stringValue = pString.toDartString();
         if (stringValue == _separator) {
           _cachedPreferences![key] = <String>[];


### PR DESCRIPTION
Fix memory leaks
- Use Arena to release memory allocated in toNativeUtf8() method.
- Use Arena instead of `malloc()` to release allocated memory automatically. 
- Free `pString` after use it. 
- Fix some styles.