### PR TITLE
[battery_plus] Remove dependency override

### DIFF
--- a/packages/battery_plus/example/pubspec.yaml
+++ b/packages/battery_plus/example/pubspec.yaml
@@ -20,12 +20,9 @@ dev_dependencies:
     path: ../../integration_test/
   pedantic: ^1.9.2
 
-dependency_overrides:
-  args: ^2.0.0
-
 flutter:
   uses-material-design: true
 
 environment:
   sdk: ">=2.12.0 <3.0.0"
-  flutter: ">=2.0.0"
+  flutter: ">=2.2.0"


### PR DESCRIPTION
`dependency_override` is removed and flutter sdk constraint is bumped up to `>=2.2.0`, see https://github.com/flutter-tizen/plugins/pull/125#issuecomment-866661681.