### PR TITLE
[battery_plus] Implement getBatteryState

### DIFF
--- a/packages/battery_plus/CHANGELOG.md
+++ b/packages/battery_plus/CHANGELOG.md
@@ -1,3 +1,11 @@
+## 1.1.0
+
+* Update battery_plus to 2.1.3.
+* Update battery_plus_platform_interface to 1.2.1.
+* Support `Battery.batteryState`.
+* Update the example app.
+* Code refactoring.
+
 ## 1.0.3
 
 * Update battery_plus to 2.0.2.

--- a/packages/battery_plus/README.md
+++ b/packages/battery_plus/README.md
@@ -10,8 +10,8 @@ This package is not an _endorsed_ implementation of `battery_plus`. Therefore, y
 
 ```yaml
 dependencies:
-  battery_plus: ^2.0.2
-  battery_plus_tizen: ^1.0.3
+  battery_plus: ^2.1.3
+  battery_plus_tizen: ^1.1.0
 ```
 
 Then you can import `battery_plus` in your Dart code:
@@ -26,6 +26,7 @@ For detailed usage, see https://pub.dev/packages/battery_plus#usage.
 
 - [x] `Battery.batteryLevel`
 - [ ] `Battery.isInBatterySaveMode`
+- [x] `Battery.batteryState`
 - [x] `Battery.onBatteryStateChanged`
 
 ## Supported devices

--- a/packages/battery_plus/example/lib/main.dart
+++ b/packages/battery_plus/example/lib/main.dart
@@ -46,11 +46,15 @@ class _MyHomePageState extends State<MyHomePage> {
   @override
   void initState() {
     super.initState();
+    _battery.batteryState.then(_updateBatteryState);
     _batteryStateSubscription =
-        _battery.onBatteryStateChanged.listen((BatteryState state) {
-      setState(() {
-        _batteryState = state;
-      });
+        _battery.onBatteryStateChanged.listen(_updateBatteryState);
+  }
+
+  void _updateBatteryState(BatteryState state) {
+    if (_batteryState == state) return;
+    setState(() {
+      _batteryState = state;
     });
   }
 

--- a/packages/battery_plus/example/pubspec.yaml
+++ b/packages/battery_plus/example/pubspec.yaml
@@ -3,7 +3,7 @@ description: Demonstrates how to use the battery_plus plugin.
 publish_to: "none"
 
 dependencies:
-  battery_plus: ^2.0.2
+  battery_plus: ^2.1.3
   battery_plus_tizen:
     path: ../
   flutter:

--- a/packages/battery_plus/pubspec.yaml
+++ b/packages/battery_plus/pubspec.yaml
@@ -2,7 +2,7 @@ name: battery_plus_tizen
 description: Tizen implementation of the battery_plus plugin
 homepage: https://github.com/flutter-tizen/plugins
 repository: https://github.com/flutter-tizen/plugins/tree/master/packages/battery_plus
-version: 1.0.3
+version: 1.1.0
 
 flutter:
   plugin:
@@ -12,7 +12,7 @@ flutter:
         fileName: battery_plus_tizen_plugin.h
 
 dependencies:
-  battery_plus_platform_interface: ^1.1.1
+  battery_plus_platform_interface: ^1.2.1
   flutter:
     sdk: flutter
 

--- a/packages/battery_plus/tizen/src/battery_plus_tizen_plugin.cc
+++ b/packages/battery_plus/tizen/src/battery_plus_tizen_plugin.cc
@@ -94,10 +94,10 @@ class BatteryPlusTizenPlugin : public flutter::Plugin {
           plugin_pointer->HandleMethodCall(call, std::move(result));
         });
 
-    auto event_channel = std::make_unique<FlEventChannel>(
+    plugin->event_channel_ = std::make_unique<FlEventChannel>(
         registrar->messenger(), "dev.fluttercommunity.plus/charging",
         &flutter::StandardMethodCodec::GetInstance());
-    event_channel->SetStreamHandler(
+    plugin->event_channel_->SetStreamHandler(
         std::make_unique<BatteryStatusStreamHandler>());
 
     registrar->AddPlugin(std::move(plugin));
@@ -134,6 +134,8 @@ class BatteryPlusTizenPlugin : public flutter::Plugin {
       result->NotImplemented();
     }
   }
+
+  std::unique_ptr<FlEventChannel> event_channel_;
 };
 
 }  // namespace

--- a/packages/battery_plus/tizen/src/battery_plus_tizen_plugin.cc
+++ b/packages/battery_plus/tizen/src/battery_plus_tizen_plugin.cc
@@ -121,6 +121,15 @@ class BatteryPlusTizenPlugin : public flutter::Plugin {
         result->Error(std::to_string(battery.GetLastError()),
                       battery.GetLastErrorString());
       }
+    } else if (method_name == "getBatteryState") {
+      DeviceBattery battery;
+      BatteryStatus status = battery.GetStatus();
+      if (status != BatteryStatus::kError) {
+        result->Success(flutter::EncodableValue(BatteryStatusToString(status)));
+      } else {
+        result->Error(std::to_string(battery.GetLastError()),
+                      battery.GetLastErrorString());
+      }
     } else {
       result->NotImplemented();
     }


### PR DESCRIPTION
Adds support for `Battery.batteryState`.

Also reverts part of https://github.com/flutter-tizen/plugins/pull/351. The `EventChannel` instance must be preserved in memory during the plugin lifetime. See https://github.com/flutter-tizen/plugins/pull/134.