### PR TITLE
[webview_flutter] In the case of sw backend, use only one buffer for rendering

### DIFF
--- a/packages/webview_flutter/tizen/src/buffer_pool.cc
+++ b/packages/webview_flutter/tizen/src/buffer_pool.cc
@@ -6,8 +6,6 @@
 
 #include "log.h"
 
-#define BUFFER_POOL_SIZE 5
-
 BufferUnit::BufferUnit(int index, int width, int height)
     : isUsed_(false),
       index_(index),
@@ -73,8 +71,8 @@ void BufferUnit::Reset(int width, int height) {
   gpu_buffer_->buffer = tbm_surface_;
 }
 
-BufferPool::BufferPool(int width, int height) : last_index_(0) {
-  for (int idx = 0; idx < BUFFER_POOL_SIZE; idx++) {
+BufferPool::BufferPool(int width, int height, int pool_size) : last_index_(0) {
+  for (int idx = 0; idx < pool_size; idx++) {
     pool_.emplace_back(new BufferUnit(idx, width, height));
   }
   Prepare(width, height);
@@ -116,6 +114,18 @@ void BufferPool::Prepare(int width, int height) {
     BufferUnit* buffer = pool_[idx].get();
     buffer->Reset(width, height);
   }
+}
+
+SingleBufferPool::SingleBufferPool(int width, int height)
+    : BufferPool(width, height, 1) {}
+
+BufferUnit* SingleBufferPool::GetAvailableBuffer() {
+  pool_[0].get()->MarkInUse();
+  return pool_[0].get();
+}
+
+BufferUnit* SingleBufferPool::Find(tbm_surface_h surface) {
+  return pool_[0].get();
 }
 
 #ifndef NDEBUG

--- a/packages/webview_flutter/tizen/src/buffer_pool.cc
+++ b/packages/webview_flutter/tizen/src/buffer_pool.cc
@@ -119,6 +119,8 @@ void BufferPool::Prepare(int width, int height) {
 SingleBufferPool::SingleBufferPool(int width, int height)
     : BufferPool(width, height, 1) {}
 
+SingleBufferPool::~SingleBufferPool() {}
+
 BufferUnit* SingleBufferPool::GetAvailableBuffer() {
   pool_[0].get()->MarkInUse();
   return pool_[0].get();

--- a/packages/webview_flutter/tizen/src/buffer_pool.h
+++ b/packages/webview_flutter/tizen/src/buffer_pool.h
@@ -38,18 +38,28 @@ class BufferUnit {
 
 class BufferPool {
  public:
-  explicit BufferPool(int width, int height);
+  explicit BufferPool(int width, int height, int pool_size);
   ~BufferPool();
 
-  BufferUnit* GetAvailableBuffer();
-  BufferUnit* Find(tbm_surface_h surface);
+  virtual BufferUnit* GetAvailableBuffer();
+  virtual BufferUnit* Find(tbm_surface_h surface);
   void Release(BufferUnit* unit);
   void Prepare(int with, int height);
+
+ protected:
+  std::vector<std::unique_ptr<BufferUnit>> pool_;
 
  private:
   int last_index_;
   std::mutex mutex_;
-  std::vector<std::unique_ptr<BufferUnit>> pool_;
+};
+
+class SingleBufferPool : public BufferPool {
+ public:
+  explicit SingleBufferPool(int width, int height);
+
+  virtual BufferUnit* GetAvailableBuffer();
+  virtual BufferUnit* Find(tbm_surface_h surface);
 };
 
 #endif

--- a/packages/webview_flutter/tizen/src/buffer_pool.h
+++ b/packages/webview_flutter/tizen/src/buffer_pool.h
@@ -57,6 +57,7 @@ class BufferPool {
 class SingleBufferPool : public BufferPool {
  public:
   explicit SingleBufferPool(int width, int height);
+  ~SingleBufferPool();
 
   virtual BufferUnit* GetAvailableBuffer();
   virtual BufferUnit* Find(tbm_surface_h surface);

--- a/packages/webview_flutter/tizen/src/webview.cc
+++ b/packages/webview_flutter/tizen/src/webview.cc
@@ -174,9 +174,9 @@ WebView::WebView(flutter::PluginRegistrar* registrar, int viewId,
       platform_window_(platform_window) {
   use_sw_backend_ = NeedsSwBackend();
   if (use_sw_backend_) {
-    tbm_pool_ = new SingleBufferPool(width, height);
+    tbm_pool_ = std::make_unique<SingleBufferPool>(width, height);
   } else {
-    tbm_pool_ = new BufferPool(width, height, BUFFER_POOL_SIZE);
+    tbm_pool_ = std::make_unique<BufferPool>(width, height, BUFFER_POOL_SIZE);
   }
 
   texture_variant_ = new flutter::TextureVariant(flutter::GpuBufferTexture(
@@ -405,11 +405,6 @@ void WebView::Dispose() {
   if (texture_variant_) {
     delete texture_variant_;
     texture_variant_ = nullptr;
-  }
-
-  if (tbm_pool_) {
-    delete tbm_pool_;
-    tbm_pool_ = nullptr;
   }
 }
 

--- a/packages/webview_flutter/tizen/src/webview.cc
+++ b/packages/webview_flutter/tizen/src/webview.cc
@@ -140,7 +140,7 @@ bool GetValueFromEncodableMap(const flutter::EncodableValue& arguments,
   return false;
 }
 
-bool needsSwBackend(void) {
+bool NeedsSwBackend(void) {
   bool result = false;
   char* value = nullptr;
   int ret = system_info_get_platform_string(
@@ -172,7 +172,7 @@ WebView::WebView(flutter::PluginRegistrar* registrar, int viewId,
       context_(nullptr),
       texture_variant_(nullptr),
       platform_window_(platform_window) {
-  use_sw_backend_ = needsSwBackend();
+  use_sw_backend_ = NeedsSwBackend();
   if (use_sw_backend_) {
     tbm_pool_ = new SingleBufferPool(width, height);
   } else {

--- a/packages/webview_flutter/tizen/src/webview.h
+++ b/packages/webview_flutter/tizen/src/webview.h
@@ -83,7 +83,7 @@ class WebView : public PlatformView {
   Ecore_IMF_Context* context_;
   flutter::TextureVariant* texture_variant_;
   std::mutex mutex_;
-  BufferPool* tbm_pool_;
+  std::unique_ptr<BufferPool> tbm_pool_;
   void* platform_window_;
   bool use_sw_backend_;
 };

--- a/packages/webview_flutter/tizen/src/webview.h
+++ b/packages/webview_flutter/tizen/src/webview.h
@@ -24,6 +24,7 @@ class WebContainer;
 
 class TextInputChannel;
 class BufferPool;
+class SingleBufferPool;
 class BufferUnit;
 
 class WebView : public PlatformView {
@@ -82,8 +83,9 @@ class WebView : public PlatformView {
   Ecore_IMF_Context* context_;
   flutter::TextureVariant* texture_variant_;
   std::mutex mutex_;
-  std::unique_ptr<BufferPool> tbm_pool_;
+  BufferPool* tbm_pool_;
   void* platform_window_;
+  bool use_sw_backend_;
 };
 
 #endif  // FLUTTER_PLUGIN_WEBVIEW_FLUTTER_TIZEN_WEVIEW_H_


### PR DESCRIPTION
This is a compromise of partial rendering for performance. A sync issue may occur in the sw backend.

This patch improves rendering which is related to issue 2 of https://github.com/flutter-tizen/plugins/issues/339 