### PR TITLE
[share_plus] Bump up versions

### DIFF
--- a/packages/share_plus/README.md
+++ b/packages/share_plus/README.md
@@ -8,7 +8,7 @@ To use this plugin, add `share_plus` and `share_plus_tizen` as [dependencies in 
 
 ```yaml
 dependencies:
-  share_plus: ^2.1.2
+  share_plus: ^3.0.4
   share_plus_tizen: ^1.0.0
 ```
 

--- a/packages/share_plus/example/pubspec.yaml
+++ b/packages/share_plus/example/pubspec.yaml
@@ -5,10 +5,10 @@ publish_to: "none"
 dependencies:
   flutter:
     sdk: flutter
-  image_picker: ^0.8.0+3
+  image_picker: ^0.8.4+3
   image_picker_tizen:
     path: ../../image_picker/
-  share_plus: ^2.1.2
+  share_plus: ^3.0.4
   share_plus_tizen:
     path: ../
 

--- a/packages/share_plus/pubspec.yaml
+++ b/packages/share_plus/pubspec.yaml
@@ -14,7 +14,7 @@ flutter:
 dependencies:
   flutter:
     sdk: flutter
-  share_plus: ^2.1.2
+  share_plus: ^3.0.4
   share_plus_platform_interface: ^2.0.0
 
 dev_dependencies:


### PR DESCRIPTION
Bump up major version of `share_plus`, the change only removes a deprecated API from Android embedding.
https://pub.dev/packages/share_plus/changelog#300