### PR TITLE
Add integration test workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -65,11 +65,12 @@ jobs:
           tizen security-profiles add -n platform -a $HOME/tizen-studio-data/keystore/author/platform.p12 -p platform
       - name: Install flutter-tizen
         if: ${{ env.HAS_CHANGED_PACKAGES == 'true' }}
-        run: |
-          git clone https://github.com/flutter-tizen/flutter-tizen.git
+        uses: actions/checkout@v2
+        with:
+          repository: flutter-tizen/flutter-tizen
+          path: flutter-tizen
       - name: Build examples of changed packages
         if: ${{ env.HAS_CHANGED_PACKAGES == 'true' }}
         run: |
-          ROOT_DIR=`pwd`
-          export PATH=$PATH:`pwd`/flutter-tizen/bin
-          tools/run_command.py build --run-on-changed-packages --base-sha $(git rev-parse HEAD^)
+          export PATH=`pwd`/flutter-tizen/bin:$PATH
+          ./tools/run_command.py build --run-on-changed-packages --base-sha $(git rev-parse HEAD^)

--- a/.github/workflows/integration_test.yml
+++ b/.github/workflows/integration_test.yml
@@ -8,9 +8,9 @@ on:
 jobs:
   changed_packages:
     runs-on: [self-hosted, linux]
-    if: ${{ github.repository_owner == 'flutter-tizen' && github.event_name == 'pull_request' }}
+    if: ${{ github.repository_owner == 'flutter-tizen' }}
     steps:
-      - name: Check out repository
+      - name: Checkout repository
         uses: actions/checkout@v2
         with:
           fetch-depth: 2

--- a/.github/workflows/integration_test.yml
+++ b/.github/workflows/integration_test.yml
@@ -15,12 +15,14 @@ jobs:
         with:
           fetch-depth: 2
       - name: Install flutter-tizen
-        run: |
-          git clone --depth=1 https://github.com/flutter-tizen/flutter-tizen.git
+        uses: actions/checkout@v2
+        with:
+          repository: flutter-tizen/flutter-tizen
+          path: flutter-tizen
       - name: Run integration tests
         run: |
           export PATH=`pwd`/flutter-tizen/bin:$PATH
-          `pwd`/tools/run_command.py test \
+          ./tools/run_command.py test \
             --run-on-changed-packages \
             --base-sha=$(git rev-parse HEAD^) \
             --exclude wearable_rotary image_picker camera webview_flutter \

--- a/.github/workflows/integration_test.yml
+++ b/.github/workflows/integration_test.yml
@@ -25,7 +25,8 @@ jobs:
             --base-sha=$(git rev-parse HEAD^) \
             --exclude wearable_rotary image_picker camera webview_flutter \
               video_player permission_handler geolocator battery connectivity \
-              device_info package_info sensors share wifi_info google_maps_flutter
+              device_info package_info sensors share wifi_info \
+              google_maps_flutter tizen_app_control
         # The following packages are excluded from tests: 
         #   wearable_rotary, image_picker: no tests.
         #   camera: the current test target is wearable emulator 5.5, which doesn't support this package.
@@ -35,3 +36,4 @@ jobs:
         #   geolocator: test requires console manipulation.
         #   battery, connectivity, device_info, package_info, sensors, share, wifi_info: deprecated.
         #   google_maps_flutter: device limitation not yet specified.
+        #   tizen_app_control: test available after Flutter 2.5 migration.

--- a/.github/workflows/integration_test.yml
+++ b/.github/workflows/integration_test.yml
@@ -27,7 +27,7 @@ jobs:
             --base-sha=$(git rev-parse HEAD^) \
             --exclude wearable_rotary image_picker camera webview_flutter \
               video_player permission_handler geolocator battery connectivity \
-              device_info package_info sensors share wifi_info \
+              device_info package_info sensors share wifi_info_flutter \
               google_maps_flutter tizen_app_control
         # The following packages are excluded from tests: 
         #   wearable_rotary, image_picker: no tests.
@@ -36,6 +36,6 @@ jobs:
         #   video_player: test frequently breaks due to memory issue(https://github.com/flutter-tizen/plugins/issues/135).
         #   permission_handler: permission related test.
         #   geolocator: test requires console manipulation.
-        #   battery, connectivity, device_info, package_info, sensors, share, wifi_info: deprecated.
+        #   battery, connectivity, device_info, package_info, sensors, share, wifi_info_flutter: deprecated.
         #   google_maps_flutter: device limitation not yet specified.
         #   tizen_app_control: test available after Flutter 2.5 migration.

--- a/.github/workflows/integration_test.yml
+++ b/.github/workflows/integration_test.yml
@@ -1,11 +1,8 @@
-# TODO: Support running all integration tests for master branch when
-# it's possible to run self-hosted runners in parallel.
+# TODO: Support running all integration tests when it's possible to 
+# run self-hosted runners in parallel.
 name: Integration Test
 
-on: 
-#  push:
-#    branches:
-#      - "master"
+on:
   pull_request:
 
 jobs:
@@ -17,9 +14,18 @@ jobs:
         uses: actions/checkout@v2
         with:
           fetch-depth: 2
+      - name: Install flutter-tizen
+        run: |
+          git clone --depth=1 https://github.com/flutter-tizen/flutter-tizen.git
       - name: Run script
         run: |
-          `pwd`/tools/run_command.py test --run-on-changed-packages --base-sha=$(git rev-parse HEAD^) --exclude wearable_rotary image_picker camera webview_flutter video_player permission_handler geolocator battery connectivity device_info package_info sensors share wifi_info google_maps_flutter
+          export PATH=`pwd`/flutter-tizen/bin:$PATH
+          `pwd`/tools/run_command.py test \
+            --run-on-changed-packages \
+            --base-sha=$(git rev-parse HEAD^) \
+            --exclude wearable_rotary image_picker camera webview_flutter \
+              video_player permission_handler geolocator battery connectivity \
+              device_info package_info sensors share wifi_info google_maps_flutter
         # The following packages are excluded from tests: 
         #   wearable_rotary, image_picker: no tests.
         #   camera: the current test target is wearable emulator 5.5, which doesn't support this package.
@@ -29,14 +35,3 @@ jobs:
         #   geolocator: test requires console manipulation.
         #   battery, connectivity, device_info, package_info, sensors, share, wifi_info: deprecated.
         #   google_maps_flutter: device limitation not yet specified.
-        
-
-#  all:
-#    runs-on: [self-hosted, linux]
-#    if: ${{ github.repository_owner == 'flutter-tizen' && github.ref == 'refs/heads/master' }}
-#    steps:
-#      - name: Check out repository
-#        uses: actions/checkout@v2
-#      - name: Run script
-#        run: |
-#          `pwd`/tools/run_command.py test --exclude wearable_rotary camera webview_flutter image_picker video_player

--- a/.github/workflows/integration_test.yml
+++ b/.github/workflows/integration_test.yml
@@ -1,4 +1,4 @@
-# TODO: Support running all integration tests when it's possible to 
+# TODO: Support running all integration tests when it's possible to
 # run self-hosted runners in parallel.
 name: Integration Test
 
@@ -23,13 +23,14 @@ jobs:
         run: |
           export PATH=`pwd`/flutter-tizen/bin:$PATH
           ./tools/run_command.py test \
+            --platforms wearable-5.5 \
             --run-on-changed-packages \
             --base-sha=$(git rev-parse HEAD^) \
             --exclude wearable_rotary image_picker camera webview_flutter \
               video_player permission_handler geolocator battery connectivity \
               device_info package_info sensors share wifi_info_flutter \
               google_maps_flutter tizen_app_control
-        # The following packages are excluded from tests: 
+        # The following packages are excluded from tests:
         #   wearable_rotary, image_picker: no tests.
         #   camera: the current test target is wearable emulator 5.5, which doesn't support this package.
         #   webview_flutter: the current test target is wearable emulator 5.5, which doesn't support this package.

--- a/.github/workflows/integration_test.yml
+++ b/.github/workflows/integration_test.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Install flutter-tizen
         run: |
           git clone --depth=1 https://github.com/flutter-tizen/flutter-tizen.git
-      - name: Run script
+      - name: Run integration tests
         run: |
           export PATH=`pwd`/flutter-tizen/bin:$PATH
           `pwd`/tools/run_command.py test \

--- a/.github/workflows/integration_test.yml
+++ b/.github/workflows/integration_test.yml
@@ -1,0 +1,42 @@
+# TODO: Support running all integration tests for master branch when
+# it's possible to run self-hosted runners in parallel.
+name: Integration Test
+
+on: 
+#  push:
+#    branches:
+#      - "master"
+  pull_request:
+
+jobs:
+  changed_packages:
+    runs-on: [self-hosted, linux]
+    if: ${{ github.repository_owner == 'flutter-tizen' && github.event_name == 'pull_request' }}
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 2
+      - name: Run script
+        run: |
+          `pwd`/tools/run_command.py test --run-on-changed-packages --base-sha=$(git rev-parse HEAD^) --exclude wearable_rotary image_picker camera webview_flutter video_player permission_handler geolocator battery connectivity device_info package_info sensors share wifi_info google_maps_flutter
+        # The following packages are excluded from tests: 
+        #   wearable_rotary, image_picker: no tests.
+        #   camera: the current test target is wearable emulator 5.5, which doesn't support this package.
+        #   webview_flutter: the current test target is wearable emulator 5.5, which doesn't support this package.
+        #   video_player: test frequently breaks due to memory issue(https://github.com/flutter-tizen/plugins/issues/135).
+        #   permission_handler: permission related test.
+        #   geolocator: test requires console manipulation.
+        #   battery, connectivity, device_info, package_info, sensors, share, wifi_info: deprecated.
+        #   google_maps_flutter: device limitation not yet specified.
+        
+
+#  all:
+#    runs-on: [self-hosted, linux]
+#    if: ${{ github.repository_owner == 'flutter-tizen' && github.ref == 'refs/heads/master' }}
+#    steps:
+#      - name: Check out repository
+#        uses: actions/checkout@v2
+#      - name: Run script
+#        run: |
+#          `pwd`/tools/run_command.py test --exclude wearable_rotary camera webview_flutter image_picker video_player


### PR DESCRIPTION
Github workflows script that runs integration test on pull requests. This PR should be merged after setting up self-hosted runner.

Notes:
- Script doesn't run on forked repositories to silence no self-hosted runner error.
- Currently only a single self-hosted runner runs on the server machine, this may lag CI when multiple commits are submitted to the repo in a short time period. I have a few solutions in mind but need to verify some things first. Anyhow, it will be implemented in the next PR.
- Currently only supports testing on wearable-5.5 emulator.

Testing done on https://github.com/flutter-tizen/plugins/pull/228.
