### PR TITLE
[connectivity_plus] Add bluetooth as connectivity result

### DIFF
--- a/packages/connectivity_plus/CHANGELOG.md
+++ b/packages/connectivity_plus/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 1.1.1
+
+* Update connectivity_plus to 2.3.0.
+* Update connectivity_plus_platform_interface to 1.2.0.
+* Support bluetooth as connectivity result.
+* Code refactoring.
+
 ## 1.1.0
 
 * Update connectivity_plus to 2.1.0.

--- a/packages/connectivity_plus/README.md
+++ b/packages/connectivity_plus/README.md
@@ -10,8 +10,8 @@ This package is not an _endorsed_ implementation of `connectivity_plus`. Therefo
 
 ```yaml
 dependencies:
-  connectivity_plus: ^2.1.0
-  connectivity_plus_tizen: ^1.1.0
+  connectivity_plus: ^2.3.0
+  connectivity_plus_tizen: ^1.1.1
 ```
 
 Then you can import `connectivity_plus` in your Dart code:

--- a/packages/connectivity_plus/example/pubspec.yaml
+++ b/packages/connectivity_plus/example/pubspec.yaml
@@ -3,7 +3,7 @@ description: Demonstrates how to use the connectivity_plus_tizen plugin.
 publish_to: "none"
 
 dependencies:
-  connectivity_plus: ^2.1.0
+  connectivity_plus: ^2.3.0
   connectivity_plus_tizen:
     path: ../
   flutter:

--- a/packages/connectivity_plus/pubspec.yaml
+++ b/packages/connectivity_plus/pubspec.yaml
@@ -2,7 +2,7 @@ name: connectivity_plus_tizen
 description: Tizen implementation of the connectivity_plus plugin.
 homepage: https://github.com/flutter-tizen/plugins
 repository: https://github.com/flutter-tizen/plugins/tree/master/packages/connectivity_plus
-version: 1.1.0
+version: 1.1.1
 
 flutter:
   plugin:
@@ -12,7 +12,7 @@ flutter:
         fileName: connectivity_plus_tizen_plugin.h
 
 dependencies:
-  connectivity_plus_platform_interface: ^1.1.1
+  connectivity_plus_platform_interface: ^1.2.0
   flutter:
     sdk: flutter
 

--- a/packages/connectivity_plus/tizen/src/connection.cc
+++ b/packages/connectivity_plus/tizen/src/connection.cc
@@ -14,6 +14,8 @@ static ConnectionType ToConnectionType(connection_type_e type) {
       return ConnectionType::kMobile;
     case CONNECTION_TYPE_ETHERNET:
       return ConnectionType::kEthernet;
+    case CONNECTION_TYPE_BT:
+      return ConnectionType::kBluetooth;
     case CONNECTION_TYPE_DISCONNECTED:
     default:
       return ConnectionType::kNone;

--- a/packages/connectivity_plus/tizen/src/connection.h
+++ b/packages/connectivity_plus/tizen/src/connection.h
@@ -11,7 +11,14 @@
 #include <functional>
 #include <string>
 
-enum class ConnectionType { kNone, kEthernet, kWiFi, kMobile, kError };
+enum class ConnectionType {
+  kNone,
+  kEthernet,
+  kWiFi,
+  kMobile,
+  kBluetooth,
+  kError
+};
 
 typedef std::function<void(ConnectionType)> ConnectionTypeCallback;
 

--- a/packages/connectivity_plus/tizen/src/connectivity_plus_tizen_plugin.cc
+++ b/packages/connectivity_plus/tizen/src/connectivity_plus_tizen_plugin.cc
@@ -35,6 +35,8 @@ std::string ConnectionTypeToString(ConnectionType type) {
       return "wifi";
     case ConnectionType::kMobile:
       return "mobile";
+    case ConnectionType::kBluetooth:
+      return "bluetooth";
     case ConnectionType::kNone:
     default:
       return "none";

--- a/packages/connectivity_plus/tizen/src/connectivity_plus_tizen_plugin.cc
+++ b/packages/connectivity_plus/tizen/src/connectivity_plus_tizen_plugin.cc
@@ -95,10 +95,10 @@ class ConnectivityPlusTizenPlugin : public flutter::Plugin {
           plugin_pointer->HandleMethodCall(call, std::move(result));
         });
 
-    auto event_channel = std::make_unique<FlEventChannel>(
+    plugin->event_channel_ = std::make_unique<FlEventChannel>(
         registrar->messenger(), "dev.fluttercommunity.plus/connectivity_status",
         &flutter::StandardMethodCodec::GetInstance());
-    event_channel->SetStreamHandler(
+    plugin->event_channel_->SetStreamHandler(
         std::make_unique<ConnectivityStreamHandler>());
 
     registrar->AddPlugin(std::move(plugin));
@@ -126,6 +126,8 @@ class ConnectivityPlusTizenPlugin : public flutter::Plugin {
       result->NotImplemented();
     }
   }
+
+  std::unique_ptr<FlEventChannel> event_channel_;
 };
 
 }  // namespace


### PR DESCRIPTION
Adds support for `ConnectivityResult.bluetooth`.

Also reverts part of https://github.com/flutter-tizen/plugins/pull/352. The `EventChannel` instance must be preserved in memory during the plugin lifetime. See https://github.com/flutter-tizen/plugins/pull/134.