### PR TITLE
[battery_plus] Update battery_plus to 2.0.1

### DIFF
--- a/packages/battery_plus/CHANGELOG.md
+++ b/packages/battery_plus/CHANGELOG.md
@@ -1,7 +1,13 @@
 ## 1.0.0
 
-* Initial release
+* Initial release.
 
 ## 1.0.1
 
-* Fix bug with EventChannel
+* Fix a bug with EventChannel.
+
+## 1.0.2
+
+* Update battery_plus and the platform interface to 2.0.1 and 1.1.0.
+* Update the example app and integration_test.
+* Minor code cleanups.

--- a/packages/battery_plus/README.md
+++ b/packages/battery_plus/README.md
@@ -8,8 +8,8 @@ This package is not an _endorsed_ implementation of `battery_plus`. Therefore, y
 
 ```yaml
 dependencies:
-  battery_plus: ^1.0.1
-  battery_plus_tizen: ^1.0.1
+  battery_plus: ^2.0.1
+  battery_plus_tizen: ^1.0.2
 ```
 
 Then you can import `battery_plus` in your Dart code:
@@ -20,6 +20,12 @@ import 'package:battery_plus/battery_plus.dart';
 
 For detailed usage, see https://github.com/fluttercommunity/plus_plugins/tree/main/packages/battery_plus/battery_plus#usage.
 
+## Supported APIs
+
+- [x] `Battery.batteryLevel`
+- [ ] `Battery.isInBatterySaveMode`
+- [x] `Battery.onBatteryStateChanged`
+
 ## Supported devices
 
-This plugin is supported on Galaxy Watch (running Tizen 4.0 or later).
+- Galaxy Watch series (running Tizen 4.0 or later)

--- a/packages/battery_plus/example/integration_test/battery_plus_test.dart
+++ b/packages/battery_plus/example/integration_test/battery_plus_test.dart
@@ -1,11 +1,12 @@
-// Copyright 2013 The Flutter Authors. All rights reserved.
-// Use of this source code is governed by a BSD-style license that can be
-// found in the LICENSE file.
+// Copyright 2020, the Chromium authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
 
-// @dart = 2.9
+// @dart=2.9
 
-import 'package:flutter_test/flutter_test.dart';
 import 'package:battery_plus/battery_plus.dart';
+import 'package:flutter/foundation.dart';
+import 'package:flutter_test/flutter_test.dart';
 import 'package:integration_test/integration_test.dart';
 
 void main() {
@@ -16,4 +17,12 @@ void main() {
     final batteryLevel = await battery.batteryLevel;
     expect(batteryLevel, isNotNull);
   });
+
+  testWidgets('Can get if device is in power mode',
+      (WidgetTester tester) async {
+    final battery = Battery();
+    final isInBatterySaveMode = await battery.isInBatterySaveMode;
+    debugPrint('$isInBatterySaveMode');
+    expect(isInBatterySaveMode, isNotNull);
+  }, skip: true);
 }

--- a/packages/battery_plus/example/lib/main.dart
+++ b/packages/battery_plus/example/lib/main.dart
@@ -10,10 +10,12 @@ import 'package:flutter/material.dart';
 import 'package:battery_plus/battery_plus.dart';
 
 void main() {
-  runApp(MyApp());
+  runApp(const MyApp());
 }
 
 class MyApp extends StatelessWidget {
+  const MyApp({Key? key}) : super(key: key);
+
   @override
   Widget build(BuildContext context) {
     return MaterialApp(
@@ -21,13 +23,13 @@ class MyApp extends StatelessWidget {
       theme: ThemeData(
         primarySwatch: Colors.blue,
       ),
-      home: MyHomePage(title: 'Flutter Demo Home Page'),
+      home: const MyHomePage(title: 'Flutter Demo Home Page'),
     );
   }
 }
 
 class MyHomePage extends StatefulWidget {
-  MyHomePage({Key? key, this.title}) : super(key: key);
+  const MyHomePage({Key? key, this.title}) : super(key: key);
 
   final String? title;
 
@@ -59,28 +61,53 @@ class _MyHomePageState extends State<MyHomePage> {
         title: const Text('Plugin example app'),
       ),
       body: Center(
-        child: Text('$_batteryState'),
-      ),
-      floatingActionButton: FloatingActionButton(
-        onPressed: () async {
-          final batteryLevel = await _battery.batteryLevel;
-          // ignore: unawaited_futures
-          showDialog<void>(
-            context: context,
-            builder: (_) => AlertDialog(
-              content: Text('Battery: $batteryLevel%'),
-              actions: <Widget>[
-                TextButton(
-                  onPressed: () {
-                    Navigator.pop(context);
-                  },
-                  child: const Text('OK'),
-                )
-              ],
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            Text('$_batteryState'),
+            ElevatedButton(
+              onPressed: () async {
+                final batteryLevel = await _battery.batteryLevel;
+                // ignore: unawaited_futures
+                showDialog<void>(
+                  context: context,
+                  builder: (_) => AlertDialog(
+                    content: Text('Battery: $batteryLevel%'),
+                    actions: <Widget>[
+                      TextButton(
+                        onPressed: () {
+                          Navigator.pop(context);
+                        },
+                        child: const Text('OK'),
+                      )
+                    ],
+                  ),
+                );
+              },
+              child: const Text('Get battery level'),
             ),
-          );
-        },
-        child: const Icon(Icons.battery_unknown),
+            ElevatedButton(
+                onPressed: () async {
+                  final isInPowerSaveMode = await _battery.isInBatterySaveMode;
+                  // ignore: unawaited_futures
+                  showDialog<void>(
+                    context: context,
+                    builder: (_) => AlertDialog(
+                      content: Text('Is on low power mode: $isInPowerSaveMode'),
+                      actions: <Widget>[
+                        TextButton(
+                          onPressed: () {
+                            Navigator.pop(context);
+                          },
+                          child: const Text('OK'),
+                        )
+                      ],
+                    ),
+                  );
+                },
+                child: const Text('Is on low power mode'))
+          ],
+        ),
       ),
     );
   }

--- a/packages/battery_plus/example/pubspec.yaml
+++ b/packages/battery_plus/example/pubspec.yaml
@@ -3,7 +3,7 @@ description: Demonstrates how to use the battery_plus plugin.
 publish_to: "none"
 
 dependencies:
-  battery_plus: ^1.0.1
+  battery_plus: ^2.0.1
   battery_plus_tizen:
     path: ../
   flutter:

--- a/packages/battery_plus/example/test_driver/integration_test.dart
+++ b/packages/battery_plus/example/test_driver/integration_test.dart
@@ -1,5 +1,3 @@
-// @dart=2.9
-
 import 'package:integration_test/integration_test_driver.dart';
 
 Future<void> main() => integrationDriver();

--- a/packages/battery_plus/example/tizen/Runner.csproj
+++ b/packages/battery_plus/example/tizen/Runner.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Tizen.NET.Sdk/1.1.5">
+﻿<Project Sdk="Tizen.NET.Sdk/1.1.6">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>

--- a/packages/battery_plus/example/tizen/tizen-manifest.xml
+++ b/packages/battery_plus/example/tizen/tizen-manifest.xml
@@ -1,11 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest package="org.tizen.battery_plus_example" version="1.0.0" api-version="4.0" xmlns="http://tizen.org/ns/packages">
-    <profile name="common"/>
-    <ui-application appid="org.tizen.battery_plus_example" exec="Runner.dll" type="dotnet" multiple="false" taskmanage="true" nodisplay="false" api-version="4" launch_mode="single">
+    <profile name="wearable"/>
+    <ui-application appid="org.tizen.battery_plus_example" exec="Runner.dll" type="dotnet" multiple="false" taskmanage="true" nodisplay="false" api-version="4">
         <label>battery_plus_tizen_example</label>
         <icon>ic_launcher.png</icon>
         <metadata key="http://tizen.org/metadata/prefer_dotnet_aot" value="true"/>
-        <metadata key="http://tizen.org/metadata/direct-launch" value="yes"/>
     </ui-application>
     <feature name="http://tizen.org/feature/screen.size.all"/>
 </manifest>

--- a/packages/battery_plus/pubspec.yaml
+++ b/packages/battery_plus/pubspec.yaml
@@ -2,7 +2,7 @@ name: battery_plus_tizen
 description: Tizen implementation of the battery_plus plugin
 homepage: https://github.com/flutter-tizen/plugins
 repository: https://github.com/flutter-tizen/plugins/tree/master/packages/battery_plus
-version: 1.0.1
+version: 1.0.2
 
 flutter:
   plugin:
@@ -13,7 +13,7 @@ flutter:
         fileName: battery_plus_tizen_plugin.h
 
 dependencies:
-  battery_plus_platform_interface: ^1.0.1
+  battery_plus_platform_interface: ^1.1.0
   flutter:
     sdk: flutter
 


### PR DESCRIPTION
- Increase the frontend package and platform interface versions to 2.0.1 and 1.1.0.
- Update the example app and integration test source code.
- Clarify that `Battery.isInBatterySaveMode` is not supported.
- Remove the `direct-launch` metadata from `tizen-manifest.xml`.
- Minor cleanups.