### PR TITLE
[multi-packages] Resolve some linter warnings

### DIFF
--- a/packages/messageport/example/integration_test/messageport_test.dart
+++ b/packages/messageport/example/integration_test/messageport_test.dart
@@ -5,8 +5,8 @@
 import 'dart:async';
 
 import 'package:flutter_test/flutter_test.dart';
-import 'package:messageport_tizen/messageport_tizen.dart';
 import 'package:integration_test/integration_test.dart';
+import 'package:messageport_tizen/messageport_tizen.dart';
 
 void main() {
   IntegrationTestWidgetsFlutterBinding.ensureInitialized();

--- a/packages/messageport/example/lib/main.dart
+++ b/packages/messageport/example/lib/main.dart
@@ -1,3 +1,5 @@
+// ignore_for_file: public_member_api_docs
+
 import 'dart:async';
 import 'package:flutter/material.dart';
 

--- a/packages/messageport/lib/messageport_tizen.dart
+++ b/packages/messageport/lib/messageport_tizen.dart
@@ -80,7 +80,7 @@ class RemotePort {
     return _manager.sendWithLocalPort(this, localPort, message);
   }
 
-  // Checks whether remote port is registered in remote application.
+  /// Checks whether remote port is registered in remote application.
   Future<bool> check() async {
     return _manager.checkForRemotePort(remoteAppId, portName, trusted);
   }
@@ -95,6 +95,7 @@ class RemotePort {
   final bool trusted;
 }
 
+// ignore: avoid_classes_with_only_static_members
 /// API for accessing MessagePorts in Tizen.
 class TizenMessagePort {
   /// Creates Local Port

--- a/packages/messageport/lib/src/messageport_manager.dart
+++ b/packages/messageport/lib/src/messageport_manager.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+// ignore_for_file: public_member_api_docs
+
 import 'dart:async';
 
 import 'package:flutter/services.dart';

--- a/packages/package_info_plus/lib/package_info_plus_tizen.dart
+++ b/packages/package_info_plus/lib/package_info_plus_tizen.dart
@@ -15,6 +15,7 @@ import 'package:package_info_plus_platform_interface/package_info_platform_inter
 /// being set to Linux's.
 /// https://github.com/fluttercommunity/plus_plugins/blob/c7c942d1d19595a536c6ae18168d3781ddef7785/packages/package_info_plus/lib/package_info_plus.dart#L43-L55
 class PackageInfoPlugin extends PackageInfoPlatform {
+  /// Register dart plugin to inject Tizen plugin.
   static void register() {
     // ignore: invalid_use_of_visible_for_testing_member
     PackageInfo.disablePackageInfoPlatformOverride = true;

--- a/packages/share_plus/example/lib/main.dart
+++ b/packages/share_plus/example/lib/main.dart
@@ -66,7 +66,7 @@ class DemoAppState extends State<DemoApp> {
                       title: Text('Add image'),
                       onTap: () async {
                         final imagePicker = ImagePicker();
-                        final pickedFile = await imagePicker.pickImage(
+                        final pickedFile = await imagePicker.getImage(
                           source: ImageSource.gallery,
                         );
                         if (pickedFile != null) {

--- a/packages/share_plus/lib/share_plus_tizen.dart
+++ b/packages/share_plus/lib/share_plus_tizen.dart
@@ -15,6 +15,7 @@ import 'package:share_plus_platform_interface/share_plus_platform_interface.dart
 /// being set to Linux's.
 /// https://github.com/fluttercommunity/plus_plugins/blob/fc6864f21cf1d1f6db47a3c938f24370362d00cd/packages/share_plus/lib/share_plus.dart#L30-L42
 class SharePlugin extends SharePlatform {
+  /// Register dart plugin to inject Tizen plugin.
   static void register() {
     // ignore: invalid_use_of_visible_for_testing_member
     Share.disableSharePlatformOverride = true;

--- a/packages/wearable_rotary/example/lib/custom_page_view.dart
+++ b/packages/wearable_rotary/example/lib/custom_page_view.dart
@@ -1,3 +1,5 @@
+// ignore_for_file: public_member_api_docs
+
 import 'dart:async';
 
 import 'package:flutter/material.dart';

--- a/packages/wearable_rotary/example/lib/main.dart
+++ b/packages/wearable_rotary/example/lib/main.dart
@@ -1,3 +1,5 @@
+// ignore_for_file: public_member_api_docs
+
 import 'package:flutter/material.dart';
 
 import './custom_page_view.dart';

--- a/packages/wearable_rotary/lib/wearable_rotary.dart
+++ b/packages/wearable_rotary/lib/wearable_rotary.dart
@@ -4,6 +4,7 @@ const String _channelName = 'flutter.wearable_rotary.channel';
 
 const EventChannel _channel = EventChannel(_channelName);
 
+/// A broadcast stream of events from the device rotary sensor.
 Stream<RotaryEvent> get rotaryEvents {
   _rotaryEvents ??= _channel
       .receiveBroadcastStream()
@@ -13,8 +14,14 @@ Stream<RotaryEvent> get rotaryEvents {
 
 Stream<RotaryEvent>? _rotaryEvents;
 
+/// Discrete reading from an rotary sensor. Rotary sensor measure the rotation
+/// of the wearable device. The event refers to a single "click" of rotatation
+/// angle which may differ by device.
 enum RotaryEvent {
+  /// A roation angle in the clockwise direction.
   clockwise,
+
+  /// A roation angle in the counter clockwise direction.
   counterClockwise,
 }
 


### PR DESCRIPTION
Resolve warnings from `dart analyze` for `package_info_plus`, `share_plus`, `wearable_rotary`, and `message_port`.

Partially contributes to #223.
