### PR TITLE
[integration_test] Version bump to 2.0.1

### DIFF
--- a/packages/integration_test/CHANGELOG.md
+++ b/packages/integration_test/CHANGELOG.md
@@ -1,16 +1,20 @@
 ## 1.0.0
 
-* Initial release
+* Initial release.
 
 ## 1.0.1
 
-* Update integration_test to 1.0.1
-* Migrate to Tizen 4.0
+* Update integration_test to 1.0.1.
+* Migrate to Tizen 4.0.
 
 ## 2.0.0
 
-* Update Dart and Flutter SDK constraints
-* Update Flutter copyright information
-* Update example and integration_test
-* Remove unnecessary test files for web
-* Organize dev_dependencies
+* Update Dart and Flutter SDK constraints.
+* Update Flutter copyright information.
+* Update the example app and integration_test.
+* Remove unnecessary test files for web.
+* Organize dev_dependencies.
+
+## 2.0.1
+
+* Change the project type to `staticLib`.

--- a/packages/integration_test/README.md
+++ b/packages/integration_test/README.md
@@ -10,7 +10,7 @@ This package is not an _endorsed_ implementation of `integration_test`. Therefor
 dev_dependencies:
   integration_test:
     sdk: flutter
-  integration_test_tizen: ^2.0.0
+  integration_test_tizen: ^2.0.1
 ```
 
 Then you can import `integration_test` in your Dart code:

--- a/packages/integration_test/example/integration_test/example_test.dart
+++ b/packages/integration_test/example/integration_test/example_test.dart
@@ -9,8 +9,6 @@
 // gestures. You can also use WidgetTester to find child widgets in the widget
 // tree, read text, and verify that the values of widget properties are correct.
 
-// @dart=2.9
-
 import 'dart:io' show Platform;
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -38,7 +36,7 @@ void main() {
         find.byWidgetPredicate(
           (Widget widget) =>
               widget is Text &&
-              widget.data.startsWith('Platform: ${Platform.operatingSystem}'),
+              widget.data!.startsWith('Platform: ${Platform.operatingSystem}'),
         ),
         findsOneWidget,
       );

--- a/packages/integration_test/example/test_driver/integration_test.dart
+++ b/packages/integration_test/example/test_driver/integration_test.dart
@@ -1,5 +1,3 @@
-// @dart=2.9
-
 import 'package:integration_test/integration_test_driver.dart';
 
 Future<void> main() => integrationDriver();

--- a/packages/integration_test/example/tizen/Runner.csproj
+++ b/packages/integration_test/example/tizen/Runner.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Tizen.NET.Sdk/1.1.5">
+﻿<Project Sdk="Tizen.NET.Sdk/1.1.7">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>

--- a/packages/integration_test/example/tizen/tizen-manifest.xml
+++ b/packages/integration_test/example/tizen/tizen-manifest.xml
@@ -1,11 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest package="org.tizen.integration_test_example" version="1.0.0" api-version="4.0" xmlns="http://tizen.org/ns/packages">
     <profile name="common"/>
-    <ui-application appid="org.tizen.integration_test_example" exec="Runner.dll" type="dotnet" multiple="false" taskmanage="true" nodisplay="false" api-version="4" launch_mode="single">
+    <ui-application appid="org.tizen.integration_test_example" exec="Runner.dll" type="dotnet" multiple="false" taskmanage="true" nodisplay="false" api-version="4">
         <label>integration_test_example</label>
         <icon>ic_launcher.png</icon>
         <metadata key="http://tizen.org/metadata/prefer_dotnet_aot" value="true"/>
-        <metadata key="http://tizen.org/metadata/direct-launch" value="yes"/>
     </ui-application>
     <feature name="http://tizen.org/feature/screen.size.all"/>
 </manifest>

--- a/packages/integration_test/pubspec.yaml
+++ b/packages/integration_test/pubspec.yaml
@@ -2,7 +2,7 @@ name: integration_test_tizen
 description: Tizen implementation of the integration_test plugin
 homepage: https://github.com/flutter-tizen/plugins
 repository: https://github.com/flutter-tizen/plugins/tree/master/packages/integration_test
-version: 2.0.0
+version: 2.0.1
 
 flutter:
   plugin:

--- a/packages/integration_test/tizen/src/integration_test_plugin.cc
+++ b/packages/integration_test/tizen/src/integration_test_plugin.cc
@@ -4,9 +4,7 @@
 #include <flutter/plugin_registrar.h>
 #include <flutter/standard_method_codec.h>
 
-#include <map>
 #include <memory>
-#include <sstream>
 #include <string>
 
 #include "log.h"
@@ -37,8 +35,10 @@ class IntegrationTestPlugin : public flutter::Plugin {
   void HandleMethodCall(
       const flutter::MethodCall<flutter::EncodableValue> &method_call,
       std::unique_ptr<flutter::MethodResult<flutter::EncodableValue>> result) {
-    if (method_call.method_name().compare("allTestsFinished") == 0) {
-      auto &arguments = *method_call.arguments();
+    const auto &method_name = method_call.method_name();
+
+    if (method_name == "allTestsFinished") {
+      const auto &arguments = *method_call.arguments();
       if (std::holds_alternative<flutter::EncodableMap>(arguments)) {
         flutter::EncodableMap map = std::get<flutter::EncodableMap>(arguments);
         flutter::EncodableValue results =


### PR DESCRIPTION
It's been 9 months since the last release of this package and we need to publish a new release to apply https://github.com/flutter-tizen/plugins/pull/175 and suppress warnings generated when building other plugins that depend on this package.