### PR TITLE
Reverse the order of CHANGELOGs

### DIFF
--- a/packages/audioplayers/CHANGELOG.md
+++ b/packages/audioplayers/CHANGELOG.md
@@ -1,18 +1,18 @@
-## 1.0.0
-
-* Initial release.
-
-## 1.0.1
-
-* Add integration test.
-
-## 1.0.2
-
-* Update README.
-
 ## 1.1.0
 
 * Update README and analysis_options.
 * Update audioplayers to 0.20.1.
 * Update the example app and integration_test.
 * Initialize variables properly.
+
+## 1.0.2
+
+* Update README.
+
+## 1.0.1
+
+* Add integration test.
+
+## 1.0.0
+
+* Initial release.

--- a/packages/battery_plus/CHANGELOG.md
+++ b/packages/battery_plus/CHANGELOG.md
@@ -1,10 +1,8 @@
-## 1.0.0
+## 1.0.3
 
-* Initial release.
-
-## 1.0.1
-
-* Fix a bug with EventChannel.
+* Update battery_plus to 2.0.2.
+* Update battery_plus_platform_interface to 1.1.1.
+* Remove obsolete `battery_plus_tizen.dart`.
 
 ## 1.0.2
 
@@ -13,8 +11,10 @@
 * Update the example app and integration_test.
 * Minor code cleanups.
 
-## 1.0.3
+## 1.0.1
 
-* Update battery_plus to 2.0.2.
-* Update battery_plus_platform_interface to 1.1.1.
-* Remove obsolete `battery_plus_tizen.dart`.
+* Fix a bug with EventChannel.
+
+## 1.0.0
+
+* Initial release.

--- a/packages/camera/CHANGELOG.md
+++ b/packages/camera/CHANGELOG.md
@@ -1,18 +1,18 @@
-## 0.1.0
-
-* Initial release.
-
-## 0.2.0
-
-* Apply new external texture APIs.
-
-## 0.2.1
-
-* Fix a freezing preview issue.
-
 ## 0.3.0
 
 * Update camera to 0.9.4.
 * Implement `pausePreview` and `resumePreview`.
 * Update the example app and integration_test.
 * Remove the unused test driver.
+
+## 0.2.1
+
+* Fix a freezing preview issue.
+
+## 0.2.0
+
+* Apply new external texture APIs.
+
+## 0.1.0
+
+* Initial release.

--- a/packages/connectivity_plus/CHANGELOG.md
+++ b/packages/connectivity_plus/CHANGELOG.md
@@ -1,10 +1,10 @@
-## 1.0.0
-
-* Initial release.
-
 ## 1.1.0
 
 * Update connectivity_plus to 2.1.0.
 * Update connectivity_plus_platform_interface to 1.1.1.
 * Support ethernet as connectivity result.
 * Remove obsolete `connectivity_plus_tizen.dart`.
+
+## 1.0.0
+
+* Initial release.

--- a/packages/device_info_plus/CHANGELOG.md
+++ b/packages/device_info_plus/CHANGELOG.md
@@ -1,7 +1,3 @@
-## 1.0.0
-
-* Initial release.
-
 ## 1.1.0
 
 * Remove dependency on `device_info_plus_platform_interface`.
@@ -9,3 +5,7 @@
 * Add support for `profile`, `platformName`, `platformProcessor`, and `tizenId`.
 * Update the example app.
 * Minor cleanups.
+
+## 1.0.0
+
+* Initial release.

--- a/packages/flutter_tts/CHANGELOG.md
+++ b/packages/flutter_tts/CHANGELOG.md
@@ -1,22 +1,22 @@
-## 1.0.0
+## 1.2.0
 
-* Initial release.
-
-## 1.0.1
-
-* Stabilize speaking states management.
-
-## 1.1.0
-
-* All APIs now return valid values (0, 1, empty list, and etc.).
+* Fix a bug where `setLanguage()` wasn't invoked due to typo in `setLanguage`.
+* Update flutter_tts to 3.2.2 and update the example app.
+* Support `setVolume()`.
+* Minor cleanups.
 
 ## 1.1.1
 
 * Fix calling onCancel in a successful situation and refactor native implementations.
 
-## 1.2.0
+## 1.1.0
 
-* Fix a bug where `setLanguage()` wasn't invoked due to typo in "setLanguage".
-* Update flutter_tts to 3.2.2 and update the example app.
-* Support `setVolume()`.
-* Minor cleanups.
+* All APIs now return valid values (0, 1, empty list, and etc.).
+
+## 1.0.1
+
+* Stabilize speaking states management.
+
+## 1.0.0
+
+* Initial release.

--- a/packages/geolocator/CHANGELOG.md
+++ b/packages/geolocator/CHANGELOG.md
@@ -1,14 +1,14 @@
-## 1.0.0
-
-* Initial release.
-
-## 1.0.1
-
-* Fix a permission request bug.
-
 ## 1.0.2
 
 * Update geolocator to 8.0.0
 * Update geolocator_platform_interface to 3.0.0.
 * Update the example app.
 * Minor cleanups.
+
+## 1.0.1
+
+* Fix a permission request bug.
+
+## 1.0.0
+
+* Initial release.

--- a/packages/google_maps_flutter/CHANGELOG.md
+++ b/packages/google_maps_flutter/CHANGELOG.md
@@ -1,16 +1,8 @@
-## 0.0.1
+## 0.1.1
 
-* Initial release
+* Update webview_flutter_tizen to 0.3.8.
+* Replace deprecated API (`evaluateJavascript` to `runJavascript`/`runJavascriptForResult`).
 
 ## 0.1.0
 
-* Update Dart and Flutter SDK constraints
-* Update Flutter and Samsung copyright information
-* Update google_map_flutter_tizen based on webview_flutter_tizen
-* Update example and integration_test
-* Update google_map_flutter to 2.0.8
-
-## 0.1.1
-
-* Update webview_flutter_tizen to 0.3.8
-* Replace deprecated API (evaluateJavascript -> [runJavascript, runJavascriptForResult])
+* Initial release.

--- a/packages/image_picker/CHANGELOG.md
+++ b/packages/image_picker/CHANGELOG.md
@@ -1,6 +1,10 @@
-## 1.0.0
+## 2.1.0
 
-* Initial release.
+* Update image_picker to 0.8.4.
+* Update image_picker_platform_interface to 2.4.1.
+* Implement `pickMultiImage`.
+* Update the example app.
+* Minor cleanups.
 
 ## 2.0.0
 
@@ -10,10 +14,6 @@
 * Port to use platform interface.
 * Organize dev_dependencies.
 
-## 2.1.0
+## 1.0.0
 
-* Update image_picker to 0.8.4.
-* Update image_picker_platform_interface to 2.4.1.
-* Implement `pickMultiImage`.
-* Update the example app.
-* Minor cleanups.
+* Initial release.

--- a/packages/integration_test/CHANGELOG.md
+++ b/packages/integration_test/CHANGELOG.md
@@ -1,11 +1,6 @@
-## 1.0.0
+## 2.0.1
 
-* Initial release.
-
-## 1.0.1
-
-* Update integration_test to 1.0.1.
-* Migrate to Tizen 4.0.
+* Change the project type to `staticLib`.
 
 ## 2.0.0
 
@@ -15,6 +10,11 @@
 * Remove unnecessary test files for web.
 * Organize dev_dependencies.
 
-## 2.0.1
+## 1.0.1
 
-* Change the project type to `staticLib`.
+* Update integration_test to 1.0.1.
+* Migrate to Tizen 4.0.
+
+## 1.0.0
+
+* Initial release.

--- a/packages/messageport/CHANGELOG.md
+++ b/packages/messageport/CHANGELOG.md
@@ -1,9 +1,9 @@
-## 0.1.0
-
-* Initial release.
-
 ## 0.2.0
 
 * Deprecate `TizenMessagePort.createLocalPort` and `TizenMessagePort.connectToRemotePort`
   in favor of newly added `LocalPort.create` and `RemotePort.connect`.
 * Minor cleanups.
+
+## 0.1.0
+
+* Initial release.

--- a/packages/network_info_plus/CHANGELOG.md
+++ b/packages/network_info_plus/CHANGELOG.md
@@ -1,20 +1,20 @@
-## 1.0.0
-
-* Initial release.
-
-## 1.1.0
-
-* Add IPv6 information.
-* Add gateway ip address information.
-* Add broadcast information.
-* Add subnet mask information.
-
-## 1.1.1
-
-* Fix app crash when wifi info is not available.
-
 ## 1.1.2
 
 * Update network_info_plus to 2.1.2
 * Update network_info_plus_platform_interface to 1.1.1.
 * Remove obsolete `network_info_plus_tizen.dart`.
+
+## 1.1.1
+
+* Fix app crash when WiFi info is not available.
+
+## 1.1.0
+
+* Add IPv6 information.
+* Add gateway IP address information.
+* Add broadcast information.
+* Add subnet mask information.
+
+## 1.0.0
+
+* Initial release.

--- a/packages/package_info_plus/CHANGELOG.md
+++ b/packages/package_info_plus/CHANGELOG.md
@@ -1,6 +1,7 @@
-## 1.0.0
+## 1.0.2
 
-* Initial release.
+* Update package_info_plus to 1.3.1.
+* Remove obsolete `package_info_plus_tizen.dart`.
 
 ## 1.0.1
 
@@ -8,7 +9,6 @@
 * Change the example app version to 1.2.3.
 * Minor cleanups.
 
-## 1.0.2
+## 1.0.0
 
-* Update package_info_plus to 1.3.1.
-* Remove obsolete `package_info_plus_tizen.dart`.
+* Initial release.

--- a/packages/path_provider/CHANGELOG.md
+++ b/packages/path_provider/CHANGELOG.md
@@ -1,17 +1,15 @@
-## 1.0.0
+## 2.0.2
 
-* Initial release.
+* Update path_provider to 2.0.7.
+* Unsupport `getDownloadsDirectory`.
+* Unskip skipped integration tests.
 
-## 1.0.1
+## 2.0.1
 
-* Update path_provider to 1.6.27.
-* Update path_provider_platform_interface to 1.0.4.
-* Remove permission_handler_tizen dependency temporarily.
-* Migrate to Tizen 4.0.
-
-## 1.0.2
-
-* Use `PlatformException` instead of a plugin-specific exception type.
+* Update path_provider to 2.0.2.
+* Remove permission_handler dependency.
+* Comment out integration tests that depend on permission_handler.
+* Migrate integration_test to null safety.
 
 ## 2.0.0
 
@@ -24,15 +22,17 @@
 * Migrate to ffi 1.0.0.
 * Migrate to null safety.
 
-## 2.0.1
+## 1.0.2
 
-* Update path_provider to 2.0.2.
-* Remove permission_handler dependency.
-* Comment out integration tests that depend on permission_handler.
-* Migrate integration_test to null safety.
+* Use `PlatformException` instead of a plugin-specific exception type.
 
-## 2.0.2
+## 1.0.1
 
-* Update path_provider to 2.0.7.
-* Unsupport `getDownloadsDirectory`.
-* Unskip skipped integration tests.
+* Update path_provider to 1.6.27.
+* Update path_provider_platform_interface to 1.0.4.
+* Remove permission_handler_tizen dependency temporarily.
+* Migrate to Tizen 4.0.
+
+## 1.0.0
+
+* Initial release.

--- a/packages/permission_handler/CHANGELOG.md
+++ b/packages/permission_handler/CHANGELOG.md
@@ -1,6 +1,13 @@
-## 1.0.0
+## 1.2.0
 
-* Initial release.
+* Update permission_handler to 8.3.0.
+* Update permission_handler_platform_interface to 3.7.0.
+* Update the example app.
+* Minor cleanups.
+
+## 1.1.1
+
+* Fix a permission request bug.
 
 ## 1.1.0
 
@@ -8,13 +15,6 @@
 * `OpenAppSetting` now opens the app's permission settings instead of the system settings.
 * Refactor the overall implementation in C++ way.
 
-## 1.1.1
+## 1.0.0
 
-* Fix a permission request bug.
-
-## 1.2.0
-
-* Update permission_handler to 8.3.0.
-* Update permission_handler_platform_interface to 3.7.0.
-* Update the example app.
-* Minor cleanups.
+* Initial release.

--- a/packages/sensors_plus/CHANGELOG.md
+++ b/packages/sensors_plus/CHANGELOG.md
@@ -1,14 +1,14 @@
-## 1.0.0
-
-* Initial release.
-
-## 1.0.1
-
-* Fix bug with EventChannel.
-
 ## 1.1.0
 
 * Update sensors_plus to 1.2.1.
 * Port to use platform interface.
 * Set the sampling interval to 60 ms.
 * Update the example app.
+
+## 1.0.1
+
+* Fix a bug with EventChannel.
+
+## 1.0.0
+
+* Initial release.

--- a/packages/share_plus/CHANGELOG.md
+++ b/packages/share_plus/CHANGELOG.md
@@ -1,13 +1,13 @@
-## 1.0.0
+## 1.1.1
 
-* Initial release.
+* Update share_plus to 3.0.5.
+* Remove obsolete registration code.
 
 ## 1.1.0
 
 * Reimplement in Dart.
 * Update the example app.
 
-## 1.1.1
+## 1.0.0
 
-* Update share_plus to 3.0.5.
-* Remove obsolete registration code.
+* Initial release.

--- a/packages/shared_preferences/CHANGELOG.md
+++ b/packages/shared_preferences/CHANGELOG.md
@@ -1,12 +1,12 @@
-## 1.0.0
+## 2.0.2
 
-* Initial release.
+* Update shared_preferences to 2.0.9.
+* Switch to new analysis options.
+* Update integration_test.
 
-## 1.0.1
+## 2.0.1
 
-* Update shared_preferences to 0.5.12+4.
-* Update shared_preferences_platform_interface to 1.0.4.
-* Migrate to Tizen 4.0.
+* Fix memory leaks.
 
 ## 2.0.0
 
@@ -19,12 +19,12 @@
 * Migrate to null safety.
 * Remove unused `PreferenceIsExisiting` from the implementation.
 
-## 2.0.1
+## 1.0.1
 
-* Fix memory leaks.
+* Update shared_preferences to 0.5.12+4.
+* Update shared_preferences_platform_interface to 1.0.4.
+* Migrate to Tizen 4.0.
 
-## 2.0.2
+## 1.0.0
 
-* Update shared_preferences to 2.0.9.
-* Switch to new analysis options.
-* Update integration_test.
+* Initial release.

--- a/packages/tizen_app_control/CHANGELOG.md
+++ b/packages/tizen_app_control/CHANGELOG.md
@@ -1,8 +1,8 @@
-## 0.1.0
-
-* Initial release.
-
 ## 0.1.1
 
 * Update messageport_tizen to 0.2.0 in example.
 * Replace deprecated members in example app.
+
+## 0.1.0
+
+* Initial release.

--- a/packages/url_launcher/CHANGELOG.md
+++ b/packages/url_launcher/CHANGELOG.md
@@ -1,31 +1,9 @@
-## 1.0.0
+## 2.1.0
 
-* Initial release.
-
-## 1.0.1
-
-* Migrate to Tizen 4.0.
-
-## 1.0.2
-
-* Update url_launcher to 5.7.10.
-* Update platform interface to 1.0.9.
-* Increase the minimum framework requirement to 1.22.0.
-
-## 1.0.3
-
-* Use `PlatformException` instead of a plugin-specific exception type.
-* Move `app_control.dart` to `src` directory.
-
-## 2.0.0
-
-* Increase Dart and Flutter SDK constraints to 2.12.0 and 2.0.0.
-* Update Flutter copyright information.
-* Update the example app and integration_test.
-* Update url_launcher_platform_interface to 2.0.2.
-* Organize dev_dependencies.
-* Migrate to ffi 1.0.0.
-* Migrate to null safety.
+* Update url_launcher to 6.0.17.
+* Add tizen_app_control dependency and remove the FFI-based implementation.
+* Switch to new analysis options.
+* Update the example app.
 
 ## 2.0.1
 
@@ -37,9 +15,31 @@
 * Remove `@dart=2.9` from test files.
 * Sync the example code.
 
-## 2.1.0
+## 2.0.0
 
-* Update url_launcher to 6.0.17.
-* Add tizen_app_control dependency and remove the FFI-based implementation.
-* Switch to new analysis options.
-* Update the example app.
+* Increase Dart and Flutter SDK constraints to 2.12.0 and 2.0.0.
+* Update Flutter copyright information.
+* Update the example app and integration_test.
+* Update url_launcher_platform_interface to 2.0.2.
+* Organize dev_dependencies.
+* Migrate to ffi 1.0.0.
+* Migrate to null safety.
+
+## 1.0.3
+
+* Use `PlatformException` instead of a plugin-specific exception type.
+* Move `app_control.dart` to `src` directory.
+
+## 1.0.2
+
+* Update url_launcher to 5.7.10.
+* Update url_launcher_platform_interface to 1.0.9.
+* Increase the minimum framework requirement to 1.22.0.
+
+## 1.0.1
+
+* Migrate to Tizen 4.0.
+
+## 1.0.0
+
+* Initial release.

--- a/packages/video_player/CHANGELOG.md
+++ b/packages/video_player/CHANGELOG.md
@@ -1,27 +1,7 @@
-## 1.0.0
+## 2.3.1
 
-* Initial release.
-
-## 2.0.0
-
-* Appaly new common texture APIs.
-
-## 2.0.1
-
-* Update integration_test.
-  
-## 2.2.0
-
-* Update video_player to 2.2.3.
-* Update platform interface to 4.2.0.
-
-## 2.2.1
-
-* Update README.
-
-## 2.2.2
-
-* Fix `seekTo` so that it returns when seeking is completed.
+* Show first frame after player is prepared.
+* Assign `on_completed_cb_` of player before calling `player_set_play_position` to fix intermittent issue.
 
 ## 2.3.0
 
@@ -30,7 +10,27 @@
 * Update video_player to 2.2.6 and update the example app.
 * Minor cleanups.
 
-## 2.3.1
+## 2.2.2
 
-* Show first frame after player is prepared.
-* Assign `on_completed_cb_` of player before calling `player_set_play_position` to fix intermittent issue.
+* Fix `seekTo` so that it returns when seeking is completed.
+
+## 2.2.1
+
+* Update README.
+
+## 2.2.0
+
+* Update video_player to 2.2.3.
+* Update video_player_platform_interface to 4.2.0.
+
+## 2.0.1
+
+* Update integration_test.
+
+## 2.0.0
+
+* Appaly new common texture APIs.
+
+## 1.0.0
+
+* Initial release.

--- a/packages/wakelock/CHANGELOG.md
+++ b/packages/wakelock/CHANGELOG.md
@@ -1,9 +1,9 @@
+## 1.0.1
+
+* Update wakelock to 0.5.6.
+* Update wakelock_platform_interface to 0.3.0.
+* Update implementation according to the changed platform interface.
+
 ## 1.0.0
 
 * Initial release.
-
-## 1.0.1
-
-* Bump up `wakelock_platform_interface` to 0.3.0.
-* Update implementation according to the changed platform interface.
-* Bump up `wakelock` to 0.5.6 in example.

--- a/packages/wearable_rotary/CHANGELOG.md
+++ b/packages/wearable_rotary/CHANGELOG.md
@@ -1,11 +1,11 @@
-## 1.0.0
-
-* Initial release.
-
-## 1.0.1
-
-* Fix bug with EventChannel.
-
 ## 1.0.2
 
 * Typo fix and minor cleanups.
+
+## 1.0.1
+
+* Fix a bug with EventChannel.
+
+## 1.0.0
+
+* Initial release.

--- a/packages/webview_flutter/CHANGELOG.md
+++ b/packages/webview_flutter/CHANGELOG.md
@@ -1,55 +1,69 @@
-## 0.1.0
+## 0.3.10
 
-* Initial release
-
-## 0.2.0
-* Update Dart and Flutter SDK constraints
-* Update Flutter and Samsung copyright information
-* Update webview_flutter_tizen to use platform view interface
-* Update example and integration_test
-* Update webivew_flutter to 2.0.4
-
-## 0.2.1
-* Add lightweight web engine binary for arm64
-
-## 0.2.2
-* Update lightweight web engine binary & header file (6263be6c888d5cb9dcca5466dfc3941a70b424eb)
-* Activate resizing function
-* Apply embedder's texture APIs change
-
-## 0.3.0
-* Apply PlatformView, PlatformViewFactory APIs change
-
-## 0.3.1
-* Update lightweight web engine binary (ad0e77631f96180e19a11c3dc80b6b72c32bdffb)
-* Fix bug on handling parameter of `loadUrl` API
-
-## 0.3.2
-* Update LWE binary (2226c28429391407d7c875c3af7531f5e1d5dfa7) for supporting google_map_flutter_tizen
-
-## 0.3.3
-* Update LWE binary (c57d045a513455115a8a4c66517e5e51f5a4dfbd)
-* Fix issue of multiple webviews
-
-## 0.3.4
-* Fix flicking issue at animation
-
-## 0.3.5
-* Update LWE binary (b2fad69f50d693c86abc45b363a39b0625f5e95f)
-* Fix crash issue
-
-## 0.3.6
-* Update LWE binary (3dff8724bfb4b2b0b9e7c4e3976a9b02e74ee13c)
-* Fix various issue
-
-## 0.3.7
-* Update webivew_flutter to 2.1.1
-
-## 0.3.8
-* Update webivew_flutter to 2.3.0
+* Apply `PlatformView` and `PlatformViewFactory` API changes.
 
 ## 0.3.9
-* Update LWE binary (6bae13cb915bd41c5aac4aaaae72865f20924c03)
 
-## 0.3.10
-* Apply PlatformView, PlatformViewFactory APIs change
+* Update LWE binary (6bae13cb915bd41c5aac4aaaae72865f20924c03).
+
+## 0.3.8
+
+* Update webivew_flutter to 2.3.0.
+
+## 0.3.7
+
+* Update webivew_flutter to 2.1.1.
+
+## 0.3.6
+
+* Update LWE binary (3dff8724bfb4b2b0b9e7c4e3976a9b02e74ee13c).
+* Fix various issues.
+
+## 0.3.5
+
+* Update LWE binary (b2fad69f50d693c86abc45b363a39b0625f5e95f).
+* Fix crash issue.
+
+## 0.3.4
+
+* Fix buffer synchronization issue.
+
+## 0.3.3
+
+* Update LWE binary (c57d045a513455115a8a4c66517e5e51f5a4dfbd).
+* Fix issue of multiple webviews.
+
+## 0.3.2
+
+* Update LWE binary (2226c28429391407d7c875c3af7531f5e1d5dfa7) for supporting google_map_flutter_tizen.
+
+## 0.3.1
+
+* Update lightweight web engine binary (ad0e77631f96180e19a11c3dc80b6b72c32bdffb).
+* Fix bug on handling parameter of `loadUrl` API.
+
+## 0.3.0
+
+* Apply `PlatformView` and `PlatformViewFactory` API changes.
+
+## 0.2.2
+
+* Update lightweight web engine binary & header file (6263be6c888d5cb9dcca5466dfc3941a70b424eb).
+* Activate resizing function.
+* Apply embedder's texture API changes.
+
+## 0.2.1
+
+* Add lightweight web engine binary for arm64.
+
+## 0.2.0
+
+* Update Dart and Flutter SDK constraints.
+* Update Flutter and Samsung copyright information.
+* Update webview_flutter_tizen to use platform view interface.
+* Update example and integration_test.
+* Update webivew_flutter to 2.0.4.
+
+## 0.1.0
+
+* Initial release.


### PR DESCRIPTION
Latest events should always come first. e.g. 
- battery_plus: https://pub.dev/packages/battery_plus/changelog (correct)
- battery_plus_tizen: https://pub.dev/packages/battery_plus_tizen/changelog (wrong)