### PR TITLE
[flutter_tts] Fix bug and support setting speech volume

### DIFF
--- a/packages/flutter_tts/CHANGELOG.md
+++ b/packages/flutter_tts/CHANGELOG.md
@@ -8,8 +8,13 @@
 
 ## 1.1.0
 
-* All APIs now return valid values.(0 or 1, empty list, etc.)
+* All APIs now return valid values(0 or 1, empty list, etc.).
 
 ## 1.1.1
 
-* Fix calling onCancel in a successful situation and refactor native implementations
+* Fix calling onCancel in a successful situation and refactor native implementations.
+
+## 1.1.2
+
+* Fix a bug where `setLanguage()` wasn't invoked due to typo in "setLanguage".
+* Update flutter_tts to 3.2.2 in example app.

--- a/packages/flutter_tts/CHANGELOG.md
+++ b/packages/flutter_tts/CHANGELOG.md
@@ -19,3 +19,4 @@
 * Fix a bug where `setLanguage()` wasn't invoked due to typo in "setLanguage".
 * Update flutter_tts to 3.2.2 and update the example app.
 * Support `setVolume()`.
+* Minor cleanups.

--- a/packages/flutter_tts/CHANGELOG.md
+++ b/packages/flutter_tts/CHANGELOG.md
@@ -14,7 +14,8 @@
 
 * Fix calling onCancel in a successful situation and refactor native implementations.
 
-## 1.1.2
+## 1.2.0
 
 * Fix a bug where `setLanguage()` wasn't invoked due to typo in "setLanguage".
-* Update flutter_tts to 3.2.2 in example app.
+* Update flutter_tts to 3.2.2 and update the example app.
+* Support `setVolume()`.

--- a/packages/flutter_tts/README.md
+++ b/packages/flutter_tts/README.md
@@ -8,8 +8,8 @@ This package is not an _endorsed_ implementation of `flutter_tts`. Therefore, yo
 
 ```yaml
 dependencies:
-  flutter_tts: ^3.0.0
-  flutter_tts_tizen: ^1.1.1
+  flutter_tts: ^3.2.2
+  flutter_tts_tizen: ^1.1.2
 ```
 
 Then you can import `flutter_tts` in your Dart code:

--- a/packages/flutter_tts/README.md
+++ b/packages/flutter_tts/README.md
@@ -9,7 +9,7 @@ This package is not an _endorsed_ implementation of `flutter_tts`. Therefore, yo
 ```yaml
 dependencies:
   flutter_tts: ^3.2.2
-  flutter_tts_tizen: ^1.1.2
+  flutter_tts_tizen: ^1.2.0
 ```
 
 Then you can import `flutter_tts` in your Dart code:
@@ -29,3 +29,4 @@ The features supported by Tizen are as follows. Other features are not supported
  - [x] get languages
  - [x] set language
  - [x] set speech rate
+ - [x] set speech volume (requires privilege `http://tizen.org/privilege/volume.set` in `tizen_manifest.xml`)

--- a/packages/flutter_tts/example/lib/main.dart
+++ b/packages/flutter_tts/example/lib/main.dart
@@ -17,6 +17,7 @@ enum TtsState { playing, stopped, paused, continued }
 class _MyAppState extends State<MyApp> {
   late FlutterTts flutterTts;
   String? language;
+  double volume = 0.5;
   double pitch = 1.0;
   double rate = 0.5;
   String? _newVoiceText;
@@ -82,6 +83,7 @@ class _MyAppState extends State<MyApp> {
   Future<dynamic> _getLanguages() => flutterTts.getLanguages;
 
   Future _speak() async {
+    await flutterTts.setVolume(volume);
     await flutterTts.setSpeechRate(rate);
 
     if (_newVoiceText != null) {
@@ -216,8 +218,20 @@ class _MyAppState extends State<MyApp> {
 
   Widget _buildSliders() {
     return Column(
-      children: [_rate()],
+      children: [_volume(), _rate()],
     );
+  }
+
+  Widget _volume() {
+    return Slider(
+        value: volume,
+        onChanged: (newVolume) {
+          setState(() => volume = newVolume);
+        },
+        min: 0.0,
+        max: 1.0,
+        divisions: 10,
+        label: "Volume: $volume");
   }
 
   Widget _rate() {

--- a/packages/flutter_tts/example/pubspec.yaml
+++ b/packages/flutter_tts/example/pubspec.yaml
@@ -5,7 +5,7 @@ publish_to: "none"
 dependencies:
   flutter:
     sdk: flutter
-  flutter_tts: ^3.0.0
+  flutter_tts: ^3.2.2
   flutter_tts_tizen:
     path: ../
 

--- a/packages/flutter_tts/example/tizen/Runner.csproj
+++ b/packages/flutter_tts/example/tizen/Runner.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Tizen.NET.Sdk/1.1.5">
+﻿<Project Sdk="Tizen.NET.Sdk/1.1.6">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>

--- a/packages/flutter_tts/example/tizen/tizen-manifest.xml
+++ b/packages/flutter_tts/example/tizen/tizen-manifest.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest package="org.tizen.flutter_tts_tizen_example" version="1.0.0" api-version="4.0" xmlns="http://tizen.org/ns/packages">
     <profile name="common"/>
-    <ui-application appid="org.tizen.flutter_tts_tizen_example" exec="Runner.dll" type="dotnet" multiple="false" taskmanage="true" nodisplay="false" api-version="4" launch_mode="single">
+    <ui-application appid="org.tizen.flutter_tts_tizen_example" exec="Runner.dll" type="dotnet" multiple="false" taskmanage="true" nodisplay="false" api-version="4">
         <label>flutter_tts_tizen_example</label>
         <icon>ic_launcher.png</icon>
         <metadata key="http://tizen.org/metadata/prefer_dotnet_aot" value="true"/>

--- a/packages/flutter_tts/example/tizen/tizen-manifest.xml
+++ b/packages/flutter_tts/example/tizen/tizen-manifest.xml
@@ -8,4 +8,7 @@
         <metadata key="http://tizen.org/metadata/direct-launch" value="yes"/>
     </ui-application>
     <feature name="http://tizen.org/feature/screen.size.all"/>
+    <privileges>
+        <privilege>http://tizen.org/privilege/volume.set</privilege>
+    </privileges>
 </manifest>

--- a/packages/flutter_tts/pubspec.yaml
+++ b/packages/flutter_tts/pubspec.yaml
@@ -2,7 +2,7 @@ name: flutter_tts_tizen
 description: The tizen implementation of flutter_tts plugin.
 homepage: https://github.com/flutter-tizen/plugins
 repository: https://github.com/flutter-tizen/plugins/tree/master/packages/flutter_tts
-version: 1.1.1
+version: 1.1.2
 
 dependencies:
   flutter:

--- a/packages/flutter_tts/pubspec.yaml
+++ b/packages/flutter_tts/pubspec.yaml
@@ -2,7 +2,7 @@ name: flutter_tts_tizen
 description: The tizen implementation of flutter_tts plugin.
 homepage: https://github.com/flutter-tizen/plugins
 repository: https://github.com/flutter-tizen/plugins/tree/master/packages/flutter_tts
-version: 1.1.2
+version: 1.2.0
 
 dependencies:
   flutter:

--- a/packages/flutter_tts/tizen/src/flutter_tts_tizen_plugin.cc
+++ b/packages/flutter_tts/tizen/src/flutter_tts_tizen_plugin.cc
@@ -146,7 +146,7 @@ class FlutterTtsTizenPlugin : public flutter::Plugin {
         return;
       }
       result->Success(flutter::EncodableValue(0));
-    } else if (method_name.compare("setLanguages") == 0) {
+    } else if (method_name.compare("setLanguage") == 0) {
       if (std::holds_alternative<std::string>(arguments)) {
         std::string language = std::move(std::get<std::string>(arguments));
         tts_->SetDefaultLanguage(language);

--- a/packages/flutter_tts/tizen/src/flutter_tts_tizen_plugin.cc
+++ b/packages/flutter_tts/tizen/src/flutter_tts_tizen_plugin.cc
@@ -73,9 +73,12 @@ class FlutterTtsTizenPlugin : public flutter::Plugin {
       const flutter::MethodCall<flutter::EncodableValue> &method_call,
       std::unique_ptr<flutter::MethodResult<flutter::EncodableValue>> result) {
     // Keep in sync with the return values implemented in:
-    // https://github.com/dlutton/flutter_tts/blob/master/android/src/main/java/com/tundralabs/fluttertts/FlutterTtsPlugin.java
-    // The API specification is vague, and there is no detailed description of
-    // the return value, so I mimic the Android implementation.
+    // https://github.com/dlutton/flutter_tts/blob/master/android/src/main/java/com/tundralabs/fluttertts/FlutterTtsPlugin.java.
+    // In principle, MethodResult was designed to call MethodResult.Error() to
+    // notify the dart code of any method call failures from the host platform.
+    // However, in the case of flutter_tts, it expects a return value 0 on
+    // failure(and value 1 on success). Therefore in the scope of this plugin,
+    // we call result->Success(flutter::EncodableValue(0)) to notify errors.
 
     const auto method_name = method_call.method_name();
     const auto &arguments = *method_call.arguments();
@@ -137,7 +140,6 @@ class FlutterTtsTizenPlugin : public flutter::Plugin {
       map.insert(std::pair<flutter::EncodableValue, flutter::EncodableValue>(
           "platform", "tizen"));
       result->Success(flutter::EncodableValue(std::move(map)));
-      return;
     } else if (method_name.compare("setSpeechRate") == 0) {
       if (std::holds_alternative<double>(arguments)) {
         int speed = (int)std::get<double>(arguments);
@@ -171,7 +173,6 @@ class FlutterTtsTizenPlugin : public flutter::Plugin {
       result->Success(flutter::EncodableValue(0));
     } else {
       result->Error("-1", "Not supported method");
-      return;
     }
   }
 

--- a/packages/flutter_tts/tizen/src/flutter_tts_tizen_plugin.cc
+++ b/packages/flutter_tts/tizen/src/flutter_tts_tizen_plugin.cc
@@ -160,6 +160,15 @@ class FlutterTtsTizenPlugin : public flutter::Plugin {
         list.push_back(flutter::EncodableValue(language));
       }
       result->Success(flutter::EncodableValue(list));
+    } else if (method_name.compare("setVolume") == 0) {
+      if (std::holds_alternative<double>(arguments)) {
+        double rate = std::get<double>(arguments);
+        if (tts_->SetVolume(rate)) {
+          result->Success(flutter::EncodableValue(1));
+          return;
+        }
+      }
+      result->Success(flutter::EncodableValue(0));
     } else {
       result->Error("-1", "Not supported method");
       return;

--- a/packages/flutter_tts/tizen/src/text_to_speech.cc
+++ b/packages/flutter_tts/tizen/src/text_to_speech.cc
@@ -166,8 +166,8 @@ bool TextToSpeech::SetVolume(double volume_rate) {
   return true;
 }
 
-bool TextToSpeech::GetSpeedRange(int *min, int *nomal, int *max) {
-  int ret = tts_get_speed_range(tts_, min, nomal, max);
+bool TextToSpeech::GetSpeedRange(int *min, int *normal, int *max) {
+  int ret = tts_get_speed_range(tts_, min, normal, max);
   if (ret != TTS_ERROR_NONE) {
     LOG_ERROR("[TTS] tts_get_speed_range failed: %s", get_error_message(ret));
     return false;

--- a/packages/flutter_tts/tizen/src/text_to_speech.h
+++ b/packages/flutter_tts/tizen/src/text_to_speech.h
@@ -72,6 +72,8 @@ class TextToSpeech {
 
   bool Pause();
 
+  bool SetVolume(double volume_rate);
+
   bool GetSpeedRange(int *min, int *nomal, int *max);
 
   void SetTtsSpeed(int speed) { tts_speed_ = speed; }
@@ -87,12 +89,19 @@ class TextToSpeech {
   void HandleAwaitSpeakCompletion(tts_state_e previous, tts_state_e current);
   void ClearUttId() { utt_id_ = 0; }
 
+  void SwitchVolumeOnStateChange(tts_state_e previous, tts_state_e current);
+  bool SetSpeechVolumeInternal(int volume);
+  int GetSpeechVolumeInternal();
+
   tts_h tts_ = nullptr;
   tts_state_e state_ = TTS_STATE_CREATED;
   std::string default_language_;
   int default_voice_type_ = TTS_VOICE_TYPE_AUTO;
   int tts_speed_ = TTS_SPEED_AUTO;
   int utt_id_ = 0;
+  int tts_volume_ = 0;
+  int system_volume_ = 0;
+  int system_max_volume_ = 0;
   std::vector<std::string> supported_lanaguages_;
 
   OnStateChangedCallback on_state_changed_;

--- a/packages/flutter_tts/tizen/src/text_to_speech.h
+++ b/packages/flutter_tts/tizen/src/text_to_speech.h
@@ -74,7 +74,7 @@ class TextToSpeech {
 
   bool SetVolume(double volume_rate);
 
-  bool GetSpeedRange(int *min, int *nomal, int *max);
+  bool GetSpeedRange(int *min, int *normal, int *max);
 
   void SetTtsSpeed(int speed) { tts_speed_ = speed; }
 
@@ -94,7 +94,6 @@ class TextToSpeech {
   int GetSpeechVolumeInternal();
 
   tts_h tts_ = nullptr;
-  tts_state_e state_ = TTS_STATE_CREATED;
   std::string default_language_;
   int default_voice_type_ = TTS_VOICE_TYPE_AUTO;
   int tts_speed_ = TTS_SPEED_AUTO;


### PR DESCRIPTION
closes #257.

TODO:
- [x] Support `set speech volume`. 
    `tts.h` doesn't have apis that can control the tts volume, I could increase the volume with sound manager but I'm looking for something that wouldn't affect other systems. -> tts internally acquire and relinquish focus on voice audio stream.