### PR TITLE
[tizen_app_control] Update messageport_tizen dependency in example to fix build error

### DIFF
--- a/packages/tizen_app_control/CHANGELOG.md
+++ b/packages/tizen_app_control/CHANGELOG.md
@@ -5,3 +5,4 @@
 ## 0.1.1
 
 * Update messageport_tizen to 0.2.0 in example.
+* Replace deprecated members in example app.

--- a/packages/tizen_app_control/CHANGELOG.md
+++ b/packages/tizen_app_control/CHANGELOG.md
@@ -1,3 +1,7 @@
 ## 0.1.0
 
 * Initial release.
+
+## 0.1.1
+
+* Update messageport_tizen to 0.2.0 in example.

--- a/packages/tizen_app_control/README.md
+++ b/packages/tizen_app_control/README.md
@@ -10,7 +10,7 @@ To use this package, add `tizen_app_control` as a dependency in your `pubspec.ya
 
 ```yaml
 dependencies:
-  tizen_app_control: ^0.1.0
+  tizen_app_control: ^0.1.1
 ```
 
 ### Sending a launch request

--- a/packages/tizen_app_control/example/lib/main.dart
+++ b/packages/tizen_app_control/example/lib/main.dart
@@ -36,8 +36,7 @@ void serviceMain() {
 
   // Connect to the UI app and send messages.
   // An exception will be thrown if the UI app is not running.
-  TizenMessagePort.connectToRemotePort(_kAppId, _kPortName)
-      .then((RemotePort remotePort) async {
+  RemotePort.connect(_kAppId, _kPortName).then((RemotePort remotePort) async {
     while (true) {
       if (await remotePort.check()) {
         await remotePort.send(null);
@@ -73,7 +72,7 @@ class _MyAppState extends State<MyApp> {
     super.initState();
 
     // Open a message port to receive messages from the service app.
-    TizenMessagePort.createLocalPort(_kPortName).then((LocalPort value) {
+    LocalPort.create(_kPortName).then((LocalPort value) {
       _localPort = value;
       _localPort?.register((dynamic message, [RemotePort? remotePort]) {
         setState(() {

--- a/packages/tizen_app_control/example/pubspec.yaml
+++ b/packages/tizen_app_control/example/pubspec.yaml
@@ -5,7 +5,7 @@ publish_to: "none"
 dependencies:
   flutter:
     sdk: flutter
-  messageport_tizen: ^0.1.0
+  messageport_tizen: ^0.2.0
   tizen_app_control:
     path: ../
 

--- a/packages/tizen_app_control/pubspec.yaml
+++ b/packages/tizen_app_control/pubspec.yaml
@@ -3,7 +3,7 @@ description: Tizen application control APIs. Used for launching and terminating
   applications on a Tizen device.
 homepage: https://github.com/flutter-tizen/plugins
 repository: https://github.com/flutter-tizen/plugins/tree/master/packages/tizen_app_control
-version: 0.1.0
+version: 0.1.1
 
 dependencies:
   ffi: ^1.1.2


### PR DESCRIPTION
Upgrade `messageport_tizen` to 0.2.0 in `tizen_app_control` example. If major version starts with 0, the next minor version is not considered a compatiable release so `pub get` will not retrieve 0.2.0 for `^0.1.0`.

Fixes:
```
Exception: The project type of messageport_tizen is "sharedLib" which is not supported.
           Make sure the package is up to date by running "flutter-tizen pub upgrade".

           If you are the maintainer of the messageport_tizen package, consider migrating the project to "staticLib" type.
           Otherwise, you may modify the value of "type" in /home/hakkyu/.pub-cache/hosted/pub.dartlang.org/messageport_tizen-0.1.0/tizen/project_def.prop to temporarily fix the problem.
```