### PR TITLE
Update links

### DIFF
--- a/packages/audioplayers/README.md
+++ b/packages/audioplayers/README.md
@@ -21,7 +21,7 @@ Then you can import `audioplayers` in your Dart code:
 import 'package:audioplayers/audioplayers.dart';
 ```
 
-For detailed usage, see https://github.com/luanpotter/audioplayers#usage.
+For detailed usage, see https://pub.dev/packages/audioplayers#usage.
 
 ## Required privileges
 

--- a/packages/battery/README.md
+++ b/packages/battery/README.md
@@ -20,7 +20,7 @@ Then you can import `battery` in your Dart code:
 import 'package:battery/battery.dart';
 ```
 
-For detailed usage, see https://github.com/flutter/plugins/tree/master/packages/battery/battery#usage.
+For detailed usage, see https://pub.dev/packages/battery#usage.
 
 ## Supported devices
 

--- a/packages/battery_plus/README.md
+++ b/packages/battery_plus/README.md
@@ -20,7 +20,7 @@ Then you can import `battery_plus` in your Dart code:
 import 'package:battery_plus/battery_plus.dart';
 ```
 
-For detailed usage, see https://github.com/fluttercommunity/plus_plugins/tree/main/packages/battery_plus/battery_plus#usage.
+For detailed usage, see https://pub.dev/packages/battery_plus#usage.
 
 ## Supported APIs
 

--- a/packages/camera/README.md
+++ b/packages/camera/README.md
@@ -35,7 +35,7 @@ Then you can import `camera` in your Dart code:
 import 'package:camera/camera.dart';
 ```
 
-For detailed usage, see https://github.com/flutter/plugins/tree/master/packages/camera/camera#example.
+For detailed usage, see https://pub.dev/packages/camera#example.
 
 ## Notes
 

--- a/packages/connectivity/README.md
+++ b/packages/connectivity/README.md
@@ -20,7 +20,7 @@ Then you can import `connectivity` in your Dart code:
 import 'package:connectivity/connectivity.dart';
 ```
 
-For detailed usage, see https://github.com/flutter/plugins/tree/master/packages/connectivity/connectivity#usage.
+For detailed usage, see https://pub.dev/packages/connectivity#usage.
 
 ## Required privileges
 

--- a/packages/flutter_tts/README.md
+++ b/packages/flutter_tts/README.md
@@ -20,7 +20,7 @@ Then you can import `flutter_tts` in your Dart code:
 import 'package:flutter_tts/flutter_tts.dart';
 ```
 
-For detailed usage, see https://github.com/dlutton/flutter_tts#usage.
+For detailed usage, see https://pub.dev/packages/flutter_tts#usage.
 
 ## Supported APIs
 

--- a/packages/geolocator/README.md
+++ b/packages/geolocator/README.md
@@ -20,7 +20,7 @@ Then you can import `geolocator` in your Dart code:
 import 'package:geolocator/geolocator.dart';
 ```
 
-For detailed usage, see https://github.com/Baseflow/flutter-geolocator/tree/master/geolocator#usage.
+For detailed usage, see https://pub.dev/packages/geolocator#usage.
 
 ## Required privileges
 

--- a/packages/image_picker/README.md
+++ b/packages/image_picker/README.md
@@ -23,7 +23,7 @@ final ImagePicker picker = ImagePicker();
 final XFile? image = await picker.pickImage(source: ImageSource.gallery);
 ```
 
-For detailed usage, see https://github.com/flutter/plugins/tree/master/packages/image_picker/image_picker#example.
+For detailed usage, see https://pub.dev/packages/image_picker#example.
 
 ## Supported devices
 

--- a/packages/integration_test/README.md
+++ b/packages/integration_test/README.md
@@ -21,4 +21,4 @@ Then you can import `integration_test` in your Dart code:
 import 'package:integration_test/integration_test.dart';
 ```
 
-For detailed usage, see https://github.com/flutter/flutter/tree/master/packages/integration_test#usage.
+For detailed usage, see https://pub.dev/packages/integration_test#usage.

--- a/packages/network_info_plus/README.md
+++ b/packages/network_info_plus/README.md
@@ -20,7 +20,7 @@ Then you can import `network_info_plus` in your Dart code:
 import 'package:network_info_plus/network_info_plus.dart';
 ```
 
-For detailed usage, see https://github.com/fluttercommunity/plus_plugins/tree/main/packages/network_info_plus/network_info_plus#usage.
+For detailed usage, see https://pub.dev/packages/network_info_plus#usage.
 
 ## Required privileges
 
@@ -32,4 +32,4 @@ To get network information using this plugin, add below lines under the `<manife
 </privileges>
 ```
 
-For details, see [Security and API Privileges](https://docs.tizen.org/application/dotnet/tutorials/sec-privileges).
+For detailed information on Tizen privileges, see [Tizen Docs: API Privileges](https://docs.tizen.org/application/dotnet/get-started/api-privileges).

--- a/packages/package_info/README.md
+++ b/packages/package_info/README.md
@@ -38,7 +38,7 @@ PackageInfo.fromPlatform().then((PackageInfo packageInfo) {
 });
 ```
 
-For detailed usage, see https://github.com/flutter/plugins/blob/master/packages/package_info/README.md#usage.
+For detailed usage, see https://pub.dev/packages/package_info#usage.
 
 ## Supported devices
 

--- a/packages/package_info_plus/README.md
+++ b/packages/package_info_plus/README.md
@@ -16,4 +16,4 @@ dependencies:
 
 Then you can import `package_info_plus` in your Dart code.
 
-For detailed usage, see https://github.com/fluttercommunity/plus_plugins/tree/main/packages/package_info_plus/package_info_plus#usage.
+For detailed usage, see https://pub.dev/packages/package_info_plus#usage.

--- a/packages/path_provider/README.md
+++ b/packages/path_provider/README.md
@@ -20,7 +20,7 @@ Then you can import `path_provider` in your Dart code:
 import 'package:path_provider/path_provider.dart';
 ```
 
-For detailed usage, see https://github.com/flutter/plugins/tree/master/packages/path_provider/path_provider#usage.
+For detailed usage, see https://pub.dev/packages/path_provider#usage.
 
 ## Supported APIs
 

--- a/packages/sensors/README.md
+++ b/packages/sensors/README.md
@@ -20,7 +20,7 @@ Then you can import `sensors` in your Dart code:
 import 'package:sensors/sensors.dart';
 ```
 
-For detailed usage, see https://github.com/flutter/plugins/tree/master/packages/sensors#usage.
+For detailed usage, see https://pub.dev/packages/sensors#usage.
 
 ## Supported devices
 

--- a/packages/shared_preferences/README.md
+++ b/packages/shared_preferences/README.md
@@ -20,4 +20,4 @@ Then you can import `shared_preferences` in your Dart code:
 import 'package:shared_preferences/shared_preferences.dart';
 ```
 
-For detailed usage, see https://github.com/flutter/plugins/tree/master/packages/shared_preferences/shared_preferences#usage.
+For detailed usage, see https://pub.dev/packages/shared_preferences#usage.

--- a/packages/sqflite/README.md
+++ b/packages/sqflite/README.md
@@ -18,4 +18,4 @@ Then you can import `sqflite` in your Dart code:
 import 'package:sqflite/sqflite.dart';
 ```
 
-For more details, see [here](https://github.com/tekartik/sqflite/blob/master/sqflite/README.md).
+For detailed usage, see https://pub.dev/packages/sqflite#usage-example.

--- a/packages/url_launcher/README.md
+++ b/packages/url_launcher/README.md
@@ -20,7 +20,7 @@ Then you can import `url_launcher` in your Dart code:
 import 'package:url_launcher/url_launcher.dart';
 ```
 
-For detailed usage, see https://github.com/flutter/plugins/tree/master/packages/url_launcher/url_launcher#usage.
+For detailed usage, see https://pub.dev/packages/url_launcher#usage.
 
 ## Required privileges
 
@@ -32,7 +32,7 @@ To use this plugin in a Tizen application, the application manager privilege is 
 </privileges>
 ```
 
-For details, see [Security and API Privileges](https://docs.tizen.org/application/dotnet/tutorials/sec-privileges).
+For detailed information on Tizen privileges, see [Tizen Docs: API Privileges](https://docs.tizen.org/application/dotnet/get-started/api-privileges).
 
 ## Notes
 

--- a/packages/video_player/README.md
+++ b/packages/video_player/README.md
@@ -38,7 +38,7 @@ Then you can import `video_player` in your Dart code:
 import 'package:video_player/video_player.dart';
 ```
 
-For how to use the plugin, see https://github.com/flutter/plugins/tree/master/packages/video_player/video_player#example.
+For detailed usage, see https://pub.dev/packages/video_player#example.
 
 ## Limitations
 

--- a/packages/wifi_info_flutter/README.md
+++ b/packages/wifi_info_flutter/README.md
@@ -20,7 +20,7 @@ Then you can import `wifi_info_flutter` in your Dart code:
 import 'package:wifi_info_flutter/wifi_info_flutter.dart';
 ```
 
-For detailed usage, see https://github.com/flutter/plugins/tree/master/packages/wifi_info_flutter/wifi_info_flutter#usage.
+For detailed usage, see https://pub.dev/packages/wifi_info_flutter#usage.
 
 ## Required privileges
 
@@ -32,4 +32,4 @@ To get network information using this plugin, add below lines under the `<manife
 </privileges>
 ```
 
-For details, see [Security and API Privileges](https://docs.tizen.org/application/dotnet/tutorials/sec-privileges).
+For detailed information on Tizen privileges, see [Tizen Docs: API Privileges](https://docs.tizen.org/application/dotnet/get-started/api-privileges).


### PR DESCRIPTION
- Use pub.dev URLs instead of github.com URLs whenever possible. github.com links are easy to break for various reasons (especially repo structure change) and the contents may contain unpublished changes.
- Fix broken links to https://docs.tizen.org/application/dotnet/tutorials/sec-privileges.
