### PR TITLE
[tizen_app_control] Support getMatchedAppIds

### DIFF
--- a/packages/tizen_app_control/example/integration_test/tizen_app_control_test.dart
+++ b/packages/tizen_app_control/example/integration_test/tizen_app_control_test.dart
@@ -26,6 +26,16 @@ void main() {
     expect(received.operation, 'http://tizen.org/appcontrol/operation/default');
   }, timeout: kTimeout);
 
+  testWidgets('Can find matching applications', (WidgetTester _) async {
+    final AppControl request = AppControl(
+      operation: 'http://tizen.org/appcontrol/operation/view',
+      uri: 'file:///opt/usr/globalapps/$kAppId/shared/res/ic_launcher.png',
+      mime: 'image/*',
+    );
+    final List<String> matches = await request.getMatchedAppIds();
+    expect(matches, isNotEmpty);
+  }, timeout: kTimeout);
+
   testWidgets('Can send and receive request', (WidgetTester _) async {
     // Send a request to this app (the test runner itself).
     final AppControl request = AppControl(

--- a/packages/tizen_app_control/example/lib/main.dart
+++ b/packages/tizen_app_control/example/lib/main.dart
@@ -99,6 +99,13 @@ class _MyAppState extends State<MyApp> {
         'http://tizen.org/appcontrol/data/text': 'Some text',
       },
     );
+    final List<String> matches = await request.getMatchedAppIds();
+    if (matches.isEmpty) {
+      _messengerKey.currentState!.showSnackBar(
+        const SnackBar(content: Text('No application found.')),
+      );
+      return;
+    }
     await request.sendLaunchRequest();
   }
 
@@ -108,6 +115,13 @@ class _MyAppState extends State<MyApp> {
       mime: 'image/*',
       launchMode: LaunchMode.group,
     );
+    final List<String> matches = await request.getMatchedAppIds();
+    if (matches.isEmpty) {
+      _messengerKey.currentState!.showSnackBar(
+        const SnackBar(content: Text('No application found.')),
+      );
+      return;
+    }
     await request.sendLaunchRequest(
       replyCallback: (
         AppControl request,

--- a/packages/tizen_app_control/lib/app_control.dart
+++ b/packages/tizen_app_control/lib/app_control.dart
@@ -144,6 +144,16 @@ class AppControl {
       .map((dynamic event) => ReceivedAppControl._fromMap(
           Map<String, dynamic>.from(event as Map<dynamic, dynamic>)));
 
+  /// Returns a list of installed applications that can handle this request.
+  Future<List<String>> getMatchedAppIds() async {
+    await _setAppControlData();
+
+    final Map<String, dynamic> args = <String, dynamic>{'id': _id};
+    final dynamic response =
+        await _methodChannel.invokeMethod<dynamic>('getMatchedAppIds', args);
+    return List<String>.from(response as List<dynamic>);
+  }
+
   /// Sends a launch request to an application.
   ///
   /// The `http://tizen.org/privilege/appmanager.launch` privilege is required
@@ -197,9 +207,7 @@ class AppControl {
   Future<void> sendTerminateRequest() async {
     await _setAppControlData();
 
-    final Map<String, dynamic> args = <String, dynamic>{
-      'id': _id,
-    };
+    final Map<String, dynamic> args = <String, dynamic>{'id': _id};
     await _methodChannel.invokeMethod<void>('sendTerminateRequest', args);
   }
 


### PR DESCRIPTION
Related to https://github.com/flutter-tizen/engine/pull/185.

Reference: TizenFX's [`AppControl.GetMatchedApplicationIds()`](https://docs.tizen.org/application/dotnet/api/TizenFX/API8/api/Tizen.Applications.AppControl.html#Tizen_Applications_AppControl_GetMatchedApplicationIds_Tizen_Applications_AppControl_)