### PR TITLE
Refactor, run clean command after each test, improve logic for setting default targets.

### DIFF
--- a/tools/commands/integration_test.py
+++ b/tools/commands/integration_test.py
@@ -236,11 +236,7 @@ def _integration_test(plugin_dir, test_targets, timeout):
                 test_results.append(
                     TestResult.fail(plugin_name, test_target, errors=errors))
     finally:
-        subprocess.run('flutter-tizen clean',
-                       shell=True,
-                       cwd=example_dir,
-                       stderr=subprocess.PIPE,
-                       stdout=subprocess.PIPE)
+        subprocess.run('flutter-tizen clean', shell=True, cwd=example_dir)
 
     return test_results
 

--- a/tools/commands/integration_test.py
+++ b/tools/commands/integration_test.py
@@ -357,7 +357,10 @@ def _integration_test(plugin_dir, platforms, timeout):
                 test_results.append(result)
 
     finally:
-        subprocess.run('flutter-tizen clean', shell=True, cwd=example_dir)
+        subprocess.run('flutter-tizen clean',
+                       shell=True,
+                       cwd=example_dir,
+                       stdout=open(os.devnull, 'wb'))
 
     return test_results
 

--- a/tools/run_command.py
+++ b/tools/run_command.py
@@ -21,15 +21,11 @@ if __name__ == "__main__":
         parser.print_help()
         exit(1)
 
-    try:
-        if args.subcommand == 'tidy':
-            check_tidy.run_check_tidy(args)
-        elif args.subcommand == 'test':
-            integration_test.run_integration_test(args)
-        elif args.subcommand == 'build':
-            build_example.run_build_examples(args)
-        elif args.subcommand == 'plugins':
-            print_plugins.run_print_plugins(args)
-    except Exception as e:
-        print(e)
-        exit(1)
+    if args.subcommand == 'tidy':
+        check_tidy.run_check_tidy(args)
+    elif args.subcommand == 'test':
+        integration_test.run_integration_test(args)
+    elif args.subcommand == 'build':
+        build_example.run_build_examples(args)
+    elif args.subcommand == 'plugins':
+        print_plugins.run_print_plugins(args)


### PR DESCRIPTION
Sorry for the unexpected huge diff, adding default targets was not as straightforward as I originally thought. I may have done some over refactoring but I already had planned the changes for #230. It was simpler to work with the refactored code so I decided to apply it a bit early.

This PR must be merged after adding the `--platforms` option in `integration_test.yml`.

Summary:
- Run clean command after each test to save disk space. ~~(Nothing has changed between line 136~237)~~
- Don't catch exceptions and print stack trace.
- Fix incorrectly used nested f-string.
- Introduce `Target` which encapsulates a Tizen device.
- Introduce `TargetManager` which finds and manages a collection of `Target`s.
- Update outdated docstrings.
- Define some words used in code, such as `target`, `platform`, etc.
- Allow tool to select all connected targets for test devices by default.
- Add `--platforms` option which takes inputs of the form `<device_profile>-<tizen_version>`, the tool will find all satisfying targets and serve them as test devices.

```bash
# When connected with 4 emulators with different platforms.
./tools/run_command.py test --plugins wakelock
============= TEST RESULT =============
SUCCEEDED: wakelock ('mobile-6.0', 'M-6.0-x86', 'emulator-26131')
SUCCEEDED: wakelock ('wearable-5.5', 'W-5.5-circle-x86', 'emulator-26121')
SUCCEEDED: wakelock ('wearable-4.0', 'w-0521-1', 'emulator-26111')
SUCCEEDED: wakelock ('tv-6.0', 'T-samsung-6.0-x86', 'emulator-26101')
All tests passed!

./tools/run_command.py test --plugins wakelock --platforms wearable-5.5
============= TEST RESULT =============
SUCCEEDED: wakelock ('wearable-5.5', 'W-5.5-circle-x86', 'emulator-26121')
All tests passed!
```