### PR TITLE
Do not use the git protocol in pubspecs

### DIFF
--- a/packages/geolocator/example/pubspec.yaml
+++ b/packages/geolocator/example/pubspec.yaml
@@ -8,7 +8,7 @@ environment:
 dependencies:
   baseflow_plugin_template:
     git:
-      url: git://github.com/Baseflow/baseflow_plugin_template.git
+      url: https://github.com/Baseflow/baseflow_plugin_template.git
       ref: v2.1.0
   cupertino_icons: ^1.0.1+1
   flutter:

--- a/packages/permission_handler/example/pubspec.yaml
+++ b/packages/permission_handler/example/pubspec.yaml
@@ -4,7 +4,7 @@ description: Demonstrates how to use the permission_handler_tizen plugin.
 dependencies:
   baseflow_plugin_template:
     git:
-      url: git://github.com/Baseflow/baseflow_plugin_template.git
+      url: https://github.com/Baseflow/baseflow_plugin_template.git
       ref: v2.0.0-nullsafety
   flutter:
     sdk: flutter


### PR DESCRIPTION
Substitute `git://` in `example/pubspec.yaml` with the GitHub-supported format `https://`.

Error log:
```
2022-03-16T05:07:41.4281921Z Running "flutter pub get" in geolocator...                       1,110ms
2022-03-16T05:07:42.0932931Z Running "flutter pub get" in example...                         
2022-03-16T05:07:42.0960824Z Git error. Command: `git clone --mirror git://github.com/Baseflow/baseflow_plugin_template.git /opt/hostedtoolcache/flutter/2.10.3-stable/x64/.pub-cache/git/cache/baseflow_plugin_template-4fbabee1114b5508a9ffc49dfff58dc6ce1c5577`
2022-03-16T05:07:42.0966073Z stdout: 
2022-03-16T05:07:42.0969027Z stderr: Cloning into bare repository '/opt/hostedtoolcache/flutter/2.10.3-stable/x64/.pub-cache/git/cache/baseflow_plugin_template-4fbabee1114b5508a9ffc49dfff58dc6ce1c5577'...
2022-03-16T05:07:42.0971411Z fatal: remote error: 
2022-03-16T05:07:42.0973580Z   The unauthenticated git protocol on port 9418 is no longer supported.
2022-03-16T05:07:42.0976169Z Please see https://github.blog/2021-09-01-improving-git-protocol-security-github/ for more information.
2022-03-16T05:07:42.0978440Z exit code: 128
```