### PR TITLE
[path_provider] Update path_provider to 2.0.7

### DIFF
--- a/packages/path_provider/CHANGELOG.md
+++ b/packages/path_provider/CHANGELOG.md
@@ -1,33 +1,38 @@
 ## 1.0.0
 
-* Initial release
+* Initial release.
 
 ## 1.0.1
 
-* Update path_provider to 1.6.27
-* Update platform interface to 1.0.4
-* Remove permission_handler_tizen dependency temporarily
-* Migrate to Tizen 4.0
+* Update path_provider to 1.6.27.
+* Update path_provider_platform_interface to 1.0.4.
+* Remove permission_handler_tizen dependency temporarily.
+* Migrate to Tizen 4.0.
 
 ## 1.0.2
 
-* Use `PlatformException` instead of a plugin-specific exception type
-  (`StorageException`)
+* Use `PlatformException` instead of a plugin-specific exception type.
 
 ## 2.0.0
 
-* Update Dart and Flutter SDK constraints
-* Update Flutter copyright information
-* Update example and integration_test
-* Update platform interface to 2.0.1
-* Update permission_handler to 6.1.1
-* Organize dev_dependencies
-* Migrate to ffi 1.0.0
-* Migrate to null safety
+* Update Dart and Flutter SDK constraints.
+* Update Flutter copyright information.
+* Update the example app and integration_test.
+* Update path_provider_platform_interface to 2.0.1.
+* Update permission_handler to 6.1.1.
+* Organize dev_dependencies.
+* Migrate to ffi 1.0.0.
+* Migrate to null safety.
 
 ## 2.0.1
 
-* Update path_provider to 2.0.2
-* Remove permission_handler dependency
-* Comment out integration tests that depend on permission_handler
-* Migrate example test code to null safety
+* Update path_provider to 2.0.2.
+* Remove permission_handler dependency.
+* Comment out integration tests that depend on permission_handler.
+* Migrate integration_test to null safety.
+
+## 2.0.2
+
+* Update path_provider to 2.0.7.
+* Unsupport `getDownloadsDirectory`.
+* Unskip skipped integration tests.

--- a/packages/path_provider/README.md
+++ b/packages/path_provider/README.md
@@ -8,8 +8,8 @@ This package is not an _endorsed_ implementation of `path_provider`. Therefore, 
 
 ```yaml
 dependencies:
-  path_provider: ^2.0.2
-  path_provider_tizen: ^2.0.1
+  path_provider: ^2.0.7
+  path_provider_tizen: ^2.0.2
 ```
 
 Then you can import `path_provider` in your Dart code:
@@ -20,19 +20,20 @@ import 'package:path_provider/path_provider.dart';
 
 For detailed usage, see https://github.com/flutter/plugins/tree/master/packages/path_provider/path_provider#usage.
 
-## Notes
+## Supported APIs
 
-- On Tizen, `getExternalStorageDirectories` will return internal storage paths (such as `/home/owner/media/Music`) unlike on Android where the function returns external storage (separate partition or SD card) paths.
-- To access paths returned by `getExternalStorageDirectory` and `getExternalCacheDirectories`, you will need an SD card inserted to your Tizen device.
+- [x] `getTemporaryDirectory` (returns the app's cache directory path)
+- [x] `getApplicationSupportDirectory` (returns the app's data directory path)
+- [ ] `getLibraryDirectory` (iOS-only)
+- [x] `getApplicationDocumentsDirectory` (returns the app's data directory path)
+- [x] `getExternalStorageDirectory` (requires an SD card)
+- [x] `getExternalCacheDirectories` (requires an SD card)
+- [x] `getExternalStorageDirectories` (returns shared media library paths such as `/home/owner/media/Music`)
+- [ ] `getDownloadsDirectory` (desktop-only)
 
 ## Required privileges
 
-- To access paths returned by
-
-  - `getExternalStorageDirectories`
-  - `getDownloadsDirectory`
-
-  add below lines under the `<manifest>` section in your `tizen-manifest.xml` file,
+- To access paths returned by `getExternalStorageDirectories`, add below lines under the `<manifest>` section in your `tizen-manifest.xml` file,
 
   ```xml
   <privileges>

--- a/packages/path_provider/example/integration_test/path_provider_test.dart
+++ b/packages/path_provider/example/integration_test/path_provider_test.dart
@@ -74,35 +74,15 @@ void main() {
         final Future<List<Directory>?> result =
             getExternalStorageDirectories(type: null);
         expect(result, throwsA(isInstanceOf<UnsupportedError>()));
-      } else if (Platform.isAndroid) {
+      } else {
         final List<Directory>? directories =
             await getExternalStorageDirectories(type: type);
         expect(directories, isNotNull);
         for (final Directory result in directories!) {
           _verifySampleFile(result, '$type');
         }
-      } else {
-        // Tizen platform
-        // Permissions for accessing media directories are granted
-        // for TV by default, but not for wearables.
-        // But the example app can't depend on permission_handler because
-        // TV doesn't support permission_handler:
-        //   https://github.com/flutter-tizen/plugins#device-limitations
-        // Uncomment and remove the skip option when it's possible
-        // to choose device types in testing.
-
-        // if (!await Permission.mediaLibrary.isGranted) {
-        //   await Permission.mediaLibrary.request();
-        // }
-
-        // final List<Directory>? directories =
-        //     await getExternalStorageDirectories(type: type);
-        // expect(directories, isNotNull);
-        // for (final Directory result in directories!) {
-        //   _verifySampleFile(result, '$type');
-        // }
       }
-    }, skip: true);
+    });
   }
 }
 

--- a/packages/path_provider/example/lib/main.dart
+++ b/packages/path_provider/example/lib/main.dart
@@ -4,7 +4,6 @@
 
 // ignore_for_file: public_member_api_docs
 
-import 'dart:async';
 import 'dart:io';
 
 import 'package:flutter/material.dart';

--- a/packages/path_provider/example/pubspec.yaml
+++ b/packages/path_provider/example/pubspec.yaml
@@ -5,7 +5,7 @@ publish_to: "none"
 dependencies:
   flutter:
     sdk: flutter
-  path_provider: ^2.0.2
+  path_provider: ^2.0.7
   path_provider_tizen:
     path: ../
 

--- a/packages/path_provider/example/tizen/Runner.csproj
+++ b/packages/path_provider/example/tizen/Runner.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Tizen.NET.Sdk/1.1.5">
+﻿<Project Sdk="Tizen.NET.Sdk/1.1.7">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>

--- a/packages/path_provider/example/tizen/tizen-manifest.xml
+++ b/packages/path_provider/example/tizen/tizen-manifest.xml
@@ -1,11 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest package="org.tizen.path_provider_tizen_example" version="1.0.0" api-version="4.0" xmlns="http://tizen.org/ns/packages">
     <profile name="common"/>
-    <ui-application appid="org.tizen.path_provider_tizen_example" exec="Runner.dll" type="dotnet" multiple="false" taskmanage="true" nodisplay="false" api-version="4" launch_mode="single">
+    <ui-application appid="org.tizen.path_provider_tizen_example" exec="Runner.dll" type="dotnet" multiple="false" taskmanage="true" nodisplay="false" api-version="4">
         <label>path_provider_tizen_example</label>
         <icon>ic_launcher.png</icon>
         <metadata key="http://tizen.org/metadata/prefer_dotnet_aot" value="true"/>
-        <metadata key="http://tizen.org/metadata/direct-launch" value="yes"/>
     </ui-application>
     <feature name="http://tizen.org/feature/screen.size.all"/>
     <privileges>

--- a/packages/path_provider/lib/path_provider_tizen.dart
+++ b/packages/path_provider/lib/path_provider_tizen.dart
@@ -71,8 +71,4 @@ class PathProviderPlugin extends PathProviderPlatform {
     }
     return <String>[await storage.getDirectory(type: dirType)];
   }
-
-  @override
-  Future<String> getDownloadsPath() async =>
-      await storage.getDirectory(type: StorageDirectoryType.downloads);
 }

--- a/packages/path_provider/pubspec.yaml
+++ b/packages/path_provider/pubspec.yaml
@@ -2,17 +2,16 @@ name: path_provider_tizen
 description: Tizen implementation of the path_provider plugin
 homepage: https://github.com/flutter-tizen/plugins
 repository: https://github.com/flutter-tizen/plugins/tree/master/packages/path_provider
-version: 2.0.1
+version: 2.0.2
 
 flutter:
   plugin:
     platforms:
       tizen:
         dartPluginClass: PathProviderPlugin
-        fileName: path_provider_tizen.dart
 
 dependencies:
-  ffi: ^1.0.0
+  ffi: ^1.1.2
   flutter:
     sdk: flutter
   path_provider_platform_interface: ^2.0.1

--- a/tools/recipe.yaml
+++ b/tools/recipe.yaml
@@ -12,7 +12,7 @@ plugins:
   messageport: ["wearable-5.5", "tv-6.0"]
   network_info_plus: []
   package_info_plus: ["wearable-5.5", "tv-6.0"]
-  path_provider: ["wearable-5.5", "tv-6.0"]
+  path_provider: ["tv-6.0"]
   permission_handler: ["wearable-5.5"]
   sensors_plus: ["wearable-5.5"]
   share_plus: ["wearable-5.5"]


### PR DESCRIPTION
`getDownloadsDirectory` has been removed because it is only relevant on desktop platforms. Use `getExternalStorageDirectories` with `StorageDirectory.downloads` as argument instead.