### PR TITLE
Implement recipe logic properly

### DIFF
--- a/tools/lib/src/integration_test_command.dart
+++ b/tools/lib/src/integration_test_command.dart
@@ -136,8 +136,9 @@ class IntegrationTestCommand extends PackageLoopingCommand {
 
   /// See: [PluginCommand.getTargetPackages].
   @override
-  Stream<PackageEnumerationEntry> getTargetPackages(
-      {bool filterExcluded = true}) async* {
+  Stream<PackageEnumerationEntry> getTargetPackages({
+    bool filterExcluded = true,
+  }) async* {
     if (_recipe == null) {
       yield* super.getTargetPackages(filterExcluded: filterExcluded);
     }
@@ -147,7 +148,7 @@ class IntegrationTestCommand extends PackageLoopingCommand {
         await super.getTargetPackages(filterExcluded: filterExcluded).toList();
     for (final PackageEnumerationEntry plugin in plugins) {
       final String pluginName = plugin.package.displayName;
-      if (!recipe.isRecognized(pluginName)) {
+      if (!recipe.contains(pluginName)) {
         continue;
       }
       if (!(filterExcluded && plugin.excluded)) {

--- a/tools/lib/src/recipe.dart
+++ b/tools/lib/src/recipe.dart
@@ -1,0 +1,52 @@
+// Copyright 2022 Samsung Electronics Co., Ltd. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:yaml/yaml.dart';
+
+import 'tizen_sdk.dart';
+
+/// A class that holds data parsed from recipe file.
+class Recipe {
+  Recipe._(Map<String, List<Profile>> profilesPerPackages,
+      {List<String> excluded = const <String>[]})
+      : _profilesPerPackage = profilesPerPackages,
+        _excluded = excluded;
+
+  /// Creates a [Recipe] instance by parsing [yamlMap].
+  factory Recipe.fromYaml(YamlMap yamlMap) {
+    final Map<String, YamlList> plugins =
+        (yamlMap['plugins'] as YamlMap).cast<String, YamlList>();
+    final List<String> excluded = <String>[];
+    final Map<String, List<Profile>> profilesPerPackage =
+        <String, List<Profile>>{};
+    for (final MapEntry<String, YamlList> plugin in plugins.entries) {
+      if (plugin.value.isEmpty) {
+        excluded.add(plugin.key);
+      } else {
+        profilesPerPackage[plugin.key] = plugin.value
+            .map((dynamic profile) => Profile.fromString(profile as String))
+            .toList();
+      }
+    }
+    return Recipe._(
+      profilesPerPackage,
+      excluded: excluded,
+    );
+  }
+
+  final List<String> _excluded;
+  final Map<String, List<Profile>> _profilesPerPackage;
+
+  /// Returns `true` if [plugin] was specified in the recipe file but
+  /// with an empty profile list.
+  bool isExcluded(String plugin) => _excluded.contains(plugin);
+
+  /// Returns `true` if [plugin] was specified in the recipe file.
+  bool isRecognized(String plugin) =>
+      _profilesPerPackage.containsKey(plugin) || _excluded.contains(plugin);
+
+  /// Returns a list of profiles to test on for [plugin].
+  List<Profile> getProfiles(String plugin) =>
+      _profilesPerPackage[plugin] ?? <Profile>[];
+}

--- a/tools/test/device_test.dart
+++ b/tools/test/device_test.dart
@@ -47,7 +47,7 @@ void main() {
       tizenSdk = MockTizenSdk();
       when(() => tizenSdk.sdbDevices()).thenReturn(<SdbDeviceInfo>[
         const SdbDeviceInfo(
-          id: 'some_id',
+          serial: 'some_id',
           status: 'device',
           name: 'some_name',
         )
@@ -63,7 +63,7 @@ void main() {
     test('fails when integration test takes longer than timeout.', () async {
       // Simulates closing the stdout stream of a child process when it exits
       // from [Process.exitCode].
-      // TODO(HakkyuKim): Properly handle this from a mock class. 
+      // TODO(HakkyuKim): Properly handle this from a mock class.
       Future<void>.delayed(Duration(seconds: timeoutLimit.inSeconds + 1), () {
         controller.close();
       });

--- a/tools/test/integration_test_command_test.dart
+++ b/tools/test/integration_test_command_test.dart
@@ -164,7 +164,7 @@ plugins:
       expect(
         output,
         containsAllInOrder(
-          <Matcher>[contains('Skipped by recipe: a')],
+          <Matcher>[contains('Excluded by recipe: a')],
         ),
       );
     });

--- a/tools/test/integration_test_command_test.dart
+++ b/tools/test/integration_test_command_test.dart
@@ -164,7 +164,7 @@ plugins:
       expect(
         output,
         containsAllInOrder(
-          <Matcher>[contains('Excluded by recipe: a')],
+          <Matcher>[contains('Not running for a; excluded')],
         ),
       );
     });

--- a/tools/test/recipe_test.dart
+++ b/tools/test/recipe_test.dart
@@ -22,8 +22,11 @@ plugins:
   test('correctly parses recipe', () {
     final Recipe recipe = Recipe.fromYaml(loadYaml(yamlString) as YamlMap);
 
-    expect(recipe.isRecognized('c'), true);
+    expect(recipe.contains('c'), true);
     expect(recipe.isExcluded('c'), true);
+
+    expect(recipe.contains('d'), false);
+    expect(recipe.isExcluded('d'), false);
 
     expect(recipe.getProfiles('a').first.toString(), 'wearable-5.5');
     expect(recipe.getProfiles('b').map((Profile profile) => profile.toString()),

--- a/tools/test/recipe_test.dart
+++ b/tools/test/recipe_test.dart
@@ -1,0 +1,32 @@
+// Copyright 2022 Samsung Electronics Co., Ltd. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter_tizen_plugin_tools/src/recipe.dart';
+import 'package:flutter_tizen_plugin_tools/src/tizen_sdk.dart';
+import 'package:test/test.dart';
+import 'package:yaml/yaml.dart';
+
+void main() {
+  late String yamlString;
+  setUp(() {
+    yamlString = '''
+plugins:
+  a: ["wearable-5.5"]
+  b: ["wearable-5.5", "tv-6.0"]
+
+  c: []
+''';
+  });
+
+  test('correctly parses recipe', () {
+    final Recipe recipe = Recipe.fromYaml(loadYaml(yamlString) as YamlMap);
+
+    expect(recipe.isRecognized('c'), true);
+    expect(recipe.isExcluded('c'), true);
+
+    expect(recipe.getProfiles('a').first.toString(), 'wearable-5.5');
+    expect(recipe.getProfiles('b').map((Profile profile) => profile.toString()),
+        unorderedEquals(<String>['wearable-5.5', 'tv-6.0']));
+  });
+}


### PR DESCRIPTION
Follows the original semantics of recipe:
- plugins not in the recipe file are not recognized by the tool during integration test.
- plugins with empty list are marked 'excluded' during integration test.