### PR TITLE
Quick fix for missing package in recipe

### DIFF
--- a/tools/lib/src/integration_test_command.dart
+++ b/tools/lib/src/integration_test_command.dart
@@ -125,11 +125,15 @@ class IntegrationTestCommand extends PackageLoopingCommand {
         throw ToolExit(exitCommandFoundErrors);
       }
       try {
-        final YamlMap recipe =
-            loadYaml(recipeFile.readAsStringSync()) as YamlMap;
-        profiles = (recipe['plugins'][package.displayName] as YamlList)
-            .cast<String>()
-            .map((String profile) => Profile.fromString(profile))
+        final Map<String, YamlList> recipe =
+            (loadYaml(recipeFile.readAsStringSync())['plugins'] as YamlMap)
+                .cast<String, YamlList>();
+        if (!recipe.containsKey(package.displayName)) {
+          return PackageResult.skip(
+              'Skipped by recipe: ${package.displayName}.');
+        }
+        profiles = recipe[package.displayName]!
+            .map((dynamic profile) => Profile.fromString(profile as String))
             .toList();
         if (profiles.isEmpty) {
           // TODO(HakkyuKim): Return [PackageResult.exclude()] after subclassing


### PR DESCRIPTION
Retaining the original semantics of recipe became tricky after depending on `flutter_plugin_tools`. I'll refactor the tool code after looking more into the base classes of `flutter_plugin_tools`, or change the semantics of recipe. For now missing packages in recipe will be skipped.