### PR TITLE
Fix video player plugin freeze issue

### DIFF
--- a/packages/video_player/tizen/src/video_player.cc
+++ b/packages/video_player/tizen/src/video_player.cc
@@ -66,20 +66,20 @@ FlutterDesktopGpuBuffer *VideoPlayer::ObtainGpuBuffer(size_t width,
     media_packet_destroy(prepared_media_packet_);
     prepared_media_packet_ = nullptr;
   }
-  if (using_media_packet_ && !isValidMediaPacket(using_media_packet_)) {
-    media_packet_destroy(using_media_packet_);
-    using_media_packet_ = nullptr;
+  if (current_media_packet_ && !isValidMediaPacket(current_media_packet_)) {
+    media_packet_destroy(current_media_packet_);
+    current_media_packet_ = nullptr;
   }
-  if (!prepared_media_packet_ && !using_media_packet_) {
+  if (!prepared_media_packet_ && !current_media_packet_) {
     LOG_ERROR("No vaild media packet");
     return nullptr;
   }
-  if (prepared_media_packet_ && !using_media_packet_) {
-    using_media_packet_ = prepared_media_packet_;
+  if (prepared_media_packet_ && !current_media_packet_) {
+    current_media_packet_ = prepared_media_packet_;
     prepared_media_packet_ = nullptr;
   }
   tbm_surface_h surface;
-  media_packet_get_tbm_surface(using_media_packet_, &surface);
+  media_packet_get_tbm_surface(current_media_packet_, &surface);
   flutter_desktop_gpu_buffer_->buffer = surface;
   flutter_desktop_gpu_buffer_->width = width;
   flutter_desktop_gpu_buffer_->height = height;
@@ -88,9 +88,9 @@ FlutterDesktopGpuBuffer *VideoPlayer::ObtainGpuBuffer(size_t width,
 
 void VideoPlayer::Destruct(void *buffer) {
   std::lock_guard<std::mutex> lock(mutex_);
-  if (using_media_packet_) {
-    media_packet_destroy(using_media_packet_);
-    using_media_packet_ = nullptr;
+  if (current_media_packet_) {
+    media_packet_destroy(current_media_packet_);
+    current_media_packet_ = nullptr;
   }
 }
 
@@ -323,9 +323,9 @@ void VideoPlayer::dispose() {
     player_ = 0;
   }
 
-  if (using_media_packet_) {
-    media_packet_destroy(using_media_packet_);
-    using_media_packet_ = nullptr;
+  if (current_media_packet_) {
+    media_packet_destroy(current_media_packet_);
+    current_media_packet_ = nullptr;
   }
 
   if (prepared_media_packet_) {

--- a/packages/video_player/tizen/src/video_player.cc
+++ b/packages/video_player/tizen/src/video_player.cc
@@ -49,7 +49,7 @@ static std::string StateToString(player_state_e state) {
   return ret;
 }
 
-bool VideoPlayer::isValidMediaPacket(media_packet_h media_packet) {
+bool VideoPlayer::IsValidMediaPacket(media_packet_h media_packet) {
   tbm_surface_h surface;
   int ret = media_packet_get_tbm_surface(media_packet, &surface);
   if (ret != MEDIA_PACKET_ERROR_NONE) {
@@ -62,11 +62,11 @@ bool VideoPlayer::isValidMediaPacket(media_packet_h media_packet) {
 FlutterDesktopGpuBuffer *VideoPlayer::ObtainGpuBuffer(size_t width,
                                                       size_t height) {
   std::lock_guard<std::mutex> lock(mutex_);
-  if (prepared_media_packet_ && !isValidMediaPacket(prepared_media_packet_)) {
+  if (prepared_media_packet_ && !IsValidMediaPacket(prepared_media_packet_)) {
     media_packet_destroy(prepared_media_packet_);
     prepared_media_packet_ = nullptr;
   }
-  if (current_media_packet_ && !isValidMediaPacket(current_media_packet_)) {
+  if (current_media_packet_ && !IsValidMediaPacket(current_media_packet_)) {
     media_packet_destroy(current_media_packet_);
     current_media_packet_ = nullptr;
   }

--- a/packages/video_player/tizen/src/video_player.cc
+++ b/packages/video_player/tizen/src/video_player.cc
@@ -548,8 +548,10 @@ void VideoPlayer::onVideoFrameDecoded(media_packet_h packet, void *data) {
   VideoPlayer *player = (VideoPlayer *)data;
   std::lock_guard<std::mutex> lock(player->mutex_);
   if (player->prepared_media_packet_) {
-    LOG_INFO("prepared_media_packet_ not null");
+    LOG_INFO("prepared packet not null, store new");
     media_packet_destroy(player->prepared_media_packet_);
+    player->prepared_media_packet_ = packet;
+    return;
   }
   player->prepared_media_packet_ = packet;
   player->texture_registrar_->MarkTextureFrameAvailable(player->texture_id_);

--- a/packages/video_player/tizen/src/video_player.cc
+++ b/packages/video_player/tizen/src/video_player.cc
@@ -49,22 +49,37 @@ static std::string StateToString(player_state_e state) {
   return ret;
 }
 
+bool VideoPlayer::IsValidMediaPacket(media_packet_h media_packet) {
+  tbm_surface_h surface;
+  int ret = media_packet_get_tbm_surface(media_packet, &surface);
+  if (ret != MEDIA_PACKET_ERROR_NONE) {
+    LOG_ERROR("get tbm surface failed, error: %d", ret);
+    return false;
+  }
+  return true;
+}
+
 FlutterDesktopGpuBuffer *VideoPlayer::ObtainGpuBuffer(size_t width,
                                                       size_t height) {
   std::lock_guard<std::mutex> lock(mutex_);
-  if (media_packet_ == nullptr) {
-    LOG_ERROR("Media packet  is null");
+  if (prepared_media_packet_ && !IsValidMediaPacket(prepared_media_packet_)) {
+    media_packet_destroy(prepared_media_packet_);
+    prepared_media_packet_ = nullptr;
+  }
+  if (using_media_packet_ && !IsValidMediaPacket(using_media_packet_)) {
+    media_packet_destroy(using_media_packet_);
+    using_media_packet_ = nullptr;
+  }
+  if (!prepared_media_packet_ && !using_media_packet_) {
+    LOG_ERROR("No vaild media packet");
     return nullptr;
+  }
+  if (prepared_media_packet_ && !using_media_packet_) {
+    using_media_packet_ = prepared_media_packet_;
+    prepared_media_packet_ = nullptr;
   }
   tbm_surface_h surface;
-  int ret = media_packet_get_tbm_surface(media_packet_, &surface);
-  if (ret != MEDIA_PACKET_ERROR_NONE) {
-    LOG_ERROR("media_packet_get_tbm_surface failed, error: %d", ret);
-    media_packet_destroy(media_packet_);
-    media_packet_ = nullptr;
-    return nullptr;
-  }
-
+  media_packet_get_tbm_surface(using_media_packet_, &surface);
   flutter_desktop_gpu_buffer_->buffer = surface;
   flutter_desktop_gpu_buffer_->width = width;
   flutter_desktop_gpu_buffer_->height = height;
@@ -73,9 +88,9 @@ FlutterDesktopGpuBuffer *VideoPlayer::ObtainGpuBuffer(size_t width,
 
 void VideoPlayer::Destruct(void *buffer) {
   std::lock_guard<std::mutex> lock(mutex_);
-  if (media_packet_) {
-    media_packet_destroy(media_packet_);
-    media_packet_ = nullptr;
+  if (using_media_packet_) {
+    media_packet_destroy(using_media_packet_);
+    using_media_packet_ = nullptr;
   }
 }
 
@@ -308,6 +323,16 @@ void VideoPlayer::dispose() {
     player_ = 0;
   }
 
+  if (using_media_packet_) {
+    media_packet_destroy(using_media_packet_);
+    using_media_packet_ = nullptr;
+  }
+
+  if (prepared_media_packet_) {
+    media_packet_destroy(prepared_media_packet_);
+    prepared_media_packet_ = nullptr;
+  }
+
   if (texture_registrar_) {
     texture_registrar_->UnregisterTexture(texture_id_);
     texture_registrar_ = nullptr;
@@ -522,11 +547,10 @@ void VideoPlayer::onErrorOccurred(int code, void *data) {
 void VideoPlayer::onVideoFrameDecoded(media_packet_h packet, void *data) {
   VideoPlayer *player = (VideoPlayer *)data;
   std::lock_guard<std::mutex> lock(player->mutex_);
-  if (player->media_packet_) {
-    LOG_INFO("Render not finished");
-    media_packet_destroy(packet);
-    return;
+  if (player->prepared_media_packet_) {
+    LOG_INFO("prepared_media_packet_ not null");
+    media_packet_destroy(player->prepared_media_packet_);
   }
-  player->media_packet_ = packet;
+  player->prepared_media_packet_ = packet;
   player->texture_registrar_->MarkTextureFrameAvailable(player->texture_id_);
 }

--- a/packages/video_player/tizen/src/video_player.cc
+++ b/packages/video_player/tizen/src/video_player.cc
@@ -49,7 +49,7 @@ static std::string StateToString(player_state_e state) {
   return ret;
 }
 
-bool VideoPlayer::IsValidMediaPacket(media_packet_h media_packet) {
+bool VideoPlayer::isValidMediaPacket(media_packet_h media_packet) {
   tbm_surface_h surface;
   int ret = media_packet_get_tbm_surface(media_packet, &surface);
   if (ret != MEDIA_PACKET_ERROR_NONE) {
@@ -62,11 +62,11 @@ bool VideoPlayer::IsValidMediaPacket(media_packet_h media_packet) {
 FlutterDesktopGpuBuffer *VideoPlayer::ObtainGpuBuffer(size_t width,
                                                       size_t height) {
   std::lock_guard<std::mutex> lock(mutex_);
-  if (prepared_media_packet_ && !IsValidMediaPacket(prepared_media_packet_)) {
+  if (prepared_media_packet_ && !isValidMediaPacket(prepared_media_packet_)) {
     media_packet_destroy(prepared_media_packet_);
     prepared_media_packet_ = nullptr;
   }
-  if (using_media_packet_ && !IsValidMediaPacket(using_media_packet_)) {
+  if (using_media_packet_ && !isValidMediaPacket(using_media_packet_)) {
     media_packet_destroy(using_media_packet_);
     using_media_packet_ = nullptr;
   }

--- a/packages/video_player/tizen/src/video_player.h
+++ b/packages/video_player/tizen/src/video_player.h
@@ -62,7 +62,7 @@ class VideoPlayer {
   std::mutex mutex_;
   SeekCompletedCb on_seek_completed_;
   media_packet_h prepared_media_packet_ = nullptr;
-  media_packet_h using_media_packet_ = nullptr;
+  media_packet_h current_media_packet_ = nullptr;
 };
 
 #endif  // VIDEO_PLAYER_H_

--- a/packages/video_player/tizen/src/video_player.h
+++ b/packages/video_player/tizen/src/video_player.h
@@ -40,6 +40,7 @@ class VideoPlayer {
   void sendBufferingEnd();
   FlutterDesktopGpuBuffer *ObtainGpuBuffer(size_t width, size_t height);
   void Destruct(void *buffer);
+  bool IsValidMediaPacket(media_packet_h media_packet);
 
   static void onPrepared(void *data);
   static void onBuffering(int percent, void *data);
@@ -59,8 +60,9 @@ class VideoPlayer {
   std::unique_ptr<flutter::TextureVariant> texture_variant_;
   std::unique_ptr<FlutterDesktopGpuBuffer> flutter_desktop_gpu_buffer_;
   std::mutex mutex_;
-  media_packet_h media_packet_ = nullptr;
   SeekCompletedCb on_seek_completed_;
+  media_packet_h prepared_media_packet_ = nullptr;
+  media_packet_h using_media_packet_ = nullptr;
 };
 
 #endif  // VIDEO_PLAYER_H_

--- a/packages/video_player/tizen/src/video_player.h
+++ b/packages/video_player/tizen/src/video_player.h
@@ -40,7 +40,7 @@ class VideoPlayer {
   void sendBufferingEnd();
   FlutterDesktopGpuBuffer *ObtainGpuBuffer(size_t width, size_t height);
   void Destruct(void *buffer);
-  bool IsValidMediaPacket(media_packet_h media_packet);
+  bool isValidMediaPacket(media_packet_h media_packet);
 
   static void onPrepared(void *data);
   static void onBuffering(int percent, void *data);

--- a/packages/video_player/tizen/src/video_player.h
+++ b/packages/video_player/tizen/src/video_player.h
@@ -40,7 +40,7 @@ class VideoPlayer {
   void sendBufferingEnd();
   FlutterDesktopGpuBuffer *ObtainGpuBuffer(size_t width, size_t height);
   void Destruct(void *buffer);
-  bool isValidMediaPacket(media_packet_h media_packet);
+  bool IsValidMediaPacket(media_packet_h media_packet);
 
   static void onPrepared(void *data);
   static void onBuffering(int percent, void *data);


### PR DESCRIPTION
When flutter engine upgrade to 2.5.1, only call mark frame available
API can triggle previous frame destruction callback.
#250 