### PR TITLE
[messageport_tizen] Add LocalPort.create and RemotePort.connect

### DIFF
--- a/packages/messageport/CHANGELOG.md
+++ b/packages/messageport/CHANGELOG.md
@@ -1,3 +1,9 @@
 ## 0.1.0
 
 * Initial release.
+
+## 0.2.0
+
+* Deprecate `TizenMessagePort.createLocalPort` and `TizenMessagePort.connectToRemotePort`
+  in favor of newly added `LocalPort.create` and `RemotePort.connect`.
+* Minor cleanups.

--- a/packages/messageport/README.md
+++ b/packages/messageport/README.md
@@ -4,9 +4,9 @@
 
 This plugin adds support for communication between Flutter applications on Tizen platform.
 
-## Getting Started
+## Usage
 
-First, import the package in dart file.
+First, import the package in Dart file.
 
 ```dart
 import 'package:messageport_tizen/messageport_tizen.dart';
@@ -14,83 +14,74 @@ import 'package:messageport_tizen/messageport_tizen.dart';
 
 ### Create local port
 
-Use `TizenMessagePort.createLocalPort` method to create local port.
+Use `LocalPort.create()` method to create a local port.
 
 ```dart
 String portName = 'servicePort';
-LocalPort localPort = await TizenMessagePort.createLocalPort(portName);
+LocalPort localPort = await LocalPort.create(portName);
 ```
 
-To register callback when message arrives to the local port, use `LocalPort.register()` method.
+To register callback to be called when message arrives to the local port, use `LocalPort.register()` method.
 
 ```dart
-  void onMessage(Object message, [RemotePort remotePort]) {
-    print('Message received: ' + message.toString());
-  }
-  ...
-  localPort.register(onMessage);
+void onMessage(Object message, [RemotePort remotePort]) {
+  print('Message received: $message');
+}
+...
+localPort.register(onMessage);
 ```
 
 Use `LocalPort.unregister()` to unregister port when it is no longer needed.
 
 ```dart
-  localPort.unregister();
+localPort.unregister();
 ```
 
 ### Connect to remote port
 
-To connect to already registered port in remote application, use `TizenMessagePort.connectToRemotePort()` method.
+To connect to already registered port in remote application, use `RemotePort.connect()` method.
 
 ```dart
-  String portName = 'servicePort';
-  String remoteAppId = 'remote.app.id';
-  RemotePort remotePort = await TizenMessagePort.connectToRemotePort(remoteAppId, portName);
+String portName = 'servicePort';
+String remoteAppId = 'remote.app.id';
+RemotePort remotePort = await RemotePort.connect(remoteAppId, portName);
 ```
 
 ### Send message
 
-To send message to remote applcation use `RemotePort.send()` method.
+To send message to remote applcation, use `RemotePort.send()` method.
 
 ```dart
-  final message = {"a": 1, "b": 2, "c": 3};
-  try{
-    await remotePort.send(message);
-  } catch (e) {
-    print('Could not send message: ${e.toString()}");
-  }
+final message = {'a': 1, 'b': 2, 'c': 3};
+try{
+  await remotePort.send(message);
+} catch (error) {
+  print('Could not send message: $error');
+}
 ```
 
 ### Send message with local port
 
-To send message with local port use `RemotePort.send()` method. Local port received by remote application can be used to send a response.
+To send message with local port information, use `RemotePort.send()` method. Local port received by remote application can be used to send a response.
 
 ```dart
-  final message = "This is a string message";
-  try{
-    await remotePort.sendWithLocalPort(message, localPort);
-  } catch (e) {
-    print('Could not send message: ${e.toString()}");
-  }
+final message = 'This is a string message';
+try{
+  await remotePort.sendWithLocalPort(message, localPort);
+} catch (error) {
+  print('Could not send message: $error');
+}
 ```
 
 ### Supported data types
 
-Data types that can be transferred using this plugin:
-* null
-* bool
-* numbers: int, double
-* String
-* Uint8List, Int32List, Int64List, Float64List
-* List of supported values
-* Map from supported values to supported values
+This plugin uses Flutter's [StandardMessageCodec](https://api.flutter.dev/flutter/services/StandardMessageCodec-class.html) to encode transferred data into binary. The data can contain any value or collection type supported by Flutter's standard method codec.
 
-Plugin uses Flutter's [StandardMessageCodec](https://api.flutter.dev/flutter/services/StandardMessageCodec-class.html) to encode transferred data into binary.
-Data can contain any value or collection type supported by Flutter's standard method codec.
+* `null`
+* `bool`
+* `int`, `double`
+* `String`
+* `Uint8List`, `Int32List`, `Int64List`, `Float64List`
+* Lists and Maps of the above
 
-To learn more about how to use this plugin, please check example application.
-
-## Releated Info
-
-To learn more about Tizen Message Port API visit following guides:
-
-- [MessagePort Native Guide](https://docs.tizen.org/application/native/guides/app-management/message-port/)
+To learn more about the Tizen Message Port API, visit [Tizen Docs: Message Port](https://docs.tizen.org/application/native/guides/app-management/message-port).

--- a/packages/messageport/example/README.md
+++ b/packages/messageport/example/README.md
@@ -3,13 +3,5 @@
 Demonstrates how to use the messageport_tizen plugin.
 
 ## Getting Started
+
 To run this app on your Tizen device, use [flutter-tizen](https://github.com/flutter-tizen/flutter-tizen).
-
-## Testing
-
-To run tests use:
-
-```bash
-cd example/
-flutter-tizen drive --target=integration_test/messageport_test.dart --driver=test_driver/integration_test.dart --no-sound-null-safety
-```

--- a/packages/messageport/example/pubspec.yaml
+++ b/packages/messageport/example/pubspec.yaml
@@ -1,9 +1,6 @@
 name: messageport_tizen_example
 description: Demonstrates how to use the messageport_tizen plugin.
-
-# The following line prevents the package from being accidentally published to
-# pub.dev using `pub publish`. This is preferred for private packages.
-publish_to: 'none' # Remove this line if you wish to publish to pub.dev
+publish_to: "none"
 
 environment:
   sdk: ">=2.12.0 <3.0.0"
@@ -22,7 +19,8 @@ dev_dependencies:
     sdk: flutter
   integration_test:
     sdk: flutter
-  integration_test_tizen: ^2.0.0
+  integration_test_tizen:
+    path: ../../integration_test/
 
 flutter:
   uses-material-design: true

--- a/packages/messageport/example/test_driver/integration_test.dart
+++ b/packages/messageport/example/test_driver/integration_test.dart
@@ -1,5 +1,3 @@
-// @dart=2.9
-
 import 'package:integration_test/integration_test_driver.dart';
 
 Future<void> main() => integrationDriver();

--- a/packages/messageport/example/tizen/Runner.csproj
+++ b/packages/messageport/example/tizen/Runner.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Tizen.NET.Sdk/1.1.5">
+﻿<Project Sdk="Tizen.NET.Sdk/1.1.7">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>

--- a/packages/messageport/example/tizen/tizen-manifest.xml
+++ b/packages/messageport/example/tizen/tizen-manifest.xml
@@ -1,11 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest package="org.tizen.messageport_tizen_example" version="1.0.0" api-version="4.0" xmlns="http://tizen.org/ns/packages">
     <profile name="common"/>
-    <ui-application appid="org.tizen.messageport_tizen_example" exec="Runner.dll" type="dotnet" multiple="false" taskmanage="true" nodisplay="false" api-version="4" launch_mode="single">
+    <ui-application appid="org.tizen.messageport_tizen_example" exec="Runner.dll" type="dotnet" multiple="false" taskmanage="true" nodisplay="false" api-version="4">
         <label>MessagePort Tizen Example</label>
         <icon>ic_launcher.png</icon>
         <metadata key="http://tizen.org/metadata/prefer_dotnet_aot" value="true"/>
-        <metadata key="http://tizen.org/metadata/direct-launch" value="yes"/>
     </ui-application>
     <feature name="http://tizen.org/feature/screen.size.all"/>
 </manifest>

--- a/packages/messageport/lib/src/messageport_manager.dart
+++ b/packages/messageport/lib/src/messageport_manager.dart
@@ -7,7 +7,8 @@
 import 'dart:async';
 
 import 'package:flutter/services.dart';
-import 'package:messageport_tizen/messageport_tizen.dart';
+
+import '../messageport_tizen.dart';
 
 const MethodChannel _channel = MethodChannel('tizen/messageport');
 
@@ -38,12 +39,14 @@ class TizenMessagePortManager {
     args['remoteAppId'] = remotePort.remoteAppId;
     args['portName'] = remotePort.portName;
     args['message'] = message;
-
     return _channel.invokeMethod('send', args);
   }
 
   Future<void> sendWithLocalPort(
-      RemotePort remotePort, LocalPort localPort, dynamic message) async {
+    RemotePort remotePort,
+    LocalPort localPort,
+    dynamic message,
+  ) async {
     final Map<String, dynamic> args = <String, dynamic>{};
     args['trusted'] = remotePort.trusted;
     args['remoteAppId'] = remotePort.remoteAppId;
@@ -51,7 +54,6 @@ class TizenMessagePortManager {
     args['localPort'] = localPort.portName;
     args['localPortTrusted'] = localPort.trusted;
     args['message'] = message;
-
     return _channel.invokeMethod('send', args);
   }
 
@@ -70,7 +72,6 @@ class TizenMessagePortManager {
           EventChannel('tizen/messageport/${localPort.portName}');
       _localPorts[localPort.portName] = eventChannel.receiveBroadcastStream();
     }
-
     return _localPorts[localPort.portName]!;
   }
 

--- a/packages/messageport/pubspec.yaml
+++ b/packages/messageport/pubspec.yaml
@@ -2,19 +2,11 @@ name: messageport_tizen
 description: A Flutter plugin that allows communication between multiple applications on Tizen using Tizen Message Port.
 homepage: https://github.com/flutter-tizen/plugins
 repository: https://github.com/flutter-tizen/plugins/tree/master/packages/messageport
-version: 0.1.0
+version: 0.2.0
 
 environment:
   sdk: ">=2.12.0 <3.0.0"
   flutter: ">=2.0.0"
-
-dependencies:
-  flutter:
-    sdk: flutter
-
-dev_dependencies:
-  flutter_test:
-    sdk: flutter
 
 flutter:
   plugin:
@@ -22,3 +14,7 @@ flutter:
       tizen:
         pluginClass: MessageportTizenPlugin
         fileName: messageport_tizen_plugin.h
+
+dependencies:
+  flutter:
+    sdk: flutter

--- a/packages/messageport/tizen/src/messageport.h
+++ b/packages/messageport/tizen/src/messageport.h
@@ -48,6 +48,7 @@ class MessagePortManager {
 
   MessagePortResult CreateResult(int return_code);
   MessagePortResult PrepareBundle(flutter::EncodableValue& message, bundle*& b);
+
   std::map<int, EventSink> sinks_;
   std::set<int> trusted_ports_;
 };

--- a/packages/messageport/tizen/src/messageport_tizen_plugin.cc
+++ b/packages/messageport/tizen/src/messageport_tizen_plugin.cc
@@ -78,17 +78,17 @@ class MessageportTizenPlugin : public flutter::Plugin {
   void HandleMethodCall(
       const flutter::MethodCall<flutter::EncodableValue> &method_call,
       std::unique_ptr<flutter::MethodResult<flutter::EncodableValue>> result) {
-    LOG_DEBUG("HandleMethodCall: %s", method_call.method_name().c_str());
+    const auto &method_name = method_call.method_name();
     const flutter::EncodableValue *args = method_call.arguments();
 
-    if (method_call.method_name().compare("createLocal") == 0) {
+    if (method_name == "createLocal") {
       CreateLocal(args, std::move(result));
-    } else if (method_call.method_name().compare("checkForRemote") == 0) {
+    } else if (method_name == "checkForRemote") {
       CheckForRemote(args, std::move(result));
-    } else if (method_call.method_name().compare("send") == 0) {
+    } else if (method_name == "send") {
       Send(args, std::move(result));
     } else {
-      result->Error("Invalid method");
+      result->NotImplemented();
     }
   }
 
@@ -166,8 +166,7 @@ class MessageportTizenPlugin : public flutter::Plugin {
                 -> std::unique_ptr<flutter::StreamHandlerError<>> {
               LOG_DEBUG("OnCancel: %s", key.first.c_str());
               if (native_ports_.find(key) == native_ports_.end()) {
-                LOG_ERROR("Error OnCancel: %s",
-                          "Could not find port to unregister");
+                LOG_ERROR("Error OnCancel: Could not find port to unregister");
                 return nullptr;
               }
 


### PR DESCRIPTION
- Add new APIs `LocalPort.create` and `RemotePort.connect` which replace `TizenMessagePort.createLocalPort` and `TizenMessagePort.connectToRemotePort` respectively.
- Minor cleanups.

Part of https://github.com/flutter-tizen/flutter-tizen/pull/303#issuecomment-1001450222.