### PR TITLE
[sensors_plus] Increase the sampling rate

### DIFF
--- a/packages/sensors_plus/CHANGELOG.md
+++ b/packages/sensors_plus/CHANGELOG.md
@@ -1,7 +1,14 @@
 ## 1.0.0
 
-* Initial release
+* Initial release.
 
 ## 1.0.1
 
-* Fix bug with EventChannel
+* Fix bug with EventChannel.
+
+## 1.1.0
+
+* Update sensors_plus to 1.2.1.
+* Port to use platform interface.
+* Set the sampling interval to 60 ms.
+* Update the example app.

--- a/packages/sensors_plus/README.md
+++ b/packages/sensors_plus/README.md
@@ -10,8 +10,8 @@ This package is not an _endorsed_ implementation of 'sensors_plus'. Therefore, y
 
 ```yaml
 dependencies:
-  sensors_plus: ^1.0.0
-  sensors_plus_tizen: ^1.0.1
+  sensors_plus: ^1.2.1
+  sensors_plus_tizen: ^1.1.0
 ```
 
 Then you can import `sensors_plus` in your Dart code:
@@ -20,10 +20,25 @@ Then you can import `sensors_plus` in your Dart code:
 import 'package:sensors_plus/sensors_plus.dart';
 ```
 
-For detailed usage, see https://github.com/fluttercommunity/plus_plugins/tree/main/packages/sensors_plus/sensors_plus#usage.
+For detailed usage, see https://pub.dev/packages/sensors_plus#usage.
 
 ## Supported devices
 
-This plugin is supported on these types of devices:
+- Galaxy Watch series (running Tizen 4.0 or later)
 
-- Galaxy Watch (running Tizen 4.0 or later)
+## Supported APIs
+
+- [x] `accelerometerEvents` (maps to [`SENSOR_ACCELEROMETER`](https://docs.tizen.org/application/native/guides/location-sensors/device-sensors/#accelerometer))
+- [x] `gyroscopeEvents` (maps to [`SENSOR_GYROSCOPE`](https://docs.tizen.org/application/native/guides/location-sensors/device-sensors/#gyroscope))
+- [x] `userAccelerometerEvents` (maps to [`SENSOR_LINEAR_ACCELERATION`](https://docs.tizen.org/application/native/guides/location-sensors/device-sensors/#linear-acceleration-sensor))
+- [ ] `magnetometerEvents` (no supported devices)
+
+## Notes
+
+You need to declare one or more of the following features in your `tizen-manifest.xml` if you plan to release your app on the app store (to enable [feature-based filtering](https://docs.tizen.org/application/native/tutorials/details/app-filtering)).
+
+```xml
+<feature name="http://tizen.org/feature/sensor.accelerometer"/>
+<feature name="http://tizen.org/feature/sensor.gyroscope"/>
+<feature name="http://tizen.org/feature/sensor.linear_acceleration"/>
+```

--- a/packages/sensors_plus/example/lib/main.dart
+++ b/packages/sensors_plus/example/lib/main.dart
@@ -46,6 +46,7 @@ class _MyHomePageState extends State<MyHomePage> {
   List<double>? _accelerometerValues;
   List<double>? _userAccelerometerValues;
   List<double>? _gyroscopeValues;
+  List<double>? _magnetometerValues;
   final _streamSubscriptions = <StreamSubscription<dynamic>>[];
 
   @override
@@ -57,6 +58,8 @@ class _MyHomePageState extends State<MyHomePage> {
     final userAccelerometer = _userAccelerometerValues
         ?.map((double v) => v.toStringAsFixed(1))
         .toList();
+    final magnetometer =
+        _magnetometerValues?.map((double v) => v.toStringAsFixed(1)).toList();
 
     return Scaffold(
       appBar: AppBar(
@@ -108,6 +111,15 @@ class _MyHomePageState extends State<MyHomePage> {
               ],
             ),
           ),
+          Padding(
+            padding: const EdgeInsets.all(16.0),
+            child: Row(
+              mainAxisAlignment: MainAxisAlignment.spaceBetween,
+              children: <Widget>[
+                Text('Magnetometer: $magnetometer'),
+              ],
+            ),
+          ),
         ],
       ),
     );
@@ -147,6 +159,15 @@ class _MyHomePageState extends State<MyHomePage> {
         (UserAccelerometerEvent event) {
           setState(() {
             _userAccelerometerValues = <double>[event.x, event.y, event.z];
+          });
+        },
+      ),
+    );
+    _streamSubscriptions.add(
+      magnetometerEvents.listen(
+        (MagnetometerEvent event) {
+          setState(() {
+            _magnetometerValues = <double>[event.x, event.y, event.z];
           });
         },
       ),

--- a/packages/sensors_plus/example/pubspec.yaml
+++ b/packages/sensors_plus/example/pubspec.yaml
@@ -5,7 +5,7 @@ publish_to: "none"
 dependencies:
   flutter:
     sdk: flutter
-  sensors_plus: ^1.0.0
+  sensors_plus: ^1.2.1
   sensors_plus_tizen:
     path: ../
 

--- a/packages/sensors_plus/example/test_driver/integration_test.dart
+++ b/packages/sensors_plus/example/test_driver/integration_test.dart
@@ -1,5 +1,3 @@
-// @dart=2.9
-
 import 'package:integration_test/integration_test_driver.dart';
 
 Future<void> main() => integrationDriver();

--- a/packages/sensors_plus/example/tizen/Runner.csproj
+++ b/packages/sensors_plus/example/tizen/Runner.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Tizen.NET.Sdk/1.1.5">
+﻿<Project Sdk="Tizen.NET.Sdk/1.1.7">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>

--- a/packages/sensors_plus/example/tizen/tizen-manifest.xml
+++ b/packages/sensors_plus/example/tizen/tizen-manifest.xml
@@ -1,11 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest package="org.tizen.sensors_plus_example" version="1.0.0" api-version="4.0" xmlns="http://tizen.org/ns/packages">
-    <profile name="common"/>
-    <ui-application appid="org.tizen.sensors_plus_example" exec="Runner.dll" type="dotnet" multiple="false" taskmanage="true" nodisplay="false" api-version="4" launch_mode="single">
+    <profile name="wearable"/>
+    <ui-application appid="org.tizen.sensors_plus_example" exec="Runner.dll" type="dotnet" multiple="false" taskmanage="true" nodisplay="false" api-version="4">
         <label>sensors_plus_example</label>
         <icon>ic_launcher.png</icon>
         <metadata key="http://tizen.org/metadata/prefer_dotnet_aot" value="true"/>
-        <metadata key="http://tizen.org/metadata/direct-launch" value="yes"/>
     </ui-application>
     <feature name="http://tizen.org/feature/screen.size.all"/>
 </manifest>

--- a/packages/sensors_plus/pubspec.yaml
+++ b/packages/sensors_plus/pubspec.yaml
@@ -2,7 +2,7 @@ name: sensors_plus_tizen
 description: Tizen implementation of the sensors plugin
 homepage: https://github.com/flutter-tizen/plugins
 repository: https://github.com/flutter-tizen/plugins/tree/master/packages/sensors_plus
-version: 1.0.1
+version: 1.1.0
 
 flutter:
   plugin:
@@ -14,6 +14,7 @@ flutter:
 dependencies:
   flutter:
     sdk: flutter
+  sensors_plus_platform_interface: ^1.1.0
 
 dev_dependencies:
   flutter_lints: ^1.0.4

--- a/packages/sensors_plus/tizen/src/sensors_plus_plugin.cc
+++ b/packages/sensors_plus/tizen/src/sensors_plus_plugin.cc
@@ -10,24 +10,17 @@
 #include <tizen.h>
 
 #include <functional>
-#include <map>
 #include <memory>
-#include <sstream>
 #include <string>
 
 #include "log.h"
-
-#define ACCELEROMETER_CHANNEL_NAME \
-  "dev.fluttercommunity.plus/sensors/accelerometer"
-#define GYROSCOPE_CHANNEL_NAME "dev.fluttercommunity.plus/sensors/gyroscope"
-#define USER_ACCELEROMETER_CHANNEL_NAME \
-  "dev.fluttercommunity.plus/sensors/user_accel"
 
 class Listener {
  public:
   Listener(
       std::unique_ptr<flutter::EventSink<flutter::EncodableValue>> &&event_sink)
       : event_sink_(std::move(event_sink)) {}
+
   bool Init(sensor_type_e type) {
     sensor_h sensor;
     int ret = sensor_get_default_sensor(type, &sensor);
@@ -50,7 +43,7 @@ class Listener {
     }
 
     int ret = sensor_listener_set_event_cb(
-        listener_, 1000,
+        listener_, 60,
         [](sensor_h sensor, sensor_event_s *event, void *user_data) {
           Listener *s = (Listener *)user_data;
           std::vector<double> list;
@@ -129,7 +122,8 @@ class SensorsPlusPlugin : public flutter::Plugin {
   void SetupEventChannels(flutter::PluginRegistrar *registrar) {
     accelerometer_channel_ =
         std::make_unique<flutter::EventChannel<flutter::EncodableValue>>(
-            registrar->messenger(), ACCELEROMETER_CHANNEL_NAME,
+            registrar->messenger(),
+            "dev.fluttercommunity.plus/sensors/accelerometer",
             &flutter::StandardMethodCodec::GetInstance());
     auto accelerometer_channel_handler =
         std::make_unique<flutter::StreamHandlerFunctions<>>(
@@ -158,7 +152,8 @@ class SensorsPlusPlugin : public flutter::Plugin {
 
     gyroscope_channel_ =
         std::make_unique<flutter::EventChannel<flutter::EncodableValue>>(
-            registrar->messenger(), GYROSCOPE_CHANNEL_NAME,
+            registrar->messenger(),
+            "dev.fluttercommunity.plus/sensors/gyroscope",
             &flutter::StandardMethodCodec::GetInstance());
     auto gyroscope_channel_handler =
         std::make_unique<flutter::StreamHandlerFunctions<>>(
@@ -186,7 +181,8 @@ class SensorsPlusPlugin : public flutter::Plugin {
 
     user_accel_channel_ =
         std::make_unique<flutter::EventChannel<flutter::EncodableValue>>(
-            registrar->messenger(), USER_ACCELEROMETER_CHANNEL_NAME,
+            registrar->messenger(),
+            "dev.fluttercommunity.plus/sensors/user_accel",
             &flutter::StandardMethodCodec::GetInstance());
     auto user_accel_handler =
         std::make_unique<flutter::StreamHandlerFunctions<>>(


### PR DESCRIPTION
- Set the sampling interval to 60 ms (same as Android's [`SENSOR_DELAY_UI`](https://developer.android.com/guide/topics/sensors/sensors_overview)) because the current 1000 ms is too large.
- Increase the frontend package version to 1.2.1.
- I didn't add support for the newly-added `magnetometerEvents` API because the magnetic sensor is available on none of Tizen devices available in the market.