### PR TITLE
[battery_plus] Refactor the C++ code

### DIFF
--- a/packages/battery_plus/tizen/src/battery_plus_tizen_plugin.cc
+++ b/packages/battery_plus/tizen/src/battery_plus_tizen_plugin.cc
@@ -4,26 +4,102 @@
 
 #include "battery_plus_tizen_plugin.h"
 
-#include <device/battery.h>
-#include <device/callback.h>
 #include <flutter/event_channel.h>
 #include <flutter/event_sink.h>
-#include <flutter/event_stream_handler_functions.h>
+#include <flutter/event_stream_handler.h>
 #include <flutter/method_channel.h>
 #include <flutter/plugin_registrar.h>
 #include <flutter/standard_method_codec.h>
 
-#include <map>
+#include <memory>
 #include <string>
 
-#include "log.h"
+#include "device_battery.h"
+
+namespace {
+
+typedef flutter::EventChannel<flutter::EncodableValue> FlEventChannel;
+typedef flutter::EventSink<flutter::EncodableValue> FlEventSink;
+typedef flutter::MethodCall<flutter::EncodableValue> FlMethodCall;
+typedef flutter::MethodResult<flutter::EncodableValue> FlMethodResult;
+typedef flutter::MethodChannel<flutter::EncodableValue> FlMethodChannel;
+typedef flutter::StreamHandler<flutter::EncodableValue> FlStreamHandler;
+typedef flutter::StreamHandlerError<flutter::EncodableValue>
+    FlStreamHandlerError;
+
+std::string BatteryStatusToString(BatteryStatus status) {
+  switch (status) {
+    case BatteryStatus::kCharging:
+      return "charging";
+    case BatteryStatus::kFull:
+      return "full";
+    case BatteryStatus::kDischarging:
+      return "discharging";
+    case BatteryStatus::kUnknown:
+    default:
+      return "unknown";
+  }
+}
+
+class BatteryStatusStreamHandler : public FlStreamHandler {
+ protected:
+  std::unique_ptr<FlStreamHandlerError> OnListenInternal(
+      const flutter::EncodableValue *arguments,
+      std::unique_ptr<FlEventSink> &&events) override {
+    events_ = std::move(events);
+
+    BatteryStatusCallback callback = [this](BatteryStatus status) -> void {
+      if (status != BatteryStatus::kError) {
+        events_->Success(
+            flutter::EncodableValue(BatteryStatusToString(status)));
+      } else {
+        events_->Error(std::to_string(battery_.GetLastError()),
+                       battery_.GetLastErrorString());
+      }
+    };
+    if (!battery_.StartListen(callback)) {
+      return std::make_unique<FlStreamHandlerError>(
+          std::to_string(battery_.GetLastError()),
+          battery_.GetLastErrorString(), nullptr);
+    }
+
+    // Send an initial event once the stream has been set up.
+    callback(battery_.GetStatus());
+
+    return nullptr;
+  }
+
+  std::unique_ptr<FlStreamHandlerError> OnCancelInternal(
+      const flutter::EncodableValue *arguments) override {
+    battery_.StopListen();
+    events_.reset();
+    return nullptr;
+  }
+
+ private:
+  DeviceBattery battery_;
+  std::unique_ptr<FlEventSink> events_;
+};
 
 class BatteryPlusTizenPlugin : public flutter::Plugin {
  public:
   static void RegisterWithRegistrar(flutter::PluginRegistrar *registrar) {
-    LOG_DEBUG("RegisterWithRegistrar for BatteryPlusTizenPlugin");
     auto plugin = std::make_unique<BatteryPlusTizenPlugin>();
-    plugin->SetupChannels(registrar);
+
+    auto method_channel = std::make_unique<FlMethodChannel>(
+        registrar->messenger(), "dev.fluttercommunity.plus/battery",
+        &flutter::StandardMethodCodec::GetInstance());
+    method_channel->SetMethodCallHandler(
+        [plugin_pointer = plugin.get()](const auto &call, auto result) {
+          plugin_pointer->HandleMethodCall(call, std::move(result));
+        });
+
+    auto event_channel = std::make_unique<FlEventChannel>(
+        registrar->messenger(), "dev.fluttercommunity.plus/charging",
+        &flutter::StandardMethodCodec::GetInstance());
+    event_channel->SetStreamHandler(
+        std::make_unique<BatteryStatusStreamHandler>());
+
     registrar->AddPlugin(std::move(plugin));
   }
 
@@ -31,171 +107,27 @@ class BatteryPlusTizenPlugin : public flutter::Plugin {
 
   virtual ~BatteryPlusTizenPlugin() {}
 
-  void RegisterObserver(
-      std::unique_ptr<flutter::EventSink<flutter::EncodableValue>> &&events) {
-    events_ = std::move(events);
-
-    // DEVICE_CALLBACK_BATTERY_CHARGING callback is called in only two cases
-    // like charging and discharing. When the charging status becomes "Full",
-    // discharging status event is called. So if it is full and disconnected
-    // from USB or AC charger, then any callbacks will not be called because the
-    // status already is the discharging status. To resolve this issue,
-    // DEVICE_CALLBACK_BATTERY_LEVEL callback is added. This callback can check
-    // whether it is disconnected in "Full" status. That is, when the battery
-    // status is full and disconnected, the level status will be changed from
-    // DEVICE_BATTERY_LEVEL_FULL to DEVICE_BATTERY_LEVEL_HIGH.
-    int ret = device_add_callback(DEVICE_CALLBACK_BATTERY_CHARGING,
-                                  BatteryChangedCB, this);
-    if (ret != DEVICE_ERROR_NONE) {
-      events_->Error("failed_to_add_callback", get_error_message(ret));
-      return;
-    }
-
-    ret = device_add_callback(DEVICE_CALLBACK_BATTERY_LEVEL, BatteryChangedCB,
-                              this);
-    if (ret != DEVICE_ERROR_NONE) {
-      events_->Error("failed_to_add_callback", get_error_message(ret));
-      return;
-    }
-
-    std::string status = GetBatteryStatus();
-    if (status.empty()) {
-      events_->Error("invalid_status", "Charging status error");
-    } else {
-      events_->Success(flutter::EncodableValue(status));
-    }
-  }
-
-  void UnregisterObserver() {
-    int ret = device_remove_callback(DEVICE_CALLBACK_BATTERY_CHARGING,
-                                     BatteryChangedCB);
-    if (ret != DEVICE_ERROR_NONE) {
-      LOG_ERROR("Failed to run device_remove_callback (%d: %s)", ret,
-                get_error_message(ret));
-    }
-    ret =
-        device_remove_callback(DEVICE_CALLBACK_BATTERY_LEVEL, BatteryChangedCB);
-    if (ret != DEVICE_ERROR_NONE) {
-      LOG_ERROR("Failed to run device_remove_callback (%d: %s)", ret,
-                get_error_message(ret));
-    }
-
-    events_ = nullptr;
-  }
-
-  static std::string GetBatteryStatus() {
-    device_battery_status_e status;
-    int ret = device_battery_get_status(&status);
-    if (ret != DEVICE_ERROR_NONE) {
-      LOG_ERROR("Failed to run device_battery_get_status (%d: %s)", ret,
-                get_error_message(ret));
-      return "";
-    }
-
-    std::string value;
-    if (status == DEVICE_BATTERY_STATUS_CHARGING) {
-      value = "charging";
-    } else if (status == DEVICE_BATTERY_STATUS_FULL) {
-      value = "full";
-    } else if (status == DEVICE_BATTERY_STATUS_DISCHARGING ||
-               status == DEVICE_BATTERY_STATUS_NOT_CHARGING) {
-      value = "discharging";
-    }
-    LOG_INFO("battery status [%s]", value.c_str());
-    return value;
-  }
-
-  static void BatteryChangedCB(device_callback_e type, void *value,
-                               void *user_data) {
-    if (!user_data) {
-      LOG_ERROR("Invalid user data");
-      return;
-    }
-
-    // DEVICE_CALLBACK_BATTERY_LEVEL callback is used only for checking whether
-    // the battery became a discharging status while it is full.
-    if (type == DEVICE_CALLBACK_BATTERY_LEVEL &&
-        intptr_t(value) < DEVICE_BATTERY_LEVEL_HIGH) {
-      return;
-    }
-
-    BatteryPlusTizenPlugin *plugin_pointer =
-        (BatteryPlusTizenPlugin *)user_data;
-
-    std::string status = GetBatteryStatus();
-    bool is_full = status == "full";
-    if (is_full && plugin_pointer->is_full_) {
-      // This function is called twice by registered callbacks when battery
-      // status is full. So, it needs to avoid the unnecessary second call.
-      return;
-    }
-    plugin_pointer->is_full_ = is_full;
-
-    if (status.empty()) {
-      plugin_pointer->events_->Error("invalid_status", "Charging status error");
-    } else {
-      plugin_pointer->events_->Success(flutter::EncodableValue(status));
-    }
-  }
-
-  void HandleMethodCall(
-      const flutter::MethodCall<flutter::EncodableValue> &method_call,
-      std::unique_ptr<flutter::MethodResult<flutter::EncodableValue>> result) {
+ private:
+  void HandleMethodCall(const FlMethodCall &method_call,
+                        std::unique_ptr<FlMethodResult> result) {
     const auto &method_name = method_call.method_name();
 
     if (method_name == "getBatteryLevel") {
-      int percentage;
-      int ret = device_battery_get_percent(&percentage);
-      if (ret != DEVICE_ERROR_NONE) {
-        result->Error("internal_error", get_error_message(ret));
+      DeviceBattery battery;
+      int32_t level = battery.GetLevel();
+      if (level >= 0) {
+        result->Success(flutter::EncodableValue(level));
+      } else {
+        result->Error(std::to_string(battery.GetLastError()),
+                      battery.GetLastErrorString());
       }
-      LOG_INFO("battery percentage [%d]", percentage);
-      result->Success(flutter::EncodableValue(percentage));
     } else {
       result->NotImplemented();
     }
   }
-
- private:
-  void SetupChannels(flutter::PluginRegistrar *registrar) {
-    auto method_channel =
-        std::make_unique<flutter::MethodChannel<flutter::EncodableValue>>(
-            registrar->messenger(), "dev.fluttercommunity.plus/battery",
-            &flutter::StandardMethodCodec::GetInstance());
-    event_channel_ =
-        std::make_unique<flutter::EventChannel<flutter::EncodableValue>>(
-            registrar->messenger(), "dev.fluttercommunity.plus/charging",
-            &flutter::StandardMethodCodec::GetInstance());
-
-    auto method_channel_handler = [this](const auto &call, auto result) {
-      LOG_DEBUG("HandleMethodCall call");
-      HandleMethodCall(call, std::move(result));
-    };
-    auto event_channel_handler =
-        std::make_unique<flutter::StreamHandlerFunctions<>>(
-            [this](const flutter::EncodableValue *arguments,
-                   std::unique_ptr<flutter::EventSink<>> &&events)
-                -> std::unique_ptr<flutter::StreamHandlerError<>> {
-              LOG_DEBUG("OnListen");
-              RegisterObserver(std::move(events));
-              return nullptr;
-            },
-            [this](const flutter::EncodableValue *arguments)
-                -> std::unique_ptr<flutter::StreamHandlerError<>> {
-              LOG_DEBUG("OnCancel");
-              UnregisterObserver();
-              return nullptr;
-            });
-
-    method_channel->SetMethodCallHandler(method_channel_handler);
-    event_channel_->SetStreamHandler(std::move(event_channel_handler));
-  }
-
-  std::unique_ptr<flutter::EventChannel<flutter::EncodableValue>>
-      event_channel_;
-  std::unique_ptr<flutter::EventSink<flutter::EncodableValue>> events_;
-  bool is_full_ = false;
 };
+
+}  // namespace
 
 void BatteryPlusTizenPluginRegisterWithRegistrar(
     FlutterDesktopPluginRegistrarRef registrar) {

--- a/packages/battery_plus/tizen/src/device_battery.cc
+++ b/packages/battery_plus/tizen/src/device_battery.cc
@@ -22,6 +22,7 @@ bool DeviceBattery::StartListen(BatteryStatusCallback callback) {
                                 OnBatteryStatusChanged, this);
   if (ret != DEVICE_ERROR_NONE) {
     LOG_ERROR("Failed to add callback: %s", get_error_message(ret));
+    last_error_ = ret;
     return false;
   }
 
@@ -29,6 +30,7 @@ bool DeviceBattery::StartListen(BatteryStatusCallback callback) {
                             OnBatteryStatusChanged, this);
   if (ret != DEVICE_ERROR_NONE) {
     LOG_ERROR("Failed to add callback: %s", get_error_message(ret));
+    last_error_ = ret;
     return false;
   }
 
@@ -41,12 +43,14 @@ void DeviceBattery::StopListen() {
                                    OnBatteryStatusChanged);
   if (ret != DEVICE_ERROR_NONE) {
     LOG_ERROR("Failed to remove callback: %s", get_error_message(ret));
+    last_error_ = ret;
   }
 
   ret = device_remove_callback(DEVICE_CALLBACK_BATTERY_LEVEL,
                                OnBatteryStatusChanged);
   if (ret != DEVICE_ERROR_NONE) {
     LOG_ERROR("Failed to remove callback: %s", get_error_message(ret));
+    last_error_ = ret;
   }
 }
 
@@ -55,6 +59,7 @@ int32_t DeviceBattery::GetLevel() {
   int ret = device_battery_get_percent(&level);
   if (ret != DEVICE_ERROR_NONE) {
     LOG_ERROR("Failed to get battery level: %s", get_error_message(ret));
+    last_error_ = ret;
     return -1;
   }
   return level;
@@ -65,6 +70,7 @@ BatteryStatus DeviceBattery::GetStatus() {
   int ret = device_battery_get_status(&status);
   if (ret != DEVICE_ERROR_NONE) {
     LOG_ERROR("Failed to get battery status: %s", get_error_message(ret));
+    last_error_ = ret;
     return BatteryStatus::kError;
   }
 

--- a/packages/battery_plus/tizen/src/device_battery.cc
+++ b/packages/battery_plus/tizen/src/device_battery.cc
@@ -1,0 +1,104 @@
+// Copyright 2022 Samsung Electronics Co., Ltd. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "device_battery.h"
+
+#include <device/battery.h>
+
+#include "log.h"
+
+bool DeviceBattery::StartListen(BatteryStatusCallback callback) {
+  // DEVICE_CALLBACK_BATTERY_CHARGING callback is called in only two cases
+  // like charging and discharing. When the charging status becomes "Full",
+  // discharging status event is called. So if it is full and disconnected
+  // from USB or AC charger, then any callbacks will not be called because the
+  // status already is the discharging status. To resolve this issue,
+  // DEVICE_CALLBACK_BATTERY_LEVEL callback is added. This callback can check
+  // whether it is disconnected in "Full" status. That is, when the battery
+  // status is full and disconnected, the level status will be changed from
+  // DEVICE_BATTERY_LEVEL_FULL to DEVICE_BATTERY_LEVEL_HIGH.
+  int ret = device_add_callback(DEVICE_CALLBACK_BATTERY_CHARGING,
+                                OnBatteryStatusChanged, this);
+  if (ret != DEVICE_ERROR_NONE) {
+    LOG_ERROR("Failed to add callback: %s", get_error_message(ret));
+    return false;
+  }
+
+  ret = device_add_callback(DEVICE_CALLBACK_BATTERY_LEVEL,
+                            OnBatteryStatusChanged, this);
+  if (ret != DEVICE_ERROR_NONE) {
+    LOG_ERROR("Failed to add callback: %s", get_error_message(ret));
+    return false;
+  }
+
+  callback_ = callback;
+  return true;
+}
+
+void DeviceBattery::StopListen() {
+  int ret = device_remove_callback(DEVICE_CALLBACK_BATTERY_CHARGING,
+                                   OnBatteryStatusChanged);
+  if (ret != DEVICE_ERROR_NONE) {
+    LOG_ERROR("Failed to remove callback: %s", get_error_message(ret));
+  }
+
+  ret = device_remove_callback(DEVICE_CALLBACK_BATTERY_LEVEL,
+                               OnBatteryStatusChanged);
+  if (ret != DEVICE_ERROR_NONE) {
+    LOG_ERROR("Failed to remove callback: %s", get_error_message(ret));
+  }
+}
+
+int32_t DeviceBattery::GetLevel() {
+  int32_t level;
+  int ret = device_battery_get_percent(&level);
+  if (ret != DEVICE_ERROR_NONE) {
+    LOG_ERROR("Failed to get battery level: %s", get_error_message(ret));
+    return -1;
+  }
+  return level;
+}
+
+BatteryStatus DeviceBattery::GetStatus() {
+  device_battery_status_e status;
+  int ret = device_battery_get_status(&status);
+  if (ret != DEVICE_ERROR_NONE) {
+    LOG_ERROR("Failed to get battery status: %s", get_error_message(ret));
+    return BatteryStatus::kError;
+  }
+
+  switch (status) {
+    case DEVICE_BATTERY_STATUS_CHARGING:
+      return BatteryStatus::kCharging;
+    case DEVICE_BATTERY_STATUS_FULL:
+      return BatteryStatus::kFull;
+    case DEVICE_BATTERY_STATUS_DISCHARGING:
+    case DEVICE_BATTERY_STATUS_NOT_CHARGING:
+      return BatteryStatus::kDischarging;
+    default:
+      return BatteryStatus::kUnknown;
+  }
+}
+
+void DeviceBattery::OnBatteryStatusChanged(device_callback_e type, void *value,
+                                           void *user_data) {
+  auto *self = static_cast<DeviceBattery *>(user_data);
+
+  // DEVICE_CALLBACK_BATTERY_LEVEL callback is used only for checking whether
+  // the battery became a discharging status while it is full.
+  if (type == DEVICE_CALLBACK_BATTERY_LEVEL &&
+      intptr_t(value) < DEVICE_BATTERY_LEVEL_HIGH) {
+    return;
+  }
+
+  BatteryStatus status = self->GetStatus();
+  if (status == BatteryStatus::kFull && self->is_full_) {
+    // This function is called twice by registered callbacks when battery
+    // status is full. So, it needs to avoid the unnecessary second call.
+    return;
+  }
+  self->is_full_ = status == BatteryStatus::kFull;
+
+  self->callback_(status);
+}

--- a/packages/battery_plus/tizen/src/device_battery.h
+++ b/packages/battery_plus/tizen/src/device_battery.h
@@ -1,0 +1,43 @@
+// Copyright 2022 Samsung Electronics Co., Ltd. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef FLUTTER_PLUGIN_DEVICE_BATTERY_H_
+#define FLUTTER_PLUGIN_DEVICE_BATTERY_H_
+
+#include <device/callback.h>
+#include <tizen.h>
+
+#include <functional>
+#include <string>
+
+enum class BatteryStatus { kFull, kCharging, kDischarging, kUnknown, kError };
+
+typedef std::function<void(BatteryStatus)> BatteryStatusCallback;
+
+class DeviceBattery {
+ public:
+  DeviceBattery() {}
+  ~DeviceBattery() {}
+
+  int GetLastError() { return get_last_result(); }
+
+  std::string GetLastErrorString() { return get_error_message(GetLastError()); }
+
+  bool StartListen(BatteryStatusCallback callback);
+
+  void StopListen();
+
+  int32_t GetLevel();
+
+  BatteryStatus GetStatus();
+
+ private:
+  static void OnBatteryStatusChanged(device_callback_e type, void *value,
+                                     void *user_data);
+
+  BatteryStatusCallback callback_ = nullptr;
+  bool is_full_ = false;
+};
+
+#endif  // FLUTTER_PLUGIN_DEVICE_BATTERY_H_

--- a/packages/battery_plus/tizen/src/device_battery.h
+++ b/packages/battery_plus/tizen/src/device_battery.h
@@ -20,9 +20,9 @@ class DeviceBattery {
   DeviceBattery() {}
   ~DeviceBattery() {}
 
-  int GetLastError() { return get_last_result(); }
+  int GetLastError() { return last_error_; }
 
-  std::string GetLastErrorString() { return get_error_message(GetLastError()); }
+  std::string GetLastErrorString() { return get_error_message(last_error_); }
 
   bool StartListen(BatteryStatusCallback callback);
 
@@ -36,6 +36,7 @@ class DeviceBattery {
   static void OnBatteryStatusChanged(device_callback_e type, void *value,
                                      void *user_data);
 
+  int last_error_ = TIZEN_ERROR_NONE;
   BatteryStatusCallback callback_ = nullptr;
   bool is_full_ = false;
 };


### PR DESCRIPTION
Part of [the code refactoring project](https://github.com/flutter-tizen/plugins/issues/354).

- Extract the `DeviceBattery` class from `BatteryPlusTizenPlugin` for better separation of the platform channel communication and the device API usage. (I referred to the [battery_plus_windows](https://github.com/fluttercommunity/plus_plugins/blob/main/packages/battery_plus/battery_plus_windows/windows/include/battery_plus_windows/system_battery.h) implementation.)
  - Create an enum `BatteryStatus` to indicate the current status of the device battery or an error status.
  - `RegisterObserver`/`UnregisterObserver` → `StartListen`/`StopListen`
  - `StartListen` takes `BatteryStatusCallback` as an argument.
  - Create a new method `GetLevel`.
  - Let `GetStatus` (previously `GetBatteryStatus`) return a value of type `BatteryStatus`.
- Create typedefs of long commonly-used types (also taken from [battery_plus_windows](https://github.com/fluttercommunity/plus_plugins/blob/main/packages/battery_plus/battery_plus_windows/windows/battery_plus_windows_plugin.cpp)) for improved readability. For example,<p>
  ```patch
  - std::unique_ptr<flutter::EventSink<flutter::EncodableValue>> events_;
  + std::unique_ptr<FlEventSink> events_;
  ```
- Create an explicit `BatteryStatusStreamHandler` class. Now the lifecycle of `EventSink` is solely managed by this class.
  - `OnListenInternal` returns a `StreamHandlerError` on initialization failure.
- Minor cleanups.
  - Remove `SetupChannels` and combine with `RegisterWithRegistrar`.
  - Style log messages and error codes in a consistent manner.
  - Wrap the non-public implementation with an anonymous namespace.

Additional note: The `batteryState` getter API has been added the platform interface and will be implemented in a later PR.