### PR TITLE
[video_player] Fix empty seekCompletedCallback issue

### DIFF
--- a/packages/video_player/CHANGELOG.md
+++ b/packages/video_player/CHANGELOG.md
@@ -30,7 +30,7 @@
 * Update video_player to 2.2.6 and update the example app.
 * Minor cleanups.
 
-## 2.4.0
+## 2.3.1
 
 * Show first frame after player is prepared.
 * Assign `on_completed_cb_` of player before calling `player_set_play_position` to fix intermittent issue.

--- a/packages/video_player/CHANGELOG.md
+++ b/packages/video_player/CHANGELOG.md
@@ -29,3 +29,8 @@
 * Never return empty error messages to avoid null reference exceptions.
 * Update video_player to 2.2.6 and update the example app.
 * Minor cleanups.
+
+## 2.4.0
+
+* Show first frame after player is prepared.
+* Assign `on_completed_cb_` of player before calling `player_set_play_position` to fix intermittent issue.

--- a/packages/video_player/README.md
+++ b/packages/video_player/README.md
@@ -29,7 +29,7 @@ This package is not an _endorsed_ implementation of `video_player`. Therefore, y
 ```yaml
 dependencies:
   video_player: ^2.2.6
-  video_player_tizen: ^2.4.0
+  video_player_tizen: ^2.3.1
 ```
 
 Then you can import `video_player` in your Dart code:

--- a/packages/video_player/README.md
+++ b/packages/video_player/README.md
@@ -29,7 +29,7 @@ This package is not an _endorsed_ implementation of `video_player`. Therefore, y
 ```yaml
 dependencies:
   video_player: ^2.2.6
-  video_player_tizen: ^2.3.0
+  video_player_tizen: ^2.4.0
 ```
 
 Then you can import `video_player` in your Dart code:

--- a/packages/video_player/pubspec.yaml
+++ b/packages/video_player/pubspec.yaml
@@ -3,7 +3,7 @@ description: Flutter plugin for displaying inline video with other Flutter
   widgets on Tizen.
 homepage: https://github.com/flutter-tizen/plugins
 repository: https://github.com/flutter-tizen/plugins/tree/master/packages/video_player
-version: 2.4.0
+version: 2.3.1
 
 flutter:
   plugin:

--- a/packages/video_player/pubspec.yaml
+++ b/packages/video_player/pubspec.yaml
@@ -3,7 +3,7 @@ description: Flutter plugin for displaying inline video with other Flutter
   widgets on Tizen.
 homepage: https://github.com/flutter-tizen/plugins
 repository: https://github.com/flutter-tizen/plugins/tree/master/packages/video_player
-version: 2.3.0
+version: 2.4.0
 
 flutter:
   plugin:

--- a/packages/video_player/tizen/src/video_player.cc
+++ b/packages/video_player/tizen/src/video_player.cc
@@ -289,15 +289,15 @@ void VideoPlayer::setPlaybackSpeed(double speed) {
 void VideoPlayer::seekTo(int position,
                          const SeekCompletedCb &seek_completed_cb) {
   LOG_DEBUG("[VideoPlayer.seekTo] position: %d", position);
+  on_seek_completed_ = seek_completed_cb;
   int ret =
       player_set_play_position(player_, position, true, onSeekCompleted, this);
   if (ret != PLAYER_ERROR_NONE) {
+    on_seek_completed_ = nullptr;
     LOG_ERROR("[VideoPlayer.seekTo] player_set_play_position failed: %s",
               get_error_message(ret));
     throw VideoPlayerError("player_set_play_position failed",
                            get_error_message(ret));
-  } else {
-    on_seek_completed_ = seek_completed_cb;
   }
 }
 


### PR DESCRIPTION
- Assign `on_seek_completed_` of player before calling `player_set_play_position` to fix intermittent errors.

   If `onSeekCompleted()` is called before `on_seek_completed_` is assigned, uninitialized `on_seek_completed_` can cause serious crash or it is not called at all.