### PR TITLE
[package_info_plus] Sync example code with app-facing package 

### DIFF
--- a/packages/package_info_plus/example/lib/main.dart
+++ b/packages/package_info_plus/example/lib/main.dart
@@ -39,6 +39,7 @@ class _MyHomePageState extends State<MyHomePage> {
     packageName: 'Unknown',
     version: 'Unknown',
     buildNumber: 'Unknown',
+    buildSignature: 'Unknown',
   );
 
   @override

--- a/packages/package_info_plus/example/pubspec.yaml
+++ b/packages/package_info_plus/example/pubspec.yaml
@@ -5,7 +5,7 @@ publish_to: "none"
 dependencies:
   flutter:
     sdk: flutter
-  package_info_plus: ^1.0.1
+  package_info_plus: ^1.0.4
   package_info_plus_tizen:
     path: ../
 

--- a/packages/package_info_plus/pubspec.yaml
+++ b/packages/package_info_plus/pubspec.yaml
@@ -14,8 +14,8 @@ flutter:
 dependencies:
   flutter:
     sdk: flutter
-  package_info_plus: ^1.0.1
-  package_info_plus_platform_interface: ^1.0.0
+  package_info_plus: ^1.0.4
+  package_info_plus_platform_interface: ^1.0.2
 
 environment:
   sdk: ">=2.12.0 <3.0.0"


### PR DESCRIPTION
This PR partially syncs the example code of `package_info_plus_tizen` with that of `package_info_plus` package. This will be released together with the next notable change.

Context: https://github.com/flutter-tizen/plugins/pull/150#discussion_r679875611