### PR TITLE
[share_plus] Remove obsolete registration code

### DIFF
--- a/packages/share_plus/CHANGELOG.md
+++ b/packages/share_plus/CHANGELOG.md
@@ -6,3 +6,8 @@
 
 * Reimplement in Dart.
 * Update the example app.
+
+## 1.1.1
+
+* Update share_plus to 3.0.5.
+* Remove obsolete registration code.

--- a/packages/share_plus/README.md
+++ b/packages/share_plus/README.md
@@ -10,8 +10,8 @@ To use this plugin, add `share_plus` and `share_plus_tizen` as [dependencies in 
 
 ```yaml
 dependencies:
-  share_plus: ^3.0.4
-  share_plus_tizen: ^1.1.0
+  share_plus: ^3.0.5
+  share_plus_tizen: ^1.1.1
 ```
 
 Then you can import `share_plus` in your Dart code.

--- a/packages/share_plus/example/pubspec.yaml
+++ b/packages/share_plus/example/pubspec.yaml
@@ -8,7 +8,7 @@ dependencies:
   image_picker: ^0.8.4+3
   image_picker_tizen:
     path: ../../image_picker/
-  share_plus: ^3.0.4
+  share_plus: ^3.0.5
   share_plus_tizen:
     path: ../
 

--- a/packages/share_plus/lib/share_plus_tizen.dart
+++ b/packages/share_plus/lib/share_plus_tizen.dart
@@ -4,7 +4,6 @@
 
 import 'dart:ui';
 
-import 'package:share_plus/share_plus.dart';
 import 'package:share_plus_platform_interface/share_plus_platform_interface.dart';
 import 'package:tizen_app_control/app_control.dart';
 
@@ -12,11 +11,6 @@ import 'package:tizen_app_control/app_control.dart';
 class SharePlugin extends SharePlatform {
   /// Registers this class as the default instance of [SharePlatform].
   static void register() {
-    // Remove this line once https://github.com/fluttercommunity/plus_plugins/pull/574
-    // is released.
-    // ignore: invalid_use_of_visible_for_testing_member
-    Share.disableSharePlatformOverride = true;
-
     SharePlatform.instance = SharePlugin();
   }
 

--- a/packages/share_plus/pubspec.yaml
+++ b/packages/share_plus/pubspec.yaml
@@ -2,7 +2,7 @@ name: share_plus_tizen
 description: Tizen implementation of the share_plus plugin
 homepage: https://github.com/flutter-tizen/plugins
 repository: https://github.com/flutter-tizen/plugins/tree/master/packages/share_plus
-version: 1.1.0
+version: 1.1.1
 
 flutter:
   plugin:
@@ -13,9 +13,8 @@ flutter:
 dependencies:
   flutter:
     sdk: flutter
-  share_plus: ^3.0.4
   share_plus_platform_interface: ^2.0.1
-  tizen_app_control: ^0.1.0
+  tizen_app_control: ^0.1.1
 
 dev_dependencies:
   flutter_lints: ^1.0.4


### PR DESCRIPTION
https://github.com/flutter-tizen/plugins/issues/310

Fixes Dart analysis error:

  error - share_plus/lib/share_plus_tizen.dart:18:11 - The setter 'disableSharePlatformOverride' isn't defined for the type 'Share'. Try importing the library that defines 'disableSharePlatformOverride', correcting the name to the name of an existing setter, or defining a setter or field named 'disableSharePlatformOverride'. - undefined_setter