### PR TITLE
Refactor tools to use subparsers

### DIFF
--- a/tools/commands/build_example.py
+++ b/tools/commands/build_example.py
@@ -1,8 +1,6 @@
-#!/usr/bin/env python3
-
 import subprocess
-import sys
 import os
+
 import commands.command_utils as command_utils
 
 
@@ -41,7 +39,3 @@ def run_build_examples(args):
         exit(0)
     else:
         exit(1)
-
-
-if __name__ == '__main__':
-    run_build_examples(sys.argv)

--- a/tools/commands/build_example.py
+++ b/tools/commands/build_example.py
@@ -5,10 +5,13 @@ import commands.command_utils as command_utils
 
 
 def set_subparser(subparsers):
-    parser = subparsers.add_parser(
-        'build', help='Build examples of plugin')
-    command_utils.set_parser_arguments(parser, 
-        plugins=True, exclude=True, run_on_changed_packages=True, base_sha=True, command='build')
+    parser = subparsers.add_parser('build', help='Build examples of plugin')
+    command_utils.set_parser_arguments(parser,
+                                       plugins=True,
+                                       exclude=True,
+                                       run_on_changed_packages=True,
+                                       base_sha=True,
+                                       command='build')
 
 
 def _build_examples(plugin):
@@ -16,9 +19,10 @@ def _build_examples(plugin):
     example_dir = os.path.join(plugin, 'example')
     subprocess.run('flutter-tizen pub get', shell=True, cwd=example_dir)
 
-    completed_process = subprocess.run('flutter-tizen build tpk --device-profile wearable -v',
-                                       shell=True,
-                                       cwd=example_dir)
+    completed_process = subprocess.run(
+        'flutter-tizen build tpk --device-profile wearable -v',
+        shell=True,
+        cwd=example_dir)
     if completed_process.returncode == 0:
         return True
     else:
@@ -28,7 +32,10 @@ def _build_examples(plugin):
 def run_build_examples(args):
     packages_dir = command_utils.get_package_dir()
     target_plugins, _ = command_utils.get_target_plugins(
-        packages_dir, plugins=args.plugins, exclude=args.exclude, run_on_changed_packages=args.run_on_changed_packages,
+        packages_dir,
+        plugins=args.plugins,
+        exclude=args.exclude,
+        run_on_changed_packages=args.run_on_changed_packages,
         base_sha=args.base_sha)
     results = []
     for plugin in target_plugins:

--- a/tools/commands/build_example.py
+++ b/tools/commands/build_example.py
@@ -6,10 +6,11 @@ import os
 import commands.command_utils as command_utils
 
 
-def parse_args(args):
-    parser = command_utils.get_options_parser(
+def set_subparser(subparsers):
+    parser = subparsers.add_parser(
+        'build', help='Build examples of plugin')
+    command_utils.set_parser_arguments(parser, 
         plugins=True, exclude=True, run_on_changed_packages=True, base_sha=True, command='build')
-    return parser.parse_args(args)
 
 
 def _build_examples(plugin):
@@ -26,8 +27,7 @@ def _build_examples(plugin):
         return False
 
 
-def run_build_examples(argv):
-    args = parse_args(argv)
+def run_build_examples(args):
     packages_dir = command_utils.get_package_dir()
     target_plugins, _ = command_utils.get_target_plugins(
         packages_dir, plugins=args.plugins, exclude=args.exclude, run_on_changed_packages=args.run_on_changed_packages,

--- a/tools/commands/check_tidy.py
+++ b/tools/commands/check_tidy.py
@@ -55,14 +55,20 @@ def _run_check_tidy(src_dir, update, clang_format, stats):
         if any(d in relpath(dirpath, src_dir) for d in skip_dirs):
             continue
 
-        for file in [join(dirpath, name) for name in filenames if is_checked_by_clang(name)]:
+        for file in [
+                join(dirpath, name) for name in filenames
+                if is_checked_by_clang(name)
+        ]:
+
             def report_error(msg, line=None):
-                print('%s%s:%s %s%s' % (TERM_YELLOW, file, '%d:' % line if line else '', msg, TERM_EMPTY))
+                print('%s%s:%s %s%s' % (TERM_YELLOW, file, '%d:' %
+                                        line if line else '', msg, TERM_EMPTY))
                 stats.errors += 1
 
             with open(file, 'r') as f:
                 original = f.readlines()
-            formatted = subprocess.check_output([clang_format, '-style=file', file]).decode('utf-8')
+            formatted = subprocess.check_output(
+                [clang_format, '-style=file', file]).decode('utf-8')
 
             if update:
                 with open(file, 'w') as f:
@@ -81,7 +87,8 @@ def _run_check_tidy(src_dir, update, clang_format, stats):
                 if line.endswith(' \n') or line.endswith('\t\n'):
                     report_error('trailing whitespace', lineno)
                 if not line.endswith('\n'):
-                    report_error('line ends without NEW LINE character', lineno)
+                    report_error('line ends without NEW LINE character',
+                                 lineno)
 
                 if not line.strip():
                     stats.empty_lines += 1
@@ -95,13 +102,19 @@ def _run_check_tidy(src_dir, update, clang_format, stats):
 
 def set_subparser(subparsers):
     parser = subparsers.add_parser(
-        'tidy', help='Check and update format for C++ files',
-        usage='run_command.py tidy [-h] [--clang-format PATH] [--update] [--dir PATH]')
-    parser.add_argument('--clang-format', metavar='PATH', default='clang-format-11',
+        'tidy',
+        help='Check and update format for C++ files',
+        usage=
+        'run_command.py tidy [-h] [--clang-format PATH] [--update] [--dir PATH]'
+    )
+    parser.add_argument('--clang-format',
+                        metavar='PATH',
+                        default='clang-format-11',
                         help='path to clang-format (default: %(default)s)')
-    parser.add_argument('--update', action='store_true',
-                        help='reformat files')
-    parser.add_argument('--dir', metavar='PATH', default=DEFAULT_DIR,
+    parser.add_argument('--update', action='store_true', help='reformat files')
+    parser.add_argument('--dir',
+                        metavar='PATH',
+                        default=DEFAULT_DIR,
                         help='directory to process (default: %(default)s)')
 
 
@@ -113,10 +126,10 @@ def run_check_tidy(args):
     print()
     print('* Total number of files: %d' % stats.files)
     print('* Total lines of code: %d' % stats.lines)
-    print('* Total non-empty lines of code: %d' % (stats.lines - stats.empty_lines))
-    print('%s* Total number of errors: %d%s' % (TERM_RED if stats.errors else TERM_GREEN,
-                                                stats.errors,
-                                                TERM_EMPTY))
+    print('* Total non-empty lines of code: %d' %
+          (stats.lines - stats.empty_lines))
+    print('%s* Total number of errors: %d%s' %
+          (TERM_RED if stats.errors else TERM_GREEN, stats.errors, TERM_EMPTY))
 
     if args.update:
         print()

--- a/tools/commands/check_tidy.py
+++ b/tools/commands/check_tidy.py
@@ -96,17 +96,19 @@ def _run_check_tidy(src_dir, update, clang_format, stats):
                     print(diffline, end='')
 
 
-def run_check_tidy(argv):
-    parser = ArgumentParser(description='Plugins Source Format Checker and Updater',
-                            usage='run_command.py tidy [-h] [--clang-format PATH] [--update] [--dir PATH]')
+def set_subparser(subparsers):
+    parser = subparsers.add_parser(
+        'tidy', help='Check and update format for C++ files',
+        usage='run_command.py tidy [-h] [--clang-format PATH] [--update] [--dir PATH]')
     parser.add_argument('--clang-format', metavar='PATH', default='clang-format-11',
                         help='path to clang-format (default: %(default)s)')
     parser.add_argument('--update', action='store_true',
                         help='reformat files')
     parser.add_argument('--dir', metavar='PATH', default=DEFAULT_DIR,
                         help='directory to process (default: %(default)s)')
-    args = parser.parse_args(argv)
 
+
+def run_check_tidy(args):
     stats = Stats()
 
     _run_check_tidy(args.dir, args.update, args.clang_format, stats)

--- a/tools/commands/check_tidy.py
+++ b/tools/commands/check_tidy.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python3
-
 # Copyright 2015-present Samsung Electronics Co., Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -20,9 +18,8 @@ import os
 import subprocess
 import sys
 
-from argparse import ArgumentParser
 from difflib import unified_diff
-from os.path import abspath, dirname, join, relpath, splitext
+from os.path import join, relpath, splitext
 import commands.command_utils as command_utils
 
 DEFAULT_DIR = command_utils.get_package_dir()
@@ -126,7 +123,3 @@ def run_check_tidy(args):
         print('All files reformatted, check for changes with `git diff`.')
 
     sys.exit(1 if stats.errors else 0)
-
-
-if __name__ == '__main__':
-    run_check_tidy(sys.argv)

--- a/tools/commands/command_utils.py
+++ b/tools/commands/command_utils.py
@@ -3,17 +3,22 @@ import os
 
 
 def set_parser_arguments(parser,
-                       plugins=False, exclude=False, run_on_changed_packages=False, base_sha=False, timeout=False, command=''):
+                         plugins=False,
+                         exclude=False,
+                         run_on_changed_packages=False,
+                         base_sha=False,
+                         timeout=False,
+                         command=''):
     if plugins:
-        parser.add_argument(
-            '--plugins',
-            type=str,
-            nargs='*',
-            default=[],
-            help=f'Specifies which plugins to {command}. \
+        parser.add_argument('--plugins',
+                            type=str,
+                            nargs='*',
+                            default=[],
+                            help=f'Specifies which plugins to {command}. \
             If it is not specified and --run-on-changed-packages is also not specified, \
             then it will include every plugin under packages. \
-            If both flags are specified, then --run-on-changed-packages is ignored.')
+            If both flags are specified, then --run-on-changed-packages is ignored.'
+                            )
 
     if exclude:
         parser.add_argument('--exclude',
@@ -23,11 +28,10 @@ def set_parser_arguments(parser,
                             help=f'Exclude plugins from {command}.')
 
     if run_on_changed_packages:
-        parser.add_argument(
-            '--run-on-changed-packages',
-            default=False,
-            action='store_true',
-            help=f'Run the {command} on changed plugins.')
+        parser.add_argument('--run-on-changed-packages',
+                            default=False,
+                            action='store_true',
+                            help=f'Run the {command} on changed plugins.')
 
     if base_sha:
         parser.add_argument(
@@ -56,12 +60,11 @@ def get_changed_plugins(packages_dir, base_sha=''):
             encoding='utf-8',
             stdout=subprocess.PIPE).stdout.strip()
         if base_sha == '':
-            base_sha = subprocess.run(
-                'git merge-base FETCH_HEAD HEAD',
-                shell=True,
-                cwd=packages_dir,
-                encoding='utf-8',
-                stdout=subprocess.PIPE).stdout.strip()
+            base_sha = subprocess.run('git merge-base FETCH_HEAD HEAD',
+                                      shell=True,
+                                      cwd=packages_dir,
+                                      encoding='utf-8',
+                                      stdout=subprocess.PIPE).stdout.strip()
 
     changed_files = subprocess.run(
         f'git diff --name-only {base_sha} HEAD',
@@ -76,13 +79,18 @@ def get_changed_plugins(packages_dir, base_sha=''):
         if 'packages' not in path_segments:
             continue
         index = path_segments.index('packages')
-        if index < len(path_segments) and path_segments[index + 1] not in changed_plugins:
+        if index < len(path_segments) and path_segments[
+                index + 1] not in changed_plugins:
             changed_plugins.append(path_segments[index + 1])
 
     return list(set(changed_plugins))
 
 
-def get_target_plugins(packages_dir, plugins=[], exclude=[], run_on_changed_packages=False, base_sha=''):
+def get_target_plugins(packages_dir,
+                       plugins=[],
+                       exclude=[],
+                       run_on_changed_packages=False,
+                       base_sha=''):
     existing_plugins = os.listdir(packages_dir)
     for plugin in plugins:
         if plugin not in existing_plugins:
@@ -110,4 +118,5 @@ def get_target_plugins(packages_dir, plugins=[], exclude=[], run_on_changed_pack
 
 
 def get_package_dir():
-    return os.path.abspath(os.path.join(os.path.dirname(__file__), '../../packages'))
+    return os.path.abspath(
+        os.path.join(os.path.dirname(__file__), '../../packages'))

--- a/tools/commands/command_utils.py
+++ b/tools/commands/command_utils.py
@@ -6,10 +6,8 @@ import os
 from time import sleep, time
 
 
-def get_options_parser(
-        plugins=False, exclude=False, run_on_changed_packages=False, base_sha=False, timeout=False, command=''):
-    parser = argparse.ArgumentParser(usage=f'{command} [optional arguments]')
-
+def set_parser_arguments(parser,
+                       plugins=False, exclude=False, run_on_changed_packages=False, base_sha=False, timeout=False, command=''):
     if plugins:
         parser.add_argument(
             '--plugins',
@@ -51,8 +49,6 @@ def get_options_parser(
             default=120,
             help=f'Timeout limit of each {command} in seconds. \
             Default is 120 seconds.')
-
-    return parser
 
 
 def get_changed_plugins(packages_dir, base_sha=''):

--- a/tools/commands/command_utils.py
+++ b/tools/commands/command_utils.py
@@ -1,9 +1,5 @@
-#!/usr/bin/env python3
-
-import argparse
 import subprocess
 import os
-from time import sleep, time
 
 
 def set_parser_arguments(parser,

--- a/tools/commands/integration_test.py
+++ b/tools/commands/integration_test.py
@@ -53,7 +53,7 @@ class TestResult:
         return cls(plugin_name, 'succeeded', test_target=test_target)
 
     @classmethod
-    def fail(cls, plugin_name, test_target, errors=[]):
+    def fail(cls, plugin_name, test_target='', errors=[]):
         return cls(plugin_name,
                    'failed',
                    test_target=test_target,

--- a/tools/commands/integration_test.py
+++ b/tools/commands/integration_test.py
@@ -40,7 +40,6 @@ class TestResult:
         run_state: The result of the test. Can be either succeeded for failed.
         details: A list of details about the test result. (e.g. reasons for failure.)
     """
-
     def __init__(self, plugin_name, run_state, test_target='', details=[]):
         self.plugin_name = plugin_name
         self.test_target = test_target
@@ -62,12 +61,12 @@ class TestResult:
 def set_subparser(subparsers):
     parser = subparsers.add_parser('test', help='Run integration test')
     command_utils.set_parser_arguments(parser,
-                                              plugins=True,
-                                              exclude=True,
-                                              run_on_changed_packages=True,
-                                              base_sha=True,
-                                              timeout=True,
-                                              command='test')
+                                       plugins=True,
+                                       exclude=True,
+                                       run_on_changed_packages=True,
+                                       base_sha=True,
+                                       timeout=True,
+                                       command='test')
     parser.add_argument(
         '--recipe',
         type=str,
@@ -237,7 +236,6 @@ def _integration_test(plugin_dir, test_targets, timeout):
 
 
 def _get_target_table():
-
     def _parse_target_info(capability_info: str):
         capability_info.rstrip()
         profile_name = ''

--- a/tools/commands/integration_test.py
+++ b/tools/commands/integration_test.py
@@ -196,8 +196,12 @@ def _integration_test(plugin_dir, test_targets, timeout):
                 TestResult.fail(plugin_name, test_target, errors=errors))
             continue
         if last_line.strip() == 'No tests ran.':
+            # This message occurs when the integration test file exists,
+            # but no actual test code is written in it.
             test_results.append(
-                TestResult.fail(plugin_name, test_target, ['No tests ran.']))
+                TestResult.fail(plugin_name, test_target, [
+                    'Missing integration tests (use --exclude if this is intentional).'
+                ]))
             continue
         elif last_line.strip().startswith('No devices found'):
             test_results.append(

--- a/tools/commands/integration_test.py
+++ b/tools/commands/integration_test.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 """A script that helps running integration tests for multiple Tizen plugins.
 
 To run integrations tests for all plugins under packages/, 
@@ -351,7 +350,3 @@ def run_integration_test(args):
     for excluded_plugin in excluded_plugins:
         print(f'{_TERM_YELLOW}EXCLUDED: {excluded_plugin}{_TERM_EMPTY}')
     exit(exit_code)
-
-
-if __name__ == "__main__":
-    run_integration_test(sys.argv)

--- a/tools/commands/integration_test.py
+++ b/tools/commands/integration_test.py
@@ -60,8 +60,10 @@ class TestResult:
                    details=errors)
 
 
-def parse_args(args):
-    parser = command_utils.get_options_parser(plugins=True,
+def set_subparser(subparsers):
+    parser = subparsers.add_parser('test', help='Run integration test')
+    command_utils.set_parser_arguments(parser,
+                                              plugins=True,
                                               exclude=True,
                                               run_on_changed_packages=True,
                                               base_sha=True,
@@ -80,8 +82,6 @@ plugins:
   b: [mobile-6.0]
   c: [wearable-4.0]
 )''')
-
-    return parser.parse_args(args)
 
 
 def _integration_test(plugin_dir, test_targets, timeout):
@@ -284,9 +284,7 @@ platform_version: {platform_version}''')
     return table
 
 
-def run_integration_test(argv):
-    args = parse_args(argv)
-
+def run_integration_test(args):
     test_targets = {}
     if args.recipe:
         if not os.path.isfile(args.recipe):

--- a/tools/commands/print_plugins.py
+++ b/tools/commands/print_plugins.py
@@ -1,7 +1,3 @@
-#!/usr/bin/env python3
-
-import sys
-
 import commands.command_utils as command_utils
 
 
@@ -17,7 +13,3 @@ def run_print_plugins(args):
         packages_dir, run_on_changed_packages=args.run_on_changed_packages, base_sha=args.base_sha)
     for target_plugin in target_plugins:
         print(target_plugin)
-
-
-if __name__ == '__main__':
-    run_print_plugins(sys.argv)

--- a/tools/commands/print_plugins.py
+++ b/tools/commands/print_plugins.py
@@ -3,13 +3,18 @@ import commands.command_utils as command_utils
 
 def set_subparser(subparsers):
     parser = subparsers.add_parser('plugins', help='Print plugins list')
-    command_utils.set_parser_arguments(parser, run_on_changed_packages=True, base_sha=True, command='print plugins')
+    command_utils.set_parser_arguments(parser,
+                                       run_on_changed_packages=True,
+                                       base_sha=True,
+                                       command='print plugins')
 
 
 def run_print_plugins(args):
     packages_dir = command_utils.get_package_dir()
 
     target_plugins, _ = command_utils.get_target_plugins(
-        packages_dir, run_on_changed_packages=args.run_on_changed_packages, base_sha=args.base_sha)
+        packages_dir,
+        run_on_changed_packages=args.run_on_changed_packages,
+        base_sha=args.base_sha)
     for target_plugin in target_plugins:
         print(target_plugin)

--- a/tools/commands/print_plugins.py
+++ b/tools/commands/print_plugins.py
@@ -5,13 +5,12 @@ import sys
 import commands.command_utils as command_utils
 
 
-def parse_args(args):
-    parser = command_utils.get_options_parser(run_on_changed_packages=True, base_sha=True, command='print plugins')
-    return parser.parse_args(args)
+def set_subparser(subparsers):
+    parser = subparsers.add_parser('plugins', help='Print plugins list')
+    command_utils.set_parser_arguments(parser, run_on_changed_packages=True, base_sha=True, command='print plugins')
 
 
-def run_print_plugins(argv):
-    args = parse_args(argv)
+def run_print_plugins(args):
     packages_dir = command_utils.get_package_dir()
 
     target_plugins, _ = command_utils.get_target_plugins(

--- a/tools/run_command.py
+++ b/tools/run_command.py
@@ -47,3 +47,4 @@ if __name__ == "__main__":
         commands[sys.argv[1]]['func'](sys.argv[2:])
     except Exception as e:
         print_usage()
+        exit(1)

--- a/tools/run_command.py
+++ b/tools/run_command.py
@@ -7,7 +7,6 @@ from commands import check_tidy
 from commands import integration_test
 from commands import build_example
 from commands import print_plugins
-from commands import command_utils
 
 
 if __name__ == "__main__":

--- a/tools/run_command.py
+++ b/tools/run_command.py
@@ -8,7 +8,6 @@ from commands import integration_test
 from commands import build_example
 from commands import print_plugins
 
-
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()
     subparsers = parser.add_subparsers(dest='subcommand')

--- a/tools/run_command.py
+++ b/tools/run_command.py
@@ -1,50 +1,37 @@
 #!/usr/bin/env python3
 
 import sys
+import argparse
 
 from commands import check_tidy
 from commands import integration_test
 from commands import build_example
 from commands import print_plugins
-
-
-# Check tidy
-def run_check_tidy(argv):
-    check_tidy.run_check_tidy(argv)
-
-
-# Excute integration_test
-def run_integration_test(argv):
-    integration_test.run_integration_test(argv)
-
-
-# Build example app
-def run_build_examples(argv):
-    build_example.run_build_examples(argv)
-
-
-# Print plugin list
-def run_print_plugins(arv):
-    print_plugins.run_print_plugins(arv)
-
-
-commands = {}
-commands['tidy'] = {'func': run_check_tidy, 'info': 'Check and update format for C++ files'}
-commands['test'] = {'func': run_integration_test, 'info': 'Run integration test'}
-commands['build'] = {'func': run_build_examples, 'info': 'Build examples of plugin'}
-commands['plugins'] = {'func': run_print_plugins, 'info': 'Print plugins list'}
-
-
-def print_usage():
-    print('usage: run_command.py [command] ')
-    print('command lists:')
-    for k, v in commands.items():
-        print(f'    { k } : { v["info"] }')
+from commands import command_utils
 
 
 if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    subparsers = parser.add_subparsers(dest='subcommand')
+    check_tidy.set_subparser(subparsers)
+    integration_test.set_subparser(subparsers)
+    build_example.set_subparser(subparsers)
+    print_plugins.set_subparser(subparsers)
+
+    args = parser.parse_args(sys.argv[1:])
+    if not args.subcommand:
+        parser.print_help()
+        exit(1)
+
     try:
-        commands[sys.argv[1]]['func'](sys.argv[2:])
+        if args.subcommand == 'tidy':
+            check_tidy.run_check_tidy(args)
+        elif args.subcommand == 'test':
+            integration_test.run_integration_test(args)
+        elif args.subcommand == 'build':
+            build_example.run_build_examples(args)
+        elif args.subcommand == 'plugins':
+            print_plugins.run_print_plugins(args)
     except Exception as e:
-        print_usage()
+        print(e)
         exit(1)


### PR DESCRIPTION
Changes:
- Refactor `run_command.py` and `commands/*.py` to use subparsers for better error handling.
- Make `test_target` an optional parameter to resolve "missing required positional argument" error in `integration_test.py`.
- Use consistent error message in `integration_test.py`.

The last two commits(d470c84f760f5304807f9d5f0658834a35a002c1, 6662780d72eb2d50a9c20360ae02fdc98d4e99eb) are code clean ups. The major changes are in 0c52a49583d7d4abdf627d7a019905f19e1d035a.