### PR TITLE
Add analysis_options.yaml files

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -18,6 +18,18 @@ analyzer:
     # Stream and not importing dart:async
     # Please see https://github.com/flutter/flutter/pull/24528 for details.
     sdk_version_async_exported_from_core: ignore
+    ### Local flutter/plugins changes ###
+    # Allow null checks for as long as mixed mode is officially supported.
+    unnecessary_null_comparison: false
+    always_require_non_null_named_parameters: false # not needed with nnbd
+    # TODO(https://github.com/flutter/flutter/issues/74381):
+    # Clean up existing unnecessary imports, and remove line to ignore.
+    unnecessary_import: ignore
+  exclude:
+    # Ignore generated files
+    - '**/*.g.dart'
+    - 'lib/src/generated/*.dart'
+    - '**/*.mocks.dart' # Mockito @GenerateMocks
 
 linter:
   rules:
@@ -29,6 +41,7 @@ linter:
     # - always_put_required_named_parameters_first # we prefer having parameters in the same order as fields https://github.com/flutter/flutter/issues/10219
     - always_require_non_null_named_parameters
     - always_specify_types
+    # - always_use_package_imports # we do this commonly
     - annotate_overrides
     # - avoid_annotating_with_dynamic # conflicts with always_specify_types
     # - avoid_as # required for implicit-casts: true
@@ -39,6 +52,7 @@ linter:
     # - avoid_double_and_int_checks # only useful when targeting JS runtime
     - avoid_empty_else
     - avoid_equals_and_hash_code_on_mutable_classes
+    # - avoid_escaping_inner_quotes # not yet tested
     - avoid_field_initializers_in_const_classes
     - avoid_function_literals_in_foreach_calls
     # - avoid_implementing_value_types # not yet tested
@@ -57,9 +71,10 @@ linter:
     - avoid_returning_null_for_void
     # - avoid_returning_this # there are plenty of valid reasons to return this
     # - avoid_setters_without_getters # not yet tested
-    # - avoid_shadowing_type_parameters # not yet tested
+    - avoid_shadowing_type_parameters
     - avoid_single_cascade_in_expression_statements
     - avoid_slow_async_io
+    # - avoid_type_to_string # we do this commonly
     - avoid_types_as_parameter_names
     # - avoid_types_on_closure_parameters # conflicts with always_specify_types
     # - avoid_unnecessary_containers # not yet tested
@@ -71,53 +86,59 @@ linter:
     - camel_case_types
     - cancel_subscriptions
     # - cascade_invocations # not yet tested
+    - cast_nullable_to_non_nullable
     # - close_sinks # not reliable enough
     # - comment_references # blocked on https://github.com/flutter/flutter/issues/20765
     # - constant_identifier_names # needs an opt-out https://github.com/dart-lang/linter/issues/204
     - control_flow_in_finally
-    # - curly_braces_in_flow_control_structures # not yet tested
+    # - curly_braces_in_flow_control_structures # not required by flutter style
     # - diagnostic_describe_all_properties # not yet tested
     - directives_ordering
+    # - do_not_use_environment # we do this commonly
     - empty_catches
     - empty_constructor_bodies
     - empty_statements
+    - exhaustive_cases
     # - file_names # not yet tested
     - flutter_style_todos
     - hash_and_equals
     - implementation_imports
     # - invariant_booleans # too many false positives: https://github.com/dart-lang/linter/issues/811
     - iterable_contains_unrelated_type
-    # - join_return_with_assignment # not yet tested
+    # - join_return_with_assignment # not required by flutter style
+    - leading_newlines_in_multiline_strings
     - library_names
     - library_prefixes
-    # - lines_longer_than_80_chars # not yet tested
+    # - lines_longer_than_80_chars # not required by flutter style
     - list_remove_unrelated_type
     # - literal_only_boolean_expressions # too many false positives: https://github.com/dart-lang/sdk/issues/34181
     # - missing_whitespace_between_adjacent_strings # not yet tested
     - no_adjacent_strings_in_list
+    # - no_default_cases # too many false positives
     - no_duplicate_case_values
-    # - no_logic_in_create_state # not yet tested
-    # - no_runtimeType_toString # not yet tested
+    - no_logic_in_create_state
+    # - no_runtimeType_toString # ok in tests; we enable this only in packages/
     - non_constant_identifier_names
-    # - null_closures  # not yet tested
+    - null_check_on_nullable_type_parameter
+    # - null_closures # not required by flutter style
     # - omit_local_variable_types # opposite of always_specify_types
     # - one_member_abstracts # too many false positives
     # - only_throw_errors # https://github.com/flutter/flutter/issues/5792
     - overridden_fields
     - package_api_docs
-    - package_names
+    # - package_names # non conforming packages in sdk
     - package_prefixed_library_names
     # - parameter_assignments # we do this commonly
     - prefer_adjacent_string_concatenation
     - prefer_asserts_in_initializer_lists
-    # - prefer_asserts_with_message # not yet tested
+    # - prefer_asserts_with_message # not required by flutter style
     - prefer_collection_literals
     - prefer_conditional_assignment
     - prefer_const_constructors
     - prefer_const_constructors_in_immutables
     - prefer_const_declarations
     - prefer_const_literals_to_create_immutables
-    # - prefer_constructors_over_static_methods # not yet tested
+    # - prefer_constructors_over_static_methods # far too many false positives
     - prefer_contains
     # - prefer_double_quotes # opposite of prefer_single_quotes
     - prefer_equal_for_default_values
@@ -149,13 +170,14 @@ linter:
     # - provide_deprecation_message # not yet tested
     # - public_member_api_docs # enabled on a case-by-case basis; see e.g. packages/analysis_options.yaml
     - recursive_getters
+    # - sized_box_for_whitespace # not yet tested
     - slash_for_doc_comments
     # - sort_child_properties_last # not yet tested
     - sort_constructors_first
-    - sort_pub_dependencies
     - sort_unnamed_constructors_first
     - test_types_in_equals
     - throw_in_finally
+    - tighten_type_of_initializing_formals
     # - type_annotate_public_apis # subset of always_specify_types
     - type_init_formals
     # - unawaited_futures # too many false positives
@@ -167,21 +189,35 @@ linter:
     # - unnecessary_lambdas # has false positives: https://github.com/dart-lang/linter/issues/498
     - unnecessary_new
     - unnecessary_null_aware_assignments
+    # - unnecessary_null_checks # not yet tested
     - unnecessary_null_in_if_null_operators
+    - unnecessary_nullable_for_final_variable_declarations
     - unnecessary_overrides
     - unnecessary_parenthesis
+    # - unnecessary_raw_strings # not yet tested
     - unnecessary_statements
+    - unnecessary_string_escapes
     - unnecessary_string_interpolations
     - unnecessary_this
     - unrelated_type_equality_checks
     # - unsafe_html # not yet tested
     - use_full_hex_values_for_flutter_colors
     # - use_function_type_syntax_for_parameters # not yet tested
+    - use_is_even_rather_than_modulo
     # - use_key_in_widget_constructors # not yet tested
     - use_late_for_private_fields_and_variables
+    - use_raw_strings
     - use_rethrow_when_possible
     # - use_setters_to_change_properties # not yet tested
     # - use_string_buffers # has false positives: https://github.com/dart-lang/sdk/issues/34182
     # - use_to_and_as_if_applicable # has false positives, so we prefer to catch this by code-review
     - valid_regexps
     - void_checks
+    ### Local flutter/plugins changes ###
+    # These are from flutter/flutter/packages, so will need to be preserved
+    # separately when moving to a shared file.
+    - no_runtimeType_toString # use objectRuntimeType from package:foundation
+    - public_member_api_docs # see https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#documentation-dartdocs-javadocs-etc
+    # Flutter has a specific use case for dependencies that are intentionally
+    # not sorted, which doesn't apply to this repo.
+    - sort_pub_dependencies

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -1,4 +1,4 @@
-# This file was copied from flutter/analysis_options.yaml.
+# This file was copied from flutter/plugins/analysis_options.yaml.
 
 analyzer:
   strong-mode:

--- a/analysis_options_legacy.yaml
+++ b/analysis_options_legacy.yaml
@@ -1,4 +1,4 @@
-# This file was copied from plugins/analysis_options_legacy.yaml
+# This file was copied from flutter/plugins/analysis_options_legacy.yaml
 
 include: package:pedantic/analysis_options.1.8.0.yaml
 analyzer:

--- a/analysis_options_legacy.yaml
+++ b/analysis_options_legacy.yaml
@@ -1,0 +1,15 @@
+# This file was copied from plugins/analysis_options_legacy.yaml
+
+include: package:pedantic/analysis_options.1.8.0.yaml
+analyzer:
+  exclude:
+    # Ignore generated files
+    - '**/*.g.dart'
+    - 'lib/src/generated/*.dart'
+    - '**/*.mocks.dart' # Mockito @GenerateMocks
+  errors:
+    always_require_non_null_named_parameters: false # not needed with nnbd
+    unnecessary_null_comparison: false # Turned as long as nnbd mix-mode is supported.
+linter:
+  rules:
+    - public_member_api_docs

--- a/analysis_options_plus.yaml
+++ b/analysis_options_plus.yaml
@@ -1,0 +1,17 @@
+# This file was copied from plus_plugins/analysis_options.yaml.
+
+include: package:pedantic/analysis_options.yaml
+
+analyzer:
+  enable-experiment:
+    - non-nullable
+  exclude:
+    # Ignore generated files
+    - '**/*.g.dart'
+    - 'lib/src/generated/*.dart'
+
+linter:
+  rules:
+    public_member_api_docs: true
+    prefer_final_in_for_each: true
+    prefer_final_locals: true

--- a/packages/audioplayers/analysis_options.yaml
+++ b/packages/audioplayers/analysis_options.yaml
@@ -1,0 +1,13 @@
+# This file was copied from audioplayers/analysis_options.yaml(tag:0.18.3).
+
+# Source of linter options:
+# http://dart-lang.github.io/linter/lints/options/options.html
+
+linter:
+  rules:
+    - camel_case_types
+    - hash_and_equals
+    - iterable_contains_unrelated_type
+    - list_remove_unrelated_type
+    - unrelated_type_equality_checks
+    - valid_regexps

--- a/packages/battery/analysis_options.yaml
+++ b/packages/battery/analysis_options.yaml
@@ -1,0 +1,1 @@
+include: ../../analysis_options_legacy.yaml

--- a/packages/battery/example/pubspec.yaml
+++ b/packages/battery/example/pubspec.yaml
@@ -18,6 +18,7 @@ dev_dependencies:
     sdk: flutter
   integration_test_tizen:
     path: ../../integration_test/
+  pedantic: ^1.10.0
 
 flutter:
   uses-material-design: true

--- a/packages/battery/pubspec.yaml
+++ b/packages/battery/pubspec.yaml
@@ -16,6 +16,9 @@ dependencies:
   flutter:
     sdk: flutter
 
+dev_dependencies:
+  pedantic: ^1.10.0
+
 environment:
   sdk: ">=2.12.0 <3.0.0"
   flutter: ">=2.0.0"

--- a/packages/battery_plus/analysis_options.yaml
+++ b/packages/battery_plus/analysis_options.yaml
@@ -1,0 +1,1 @@
+include: ../../analysis_options_plus.yaml

--- a/packages/battery_plus/example/pubspec.yaml
+++ b/packages/battery_plus/example/pubspec.yaml
@@ -18,6 +18,7 @@ dev_dependencies:
     sdk: flutter
   integration_test_tizen:
     path: ../../integration_test/
+  pedantic: ^1.9.2
 
 dependency_overrides:
   args: ^2.0.0

--- a/packages/battery_plus/pubspec.yaml
+++ b/packages/battery_plus/pubspec.yaml
@@ -16,6 +16,9 @@ dependencies:
   flutter:
     sdk: flutter
 
+dev_dependencies:
+  pedantic: ^1.9.2
+
 environment:
   sdk: ">=2.12.0 <3.0.0"
   flutter: ">=2.0.0"

--- a/packages/camera/analysis_options.yaml
+++ b/packages/camera/analysis_options.yaml
@@ -1,0 +1,1 @@
+include: ../../analysis_options_legacy.yaml

--- a/packages/camera/pubspec.yaml
+++ b/packages/camera/pubspec.yaml
@@ -10,6 +10,7 @@ dependencies:
 dev_dependencies:
   flutter_test:
     sdk: flutter
+  pedantic: ^1.10.0
 
 flutter:
   plugin:

--- a/packages/connectivity/analysis_options.yaml
+++ b/packages/connectivity/analysis_options.yaml
@@ -1,0 +1,1 @@
+include: ../../analysis_options_legacy.yaml

--- a/packages/connectivity/example/pubspec.yaml
+++ b/packages/connectivity/example/pubspec.yaml
@@ -18,6 +18,7 @@ dev_dependencies:
     sdk: flutter
   integration_test_tizen:
     path: ../../integration_test/
+  pedantic: ^1.10.0
 
 flutter:
   uses-material-design: true

--- a/packages/connectivity/pubspec.yaml
+++ b/packages/connectivity/pubspec.yaml
@@ -15,6 +15,9 @@ dependencies:
   flutter:
     sdk: flutter
 
+dev_dependencies:
+  pedantic: ^1.10.0
+
 environment:
   sdk: ">=2.12.0 <3.0.0"
   flutter: ">=2.0.0"

--- a/packages/connectivity_plus/analysis_options.yaml
+++ b/packages/connectivity_plus/analysis_options.yaml
@@ -1,0 +1,1 @@
+include: ../../analysis_options_plus.yaml

--- a/packages/connectivity_plus/example/pubspec.yaml
+++ b/packages/connectivity_plus/example/pubspec.yaml
@@ -18,6 +18,7 @@ dev_dependencies:
     sdk: flutter
   integration_test_tizen:
     path: ../../integration_test/
+  pedantic: ^1.9.2
 
 flutter:
   uses-material-design: true

--- a/packages/connectivity_plus/pubspec.yaml
+++ b/packages/connectivity_plus/pubspec.yaml
@@ -16,6 +16,9 @@ dependencies:
   flutter:
     sdk: flutter
 
+dev_dependencies:
+  pedantic: ^1.9.2
+
 environment:
   sdk: ">=2.12.0 <3.0.0"
   flutter: ">=2.0.0"

--- a/packages/device_info/analysis_options.yaml
+++ b/packages/device_info/analysis_options.yaml
@@ -1,0 +1,1 @@
+include: ../../analysis_options_legacy.yaml

--- a/packages/device_info/example/pubspec.yaml
+++ b/packages/device_info/example/pubspec.yaml
@@ -17,6 +17,7 @@ dev_dependencies:
     sdk: flutter
   integration_test_tizen:
     path: ../../integration_test/
+  pedantic: ^1.10.0
 
 flutter:
   uses-material-design: true

--- a/packages/device_info/pubspec.yaml
+++ b/packages/device_info/pubspec.yaml
@@ -16,6 +16,9 @@ dependencies:
   flutter:
     sdk: flutter
 
+dev_dependencies:
+  pedantic: ^1.10.0
+
 environment:
   sdk: '>=2.12.0 <3.0.0'
   flutter: ">=2.0.0"

--- a/packages/device_info_plus/analysis_options.yaml
+++ b/packages/device_info_plus/analysis_options.yaml
@@ -1,0 +1,1 @@
+include: ../../analysis_options_plus.yaml

--- a/packages/device_info_plus/example/pubspec.yaml
+++ b/packages/device_info_plus/example/pubspec.yaml
@@ -17,6 +17,7 @@ dev_dependencies:
     sdk: flutter
   integration_test_tizen:
     path: ../../integration_test/
+  pedantic: ^1.9.2
 
 flutter:
   uses-material-design: true

--- a/packages/device_info_plus/pubspec.yaml
+++ b/packages/device_info_plus/pubspec.yaml
@@ -16,6 +16,9 @@ dependencies:
   flutter:
     sdk: flutter
 
+dev_dependencies:
+  pedantic: ^1.9.2
+
 environment:
   sdk: '>=2.12.0 <3.0.0'
   flutter: ">=2.0.0"

--- a/packages/flutter_tts/analysis_options.yaml
+++ b/packages/flutter_tts/analysis_options.yaml
@@ -1,0 +1,37 @@
+# This file was copied from flutter_tts/analysis_options.yaml.
+
+analyzer:
+  strong-mode:
+    implicit-casts: false
+  errors:
+    unused_import: error
+    unused_local_variable: error
+    dead_code: error
+linter:
+  rules:
+     - avoid_empty_else
+     - comment_references
+     - control_flow_in_finally
+     - empty_statements
+     - hash_and_equals
+     - only_throw_errors
+     - test_types_in_equals
+     - throw_in_finally
+     - unrelated_type_equality_checks
+     - valid_regexps
+     - avoid_init_to_null
+     - avoid_return_types_on_setters
+     - await_only_futures
+     - camel_case_types
+     - directives_ordering
+     - empty_catches
+     - empty_constructor_bodies
+     - library_names
+     - library_prefixes
+     - non_constant_identifier_names
+     - omit_local_variable_types
+     - prefer_final_fields
+     - prefer_is_not_empty
+     - prefer_typing_uninitialized_variables
+     - slash_for_doc_comments
+     - type_init_formals

--- a/packages/image_picker/analysis_options.yaml
+++ b/packages/image_picker/analysis_options.yaml
@@ -1,0 +1,1 @@
+include: ../../analysis_options_legacy.yaml

--- a/packages/image_picker/example/pubspec.yaml
+++ b/packages/image_picker/example/pubspec.yaml
@@ -19,6 +19,7 @@ dev_dependencies:
     sdk: flutter
   integration_test_tizen:
     path: ../../integration_test/
+  pedantic: ^1.10.0
 
 flutter:
   uses-material-design: true

--- a/packages/image_picker/pubspec.yaml
+++ b/packages/image_picker/pubspec.yaml
@@ -16,6 +16,9 @@ dependencies:
     sdk: flutter
   image_picker_platform_interface: ^2.0.1
 
+dev_dependencies:
+  pedantic: ^1.10.0
+
 environment:
   sdk: ">=2.12.0 <3.0.0"
   flutter: ">=2.0.0"

--- a/packages/network_info_plus/analysis_options.yaml
+++ b/packages/network_info_plus/analysis_options.yaml
@@ -1,0 +1,1 @@
+include: ../../analysis_options_plus.yaml

--- a/packages/network_info_plus/example/pubspec.yaml
+++ b/packages/network_info_plus/example/pubspec.yaml
@@ -16,6 +16,7 @@ dev_dependencies:
     sdk: flutter
   integration_test_tizen:
     path: ../../integration_test/
+  pedantic: ^1.9.2
 
 dependency_overrides:
   args: ^2.0.0

--- a/packages/network_info_plus/pubspec.yaml
+++ b/packages/network_info_plus/pubspec.yaml
@@ -16,6 +16,9 @@ dependencies:
     sdk: flutter
   network_info_plus_platform_interface: ^1.0.0
 
+dev_dependencies:
+  pedantic: ^1.9.2
+
 environment:
   sdk: ">=2.12.0 <3.0.0"
   flutter: ">=2.0.0"

--- a/packages/package_info/analysis_options.yaml
+++ b/packages/package_info/analysis_options.yaml
@@ -1,0 +1,1 @@
+include: ../../analysis_options_legacy.yaml

--- a/packages/package_info/example/pubspec.yaml
+++ b/packages/package_info/example/pubspec.yaml
@@ -18,6 +18,7 @@ dev_dependencies:
     sdk: flutter
   integration_test_tizen:
     path: ../../integration_test/
+  pedantic: ^1.10.0
 
 flutter:
   uses-material-design: true

--- a/packages/package_info/pubspec.yaml
+++ b/packages/package_info/pubspec.yaml
@@ -15,6 +15,9 @@ dependencies:
   flutter:
     sdk: flutter
 
+dev_dependencies:
+  pedantic: ^1.10.0
+
 environment:
   sdk: ">=2.12.0 <3.0.0"
   flutter: ">=2.0.0"

--- a/packages/package_info_plus/analysis_options.yaml
+++ b/packages/package_info_plus/analysis_options.yaml
@@ -1,0 +1,1 @@
+include: ../../analysis_options_plus.yaml

--- a/packages/package_info_plus/example/pubspec.yaml
+++ b/packages/package_info_plus/example/pubspec.yaml
@@ -18,6 +18,7 @@ dev_dependencies:
     sdk: flutter
   integration_test_tizen:
     path: ../../integration_test/
+  pedantic: ^1.9.2
 
 flutter:
   uses-material-design: true

--- a/packages/package_info_plus/pubspec.yaml
+++ b/packages/package_info_plus/pubspec.yaml
@@ -17,6 +17,9 @@ dependencies:
   package_info_plus: ^1.0.4
   package_info_plus_platform_interface: ^1.0.2
 
+dev_dependencies:
+  pedantic: ^1.9.2
+
 environment:
   sdk: ">=2.12.0 <3.0.0"
   flutter: ">=2.0.0"

--- a/packages/permission_handler/analysis_options.yaml
+++ b/packages/permission_handler/analysis_options.yaml
@@ -1,0 +1,7 @@
+# This file was copied from Baseflow/flutter-permission-handler/analysis_options.yaml.
+
+include: package:effective_dart/analysis_options.1.2.0.yaml
+
+linter:
+  rules:
+    - public_member_api_docs

--- a/packages/permission_handler/example/pubspec.yaml
+++ b/packages/permission_handler/example/pubspec.yaml
@@ -19,6 +19,7 @@ dev_dependencies:
     sdk: flutter
   integration_test_tizen:
     path: ../../integration_test/
+  effective_dart: ^1.3.0
 
 flutter:
   uses-material-design: true

--- a/packages/permission_handler/pubspec.yaml
+++ b/packages/permission_handler/pubspec.yaml
@@ -15,6 +15,9 @@ dependencies:
     sdk: flutter
   permission_handler_platform_interface: ^3.1.1
 
+dev_dependencies:
+  effective_dart: ^1.3.0
+
 environment:
   sdk: ">=2.12.0 <3.0.0"
   flutter: ">=2.0.0"

--- a/packages/sensors/analysis_options.yaml
+++ b/packages/sensors/analysis_options.yaml
@@ -1,0 +1,1 @@
+include: ../../analysis_options_legacy.yaml

--- a/packages/sensors/example/pubspec.yaml
+++ b/packages/sensors/example/pubspec.yaml
@@ -18,6 +18,7 @@ dev_dependencies:
     sdk: flutter
   integration_test_tizen:
     path: ../../integration_test/
+  pedantic: ^1.10.0
 
 flutter:
   uses-material-design: true

--- a/packages/sensors/pubspec.yaml
+++ b/packages/sensors/pubspec.yaml
@@ -14,6 +14,9 @@ dependencies:
   flutter:
     sdk: flutter
 
+dev_dependencies:
+  pedantic: ^1.10.0
+
 environment:
   sdk: ">=2.12.0 <3.0.0"
   flutter: ">=2.0.0"

--- a/packages/sensors_plus/analysis_options.yaml
+++ b/packages/sensors_plus/analysis_options.yaml
@@ -1,0 +1,1 @@
+include: ../../analysis_options_plus.yaml

--- a/packages/sensors_plus/example/pubspec.yaml
+++ b/packages/sensors_plus/example/pubspec.yaml
@@ -16,6 +16,7 @@ dev_dependencies:
     sdk: flutter
   integration_test_tizen:
     path: ../../integration_test/
+  pedantic: ^1.9.2
 
 flutter:
   uses-material-design: true

--- a/packages/sensors_plus/pubspec.yaml
+++ b/packages/sensors_plus/pubspec.yaml
@@ -14,6 +14,9 @@ dependencies:
   flutter:
     sdk: flutter
 
+dev_dependencies:
+  pedantic: ^1.9.2
+
 environment:
   sdk: ">=2.12.0 <3.0.0"
   flutter: ">=2.0.0"

--- a/packages/share/analysis_options.yaml
+++ b/packages/share/analysis_options.yaml
@@ -1,0 +1,1 @@
+include: ../../analysis_options_legacy.yaml

--- a/packages/share/example/pubspec.yaml
+++ b/packages/share/example/pubspec.yaml
@@ -21,6 +21,7 @@ dev_dependencies:
     sdk: flutter
   integration_test_tizen:
     path: ../../integration_test/
+  pedantic: ^1.10.0
 
 flutter:
   uses-material-design: true

--- a/packages/share/pubspec.yaml
+++ b/packages/share/pubspec.yaml
@@ -14,6 +14,9 @@ dependencies:
   flutter:
     sdk: flutter
 
+dev_dependencies:
+  pedantic: ^1.10.0
+
 environment:
   sdk: ">=2.12.0 <3.0.0"
   flutter: ">=2.0.0"

--- a/packages/share_plus/analysis_options.yaml
+++ b/packages/share_plus/analysis_options.yaml
@@ -1,0 +1,1 @@
+include: ../../analysis_options_plus.yaml

--- a/packages/share_plus/example/pubspec.yaml
+++ b/packages/share_plus/example/pubspec.yaml
@@ -21,6 +21,7 @@ dev_dependencies:
     sdk: flutter
   integration_test_tizen:
     path: ../../integration_test/
+  pedantic: ^1.9.2
 
 flutter:
   uses-material-design: true

--- a/packages/share_plus/pubspec.yaml
+++ b/packages/share_plus/pubspec.yaml
@@ -17,6 +17,9 @@ dependencies:
   share_plus: ^2.1.2
   share_plus_platform_interface: ^2.0.0
 
+dev_dependencies:
+  pedantic: ^1.9.2
+
 environment:
   sdk: ">=2.12.0 <3.0.0"
   flutter: ">=2.0.0"

--- a/packages/shared_preferences/analysis_options.yaml
+++ b/packages/shared_preferences/analysis_options.yaml
@@ -1,0 +1,1 @@
+include: ../../analysis_options_legacy.yaml

--- a/packages/shared_preferences/example/pubspec.yaml
+++ b/packages/shared_preferences/example/pubspec.yaml
@@ -18,6 +18,7 @@ dev_dependencies:
     sdk: flutter
   integration_test_tizen:
     path: ../../integration_test/
+  pedantic: ^1.10.0
 
 flutter:
   uses-material-design: true

--- a/packages/shared_preferences/pubspec.yaml
+++ b/packages/shared_preferences/pubspec.yaml
@@ -16,6 +16,9 @@ dependencies:
     sdk: flutter
   shared_preferences_platform_interface: ^2.0.0
 
+dev_dependencies:
+  pedantic: ^1.10.0
+
 environment:
   sdk: '>=2.12.0 <3.0.0'
   flutter: ">=2.0.0"

--- a/packages/url_launcher/analysis_options.yaml
+++ b/packages/url_launcher/analysis_options.yaml
@@ -1,0 +1,1 @@
+include: ../../analysis_options_legacy.yaml

--- a/packages/url_launcher/example/pubspec.yaml
+++ b/packages/url_launcher/example/pubspec.yaml
@@ -18,6 +18,7 @@ dev_dependencies:
     sdk: flutter
   integration_test_tizen:
     path: ../../integration_test/
+  pedantic: ^1.10.0
 
 flutter:
   uses-material-design: true

--- a/packages/url_launcher/pubspec.yaml
+++ b/packages/url_launcher/pubspec.yaml
@@ -16,6 +16,9 @@ dependencies:
     sdk: flutter
   url_launcher_platform_interface: ^2.0.4
 
+dev_dependencies:
+  pedantic: ^1.10.0
+
 environment:
   sdk: '>=2.13.0 <3.0.0'
   flutter: ">=2.2.0"

--- a/packages/video_player/analysis_options.yaml
+++ b/packages/video_player/analysis_options.yaml
@@ -1,0 +1,1 @@
+include: ../../analysis_options_legacy.yaml

--- a/packages/video_player/pubspec.yaml
+++ b/packages/video_player/pubspec.yaml
@@ -16,6 +16,9 @@ dependencies:
   flutter:
     sdk: flutter
 
+dev_dependencies:
+  pedantic: ^1.10.0
+
 environment:
   sdk: ">=2.12.0<3.0.0"
   flutter: ">=2.0.0"

--- a/packages/wakelock/analysis_options.yaml
+++ b/packages/wakelock/analysis_options.yaml
@@ -1,0 +1,9 @@
+# This file was copied from wakelock/analysis_options.yaml.
+
+include: package:pedantic/analysis_options.yaml
+
+linter:
+  rules:
+    public_member_api_docs: true
+    # Ignoring unsafe_html as we need to import a JS script in wakelock_web and because of https://github.com/dart-lang/sdk/issues/45230.
+    unsafe_html: false

--- a/packages/wakelock/example/pubspec.yaml
+++ b/packages/wakelock/example/pubspec.yaml
@@ -22,3 +22,4 @@ dev_dependencies:
     sdk: flutter
   integration_test_tizen:
     path: ../../integration_test/
+  pedantic: ^1.11.0

--- a/packages/wakelock/pubspec.yaml
+++ b/packages/wakelock/pubspec.yaml
@@ -15,6 +15,9 @@ dependencies:
     sdk: flutter
   wakelock_platform_interface: ^0.2.0
 
+dev_dependencies:
+  pedantic: ^1.11.0
+
 environment:
   sdk: ">=2.12.0 <3.0.0"
   flutter: ">=2.0.0"

--- a/packages/webview_flutter/analysis_options.yaml
+++ b/packages/webview_flutter/analysis_options.yaml
@@ -1,0 +1,1 @@
+include: ../../analysis_options_legacy.yaml

--- a/packages/webview_flutter/example/pubspec.yaml
+++ b/packages/webview_flutter/example/pubspec.yaml
@@ -18,6 +18,7 @@ dev_dependencies:
   integration_test: ^1.0.1
   integration_test_tizen:
     path: ../../integration_test/
+  pedantic: ^1.10.0
 
 flutter:
   uses-material-design: true

--- a/packages/webview_flutter/pubspec.yaml
+++ b/packages/webview_flutter/pubspec.yaml
@@ -15,6 +15,7 @@ dependencies:
 dev_dependencies:
   flutter_test:
     sdk: flutter
+  pedantic: ^1.10.0
 
 flutter:
   plugin:

--- a/packages/wifi_info_flutter/analysis_options.yaml
+++ b/packages/wifi_info_flutter/analysis_options.yaml
@@ -1,0 +1,1 @@
+include: ../../analysis_options_legacy.yaml

--- a/packages/wifi_info_flutter/example/pubspec.yaml
+++ b/packages/wifi_info_flutter/example/pubspec.yaml
@@ -19,6 +19,7 @@ dev_dependencies:
     sdk: flutter
   integration_test_tizen:
     path: ../../integration_test/
+  pedantic: ^1.10.0
 
 flutter:
   uses-material-design: true

--- a/packages/wifi_info_flutter/pubspec.yaml
+++ b/packages/wifi_info_flutter/pubspec.yaml
@@ -15,6 +15,9 @@ dependencies:
     sdk: flutter
   wifi_info_flutter_platform_interface: ^2.0.1
 
+dev_dependencies:
+  pedantic: ^1.10.0
+
 environment:
   sdk: ">=2.12.0 <3.0.0"
   flutter: ">=2.0.0"


### PR DESCRIPTION
* Fix #161
* Add analysis_options_legacy.yaml for legacy plugins
* Sync analysis_options.yaml with flutter/plugins/analysis_options.yaml
* Add analysis_options_plus.yaml
* Add 3rd-party's analysis_options_plus.yaml
* Add some package which used in each analysis_options.yaml to dev_dependencies

Signed-off-by: Boram Bae <boram21.bae@samsung.com>