### PR TITLE
[video_player] Minor code cleanup

### DIFF
--- a/packages/video_player/CHANGELOG.md
+++ b/packages/video_player/CHANGELOG.md
@@ -1,3 +1,7 @@
+## NEXT
+
+* Code cleanups.
+
 ## 2.3.2
 
 * Apply texture common release callback.

--- a/packages/video_player/tizen/src/message.cc
+++ b/packages/video_player/tizen/src/message.cc
@@ -3,14 +3,11 @@
 #include <flutter/basic_message_channel.h>
 #include <flutter/standard_message_codec.h>
 
-#include "log.h"
-
 int64_t TextureMessage::getTextureId() const { return textureId_; }
 
 void TextureMessage::setTextureId(int64_t textureId) { textureId_ = textureId; }
 
 flutter::EncodableValue TextureMessage::toMap() {
-  LOG_DEBUG("[TextureMessage.toMap] textureId: %ld", textureId_);
   flutter::EncodableMap toMapResult = {{flutter::EncodableValue("textureId"),
                                         flutter::EncodableValue(textureId_)}};
   return flutter::EncodableValue(toMapResult);
@@ -25,8 +22,6 @@ TextureMessage TextureMessage::fromMap(const flutter::EncodableValue &value) {
     if (std::holds_alternative<int32_t>(textureId) ||
         std::holds_alternative<int64_t>(textureId)) {
       fromMapResult.setTextureId(textureId.LongValue());
-      LOG_DEBUG("[TextureMessage.fromMap] textureId: %ld",
-                fromMapResult.getTextureId());
     }
   }
   return fromMapResult;
@@ -53,11 +48,6 @@ void CreateMessage::setFormatHint(const std::string &formatHint) {
 }
 
 flutter::EncodableValue CreateMessage::toMap() {
-  LOG_DEBUG("[CreateMessage.toMap] asset: %s", asset_.c_str());
-  LOG_DEBUG("[CreateMessage.toMap] uri: %s", uri_.c_str());
-  LOG_DEBUG("[CreateMessage.toMap] packageName: %s", packageName_.c_str());
-  LOG_DEBUG("[CreateMessage.toMap] formatHint: %s", formatHint_.c_str());
-
   flutter::EncodableMap toMapResult = {
       {flutter::EncodableValue("asset"), flutter::EncodableValue(asset_)},
       {flutter::EncodableValue("uri"), flutter::EncodableValue(uri_)},
@@ -65,7 +55,6 @@ flutter::EncodableValue CreateMessage::toMap() {
        flutter::EncodableValue(packageName_)},
       {flutter::EncodableValue("formatHint"),
        flutter::EncodableValue(formatHint_)}};
-
   return flutter::EncodableValue(toMapResult);
 }
 
@@ -76,34 +65,25 @@ CreateMessage CreateMessage::fromMap(const flutter::EncodableValue &value) {
     flutter::EncodableValue &asset = emap[flutter::EncodableValue("asset")];
     if (std::holds_alternative<std::string>(asset)) {
       fromMapResult.setAsset(std::get<std::string>(asset));
-      LOG_DEBUG("[CreateMessage.fromMap] asset: %s",
-                fromMapResult.getAsset().c_str());
     }
 
     flutter::EncodableValue &uri = emap[flutter::EncodableValue("uri")];
     if (std::holds_alternative<std::string>(uri)) {
       fromMapResult.setUri(std::get<std::string>(uri));
-      LOG_DEBUG("[CreateMessage.fromMap] uri: %s",
-                fromMapResult.getUri().c_str());
     }
 
     flutter::EncodableValue &packageName =
         emap[flutter::EncodableValue("packageName")];
     if (std::holds_alternative<std::string>(packageName)) {
       fromMapResult.setPackageName(std::get<std::string>(uri));
-      LOG_DEBUG("[CreateMessage.fromMap] packageName: %s",
-                fromMapResult.getPackageName().c_str());
     }
 
     flutter::EncodableValue &formatHint =
         emap[flutter::EncodableValue("formatHint")];
     if (std::holds_alternative<std::string>(formatHint)) {
       fromMapResult.setFormatHint(std::get<std::string>(formatHint));
-      LOG_DEBUG("[CreateMessage.fromMap] formatHint: %s",
-                fromMapResult.getFormatHint().c_str());
     }
   }
-
   return fromMapResult;
 }
 
@@ -116,14 +96,10 @@ bool LoopingMessage::getIsLooping() const { return isLooping_; }
 void LoopingMessage::setIsLooping(bool isLooping) { isLooping_ = isLooping; }
 
 flutter::EncodableValue LoopingMessage::toMap() {
-  LOG_DEBUG("[LoopingMessage.toMap] textureId: %ld", textureId_);
-  LOG_DEBUG("[LoopingMessage.toMap] isLooping: %d", isLooping_);
-
   flutter::EncodableMap toMapResult = {{flutter::EncodableValue("textureId"),
                                         flutter::EncodableValue(textureId_)},
                                        {flutter::EncodableValue("isLooping"),
                                         flutter::EncodableValue(isLooping_)}};
-
   return flutter::EncodableValue(toMapResult);
 }
 
@@ -136,19 +112,14 @@ LoopingMessage LoopingMessage::fromMap(const flutter::EncodableValue &value) {
     if (std::holds_alternative<int32_t>(textureId) ||
         std::holds_alternative<int64_t>(textureId)) {
       fromMapResult.setTextureId(textureId.LongValue());
-      LOG_DEBUG("[LoopingMessage.fromMap] textureId: %ld",
-                fromMapResult.getTextureId());
     }
 
     flutter::EncodableValue &isLooping =
         emap[flutter::EncodableValue("isLooping")];
     if (std::holds_alternative<bool>(isLooping)) {
       fromMapResult.setIsLooping(std::get<bool>(isLooping));
-      LOG_DEBUG("[LoopingMessage.fromMap] isLooping: %d",
-                fromMapResult.getIsLooping());
     }
   }
-
   return fromMapResult;
 }
 
@@ -161,14 +132,10 @@ double VolumeMessage::getVolume() const { return volume_; }
 void VolumeMessage::setVolume(double volume) { volume_ = volume; }
 
 flutter::EncodableValue VolumeMessage::toMap() {
-  LOG_DEBUG("[VolumeMessage.toMap] textureId: %ld", textureId_);
-  LOG_DEBUG("[VolumeMessage.toMap] volume: %f", volume_);
-
   flutter::EncodableMap toMapResult = {
       {flutter::EncodableValue("textureId"),
        flutter::EncodableValue(textureId_)},
       {flutter::EncodableValue("volume"), flutter::EncodableValue(volume_)}};
-
   return flutter::EncodableValue(toMapResult);
 }
 
@@ -181,18 +148,13 @@ VolumeMessage VolumeMessage::fromMap(const flutter::EncodableValue &value) {
     if (std::holds_alternative<int32_t>(textureId) ||
         std::holds_alternative<int64_t>(textureId)) {
       fromMapResult.setTextureId(textureId.LongValue());
-      LOG_DEBUG("[VolumeMessage.fromMap] textureId: %ld",
-                fromMapResult.getTextureId());
     }
 
     flutter::EncodableValue &volume = emap[flutter::EncodableValue("volume")];
     if (std::holds_alternative<double>(volume)) {
       fromMapResult.setVolume(std::get<double>(volume));
-      LOG_DEBUG("[VolumeMessage.fromMap] volume: %f",
-                fromMapResult.getVolume());
     }
   }
-
   return fromMapResult;
 }
 
@@ -207,14 +169,10 @@ double PlaybackSpeedMessage::getSpeed() const { return speed_; }
 void PlaybackSpeedMessage::setSpeed(double speed) { speed_ = speed; }
 
 flutter::EncodableValue PlaybackSpeedMessage::toMap() {
-  LOG_DEBUG("[PlaybackSpeedMessage.toMap] textureId: %ld", textureId_);
-  LOG_DEBUG("[PlaybackSpeedMessage.toMap] speed: %f", speed_);
-
   flutter::EncodableMap toMapResult = {
       {flutter::EncodableValue("textureId"),
        flutter::EncodableValue(textureId_)},
       {flutter::EncodableValue("speed"), flutter::EncodableValue(speed_)}};
-
   return flutter::EncodableValue(toMapResult);
 }
 
@@ -228,17 +186,13 @@ PlaybackSpeedMessage PlaybackSpeedMessage::fromMap(
     if (std::holds_alternative<int32_t>(textureId) ||
         std::holds_alternative<int64_t>(textureId)) {
       fromMapResult.setTextureId(textureId.LongValue());
-      LOG_DEBUG("[VolumeMessage.fromMap] textureId: %ld",
-                fromMapResult.getTextureId());
     }
 
     flutter::EncodableValue &speed = emap[flutter::EncodableValue("speed")];
     if (std::holds_alternative<double>(speed)) {
       fromMapResult.setSpeed(std::get<double>(speed));
-      LOG_DEBUG("[VolumeMessage.fromMap] speed: %f", fromMapResult.getSpeed());
     }
   }
-
   return fromMapResult;
 }
 
@@ -253,14 +207,10 @@ int64_t PositionMessage::getPosition() const { return position_; }
 void PositionMessage::setPosition(int64_t position) { position_ = position; }
 
 flutter::EncodableValue PositionMessage::toMap() {
-  LOG_DEBUG("[PositionMessage.toMap] textureId: %ld", textureId_);
-  LOG_DEBUG("[PositionMessage.toMap] position: %ld", position_);
-
   flutter::EncodableMap toMapResult = {{flutter::EncodableValue("textureId"),
                                         flutter::EncodableValue(textureId_)},
                                        {flutter::EncodableValue("position"),
                                         flutter::EncodableValue(position_)}};
-
   return flutter::EncodableValue(toMapResult);
 }
 
@@ -273,8 +223,6 @@ PositionMessage PositionMessage::fromMap(const flutter::EncodableValue &value) {
     if (std::holds_alternative<int32_t>(textureId) ||
         std::holds_alternative<int64_t>(textureId)) {
       fromMapResult.setTextureId(textureId.LongValue());
-      LOG_DEBUG("[PositionMessage.fromMap] textureId: %ld",
-                fromMapResult.getTextureId());
     }
 
     flutter::EncodableValue &position =
@@ -282,11 +230,8 @@ PositionMessage PositionMessage::fromMap(const flutter::EncodableValue &value) {
     if (std::holds_alternative<int32_t>(position) ||
         std::holds_alternative<int64_t>(position)) {
       fromMapResult.setPosition(position.LongValue());
-      LOG_DEBUG("[PositionMessage.fromMap] position: %ld",
-                fromMapResult.getPosition());
     }
   }
-
   return fromMapResult;
 }
 
@@ -297,12 +242,9 @@ void MixWithOthersMessage::setMixWithOthers(bool mixWithOthers) {
 }
 
 flutter::EncodableValue MixWithOthersMessage::toMap() {
-  LOG_DEBUG("[MixWithOthersMessage.toMap] mixWithOthers: %d", mixWithOthers_);
-
   flutter::EncodableMap toMapResult = {
       {flutter::EncodableValue("mixWithOthers"),
        flutter::EncodableValue(mixWithOthers_)}};
-
   return flutter::EncodableValue(toMapResult);
 }
 
@@ -315,17 +257,13 @@ MixWithOthersMessage MixWithOthersMessage::fromMap(
         emap[flutter::EncodableValue("mixWithOthers")];
     if (std::holds_alternative<bool>(mixWithOthers)) {
       fromMapResult.setMixWithOthers(std::get<bool>(mixWithOthers));
-      LOG_DEBUG("[MixWithOthersMessage.fromMap] mixWithOthers: %d",
-                fromMapResult.getMixWithOthers());
     }
   }
-
   return fromMapResult;
 }
 
 void VideoPlayerApi::setup(flutter::BinaryMessenger *binaryMessenger,
                            VideoPlayerApi *api) {
-  LOG_DEBUG("[VideoPlayerApi.setup] setup initialize channel");
   auto initChannel =
       std::make_unique<flutter::BasicMessageChannel<flutter::EncodableValue>>(
           binaryMessenger, "dev.flutter.pigeon.VideoPlayerApi.initialize",
@@ -347,7 +285,6 @@ void VideoPlayerApi::setup(flutter::BinaryMessenger *binaryMessenger,
         });
   }
 
-  LOG_DEBUG("[VideoPlayerApi.setup] setup create channel");
   auto createChannel =
       std::make_unique<flutter::BasicMessageChannel<flutter::EncodableValue>>(
           binaryMessenger, "dev.flutter.pigeon.VideoPlayerApi.create",
@@ -369,7 +306,6 @@ void VideoPlayerApi::setup(flutter::BinaryMessenger *binaryMessenger,
         });
   }
 
-  LOG_DEBUG("[VideoPlayerApi.setup] setup dispose channel");
   auto disposeChannel =
       std::make_unique<flutter::BasicMessageChannel<flutter::EncodableValue>>(
           binaryMessenger, "dev.flutter.pigeon.VideoPlayerApi.dispose",
@@ -392,7 +328,6 @@ void VideoPlayerApi::setup(flutter::BinaryMessenger *binaryMessenger,
         });
   }
 
-  LOG_DEBUG("[VideoPlayerApi.setup] setup setLooping channel");
   auto loopingChannel =
       std::make_unique<flutter::BasicMessageChannel<flutter::EncodableValue>>(
           binaryMessenger, "dev.flutter.pigeon.VideoPlayerApi.setLooping",
@@ -415,7 +350,6 @@ void VideoPlayerApi::setup(flutter::BinaryMessenger *binaryMessenger,
         });
   }
 
-  LOG_DEBUG("[VideoPlayerApi.setup] setup setVolume channel");
   auto volumeChannel =
       std::make_unique<flutter::BasicMessageChannel<flutter::EncodableValue>>(
           binaryMessenger, "dev.flutter.pigeon.VideoPlayerApi.setVolume",
@@ -438,7 +372,6 @@ void VideoPlayerApi::setup(flutter::BinaryMessenger *binaryMessenger,
         });
   }
 
-  LOG_DEBUG("[VideoPlayerApi.setup] setup setPlaybackSpeed channel");
   auto speedChannel =
       std::make_unique<flutter::BasicMessageChannel<flutter::EncodableValue>>(
           binaryMessenger, "dev.flutter.pigeon.VideoPlayerApi.setPlaybackSpeed",
@@ -461,7 +394,6 @@ void VideoPlayerApi::setup(flutter::BinaryMessenger *binaryMessenger,
         });
   }
 
-  LOG_DEBUG("[VideoPlayerApi.setup] setup play channel");
   auto playChannel =
       std::make_unique<flutter::BasicMessageChannel<flutter::EncodableValue>>(
           binaryMessenger, "dev.flutter.pigeon.VideoPlayerApi.play",
@@ -484,7 +416,6 @@ void VideoPlayerApi::setup(flutter::BinaryMessenger *binaryMessenger,
         });
   }
 
-  LOG_DEBUG("[VideoPlayerApi.setup] setup position channel");
   auto positionChannel =
       std::make_unique<flutter::BasicMessageChannel<flutter::EncodableValue>>(
           binaryMessenger, "dev.flutter.pigeon.VideoPlayerApi.position",
@@ -506,7 +437,6 @@ void VideoPlayerApi::setup(flutter::BinaryMessenger *binaryMessenger,
         });
   }
 
-  LOG_DEBUG("[VideoPlayerApi.setup] setup seekTo channel");
   auto seekToChannel =
       std::make_unique<flutter::BasicMessageChannel<flutter::EncodableValue>>(
           binaryMessenger, "dev.flutter.pigeon.VideoPlayerApi.seekTo",
@@ -531,7 +461,6 @@ void VideoPlayerApi::setup(flutter::BinaryMessenger *binaryMessenger,
         });
   }
 
-  LOG_DEBUG("[VideoPlayerApi.setup] setup pause channel");
   auto pauseChannel =
       std::make_unique<flutter::BasicMessageChannel<flutter::EncodableValue>>(
           binaryMessenger, "dev.flutter.pigeon.VideoPlayerApi.pause",
@@ -554,7 +483,6 @@ void VideoPlayerApi::setup(flutter::BinaryMessenger *binaryMessenger,
         });
   }
 
-  LOG_DEBUG("[VideoPlayerApi.setup] setup setMixWithOthers channel");
   auto mixChannel =
       std::make_unique<flutter::BasicMessageChannel<flutter::EncodableValue>>(
           binaryMessenger, "dev.flutter.pigeon.VideoPlayerApi.setMixWithOthers",

--- a/packages/video_player/tizen/src/message.cc
+++ b/packages/video_player/tizen/src/message.cc
@@ -16,9 +16,9 @@ flutter::EncodableValue TextureMessage::toMap() {
 TextureMessage TextureMessage::fromMap(const flutter::EncodableValue &value) {
   TextureMessage fromMapResult;
   if (std::holds_alternative<flutter::EncodableMap>(value)) {
-    flutter::EncodableMap emap = std::get<flutter::EncodableMap>(value);
+    flutter::EncodableMap map = std::get<flutter::EncodableMap>(value);
     flutter::EncodableValue &textureId =
-        emap[flutter::EncodableValue("textureId")];
+        map[flutter::EncodableValue("textureId")];
     if (std::holds_alternative<int32_t>(textureId) ||
         std::holds_alternative<int64_t>(textureId)) {
       fromMapResult.setTextureId(textureId.LongValue());
@@ -61,25 +61,25 @@ flutter::EncodableValue CreateMessage::toMap() {
 CreateMessage CreateMessage::fromMap(const flutter::EncodableValue &value) {
   CreateMessage fromMapResult;
   if (std::holds_alternative<flutter::EncodableMap>(value)) {
-    flutter::EncodableMap emap = std::get<flutter::EncodableMap>(value);
-    flutter::EncodableValue &asset = emap[flutter::EncodableValue("asset")];
+    flutter::EncodableMap map = std::get<flutter::EncodableMap>(value);
+    flutter::EncodableValue &asset = map[flutter::EncodableValue("asset")];
     if (std::holds_alternative<std::string>(asset)) {
       fromMapResult.setAsset(std::get<std::string>(asset));
     }
 
-    flutter::EncodableValue &uri = emap[flutter::EncodableValue("uri")];
+    flutter::EncodableValue &uri = map[flutter::EncodableValue("uri")];
     if (std::holds_alternative<std::string>(uri)) {
       fromMapResult.setUri(std::get<std::string>(uri));
     }
 
     flutter::EncodableValue &packageName =
-        emap[flutter::EncodableValue("packageName")];
+        map[flutter::EncodableValue("packageName")];
     if (std::holds_alternative<std::string>(packageName)) {
       fromMapResult.setPackageName(std::get<std::string>(uri));
     }
 
     flutter::EncodableValue &formatHint =
-        emap[flutter::EncodableValue("formatHint")];
+        map[flutter::EncodableValue("formatHint")];
     if (std::holds_alternative<std::string>(formatHint)) {
       fromMapResult.setFormatHint(std::get<std::string>(formatHint));
     }
@@ -106,16 +106,16 @@ flutter::EncodableValue LoopingMessage::toMap() {
 LoopingMessage LoopingMessage::fromMap(const flutter::EncodableValue &value) {
   LoopingMessage fromMapResult;
   if (std::holds_alternative<flutter::EncodableMap>(value)) {
-    flutter::EncodableMap emap = std::get<flutter::EncodableMap>(value);
+    flutter::EncodableMap map = std::get<flutter::EncodableMap>(value);
     flutter::EncodableValue &textureId =
-        emap[flutter::EncodableValue("textureId")];
+        map[flutter::EncodableValue("textureId")];
     if (std::holds_alternative<int32_t>(textureId) ||
         std::holds_alternative<int64_t>(textureId)) {
       fromMapResult.setTextureId(textureId.LongValue());
     }
 
     flutter::EncodableValue &isLooping =
-        emap[flutter::EncodableValue("isLooping")];
+        map[flutter::EncodableValue("isLooping")];
     if (std::holds_alternative<bool>(isLooping)) {
       fromMapResult.setIsLooping(std::get<bool>(isLooping));
     }
@@ -142,15 +142,15 @@ flutter::EncodableValue VolumeMessage::toMap() {
 VolumeMessage VolumeMessage::fromMap(const flutter::EncodableValue &value) {
   VolumeMessage fromMapResult;
   if (std::holds_alternative<flutter::EncodableMap>(value)) {
-    flutter::EncodableMap emap = std::get<flutter::EncodableMap>(value);
+    flutter::EncodableMap map = std::get<flutter::EncodableMap>(value);
     flutter::EncodableValue &textureId =
-        emap[flutter::EncodableValue("textureId")];
+        map[flutter::EncodableValue("textureId")];
     if (std::holds_alternative<int32_t>(textureId) ||
         std::holds_alternative<int64_t>(textureId)) {
       fromMapResult.setTextureId(textureId.LongValue());
     }
 
-    flutter::EncodableValue &volume = emap[flutter::EncodableValue("volume")];
+    flutter::EncodableValue &volume = map[flutter::EncodableValue("volume")];
     if (std::holds_alternative<double>(volume)) {
       fromMapResult.setVolume(std::get<double>(volume));
     }
@@ -180,15 +180,15 @@ PlaybackSpeedMessage PlaybackSpeedMessage::fromMap(
     const flutter::EncodableValue &value) {
   PlaybackSpeedMessage fromMapResult;
   if (std::holds_alternative<flutter::EncodableMap>(value)) {
-    flutter::EncodableMap emap = std::get<flutter::EncodableMap>(value);
+    flutter::EncodableMap map = std::get<flutter::EncodableMap>(value);
     flutter::EncodableValue &textureId =
-        emap[flutter::EncodableValue("textureId")];
+        map[flutter::EncodableValue("textureId")];
     if (std::holds_alternative<int32_t>(textureId) ||
         std::holds_alternative<int64_t>(textureId)) {
       fromMapResult.setTextureId(textureId.LongValue());
     }
 
-    flutter::EncodableValue &speed = emap[flutter::EncodableValue("speed")];
+    flutter::EncodableValue &speed = map[flutter::EncodableValue("speed")];
     if (std::holds_alternative<double>(speed)) {
       fromMapResult.setSpeed(std::get<double>(speed));
     }
@@ -217,16 +217,16 @@ flutter::EncodableValue PositionMessage::toMap() {
 PositionMessage PositionMessage::fromMap(const flutter::EncodableValue &value) {
   PositionMessage fromMapResult;
   if (std::holds_alternative<flutter::EncodableMap>(value)) {
-    flutter::EncodableMap emap = std::get<flutter::EncodableMap>(value);
+    flutter::EncodableMap map = std::get<flutter::EncodableMap>(value);
     flutter::EncodableValue &textureId =
-        emap[flutter::EncodableValue("textureId")];
+        map[flutter::EncodableValue("textureId")];
     if (std::holds_alternative<int32_t>(textureId) ||
         std::holds_alternative<int64_t>(textureId)) {
       fromMapResult.setTextureId(textureId.LongValue());
     }
 
     flutter::EncodableValue &position =
-        emap[flutter::EncodableValue("position")];
+        map[flutter::EncodableValue("position")];
     if (std::holds_alternative<int32_t>(position) ||
         std::holds_alternative<int64_t>(position)) {
       fromMapResult.setPosition(position.LongValue());
@@ -252,9 +252,9 @@ MixWithOthersMessage MixWithOthersMessage::fromMap(
     const flutter::EncodableValue &value) {
   MixWithOthersMessage fromMapResult;
   if (std::holds_alternative<flutter::EncodableMap>(value)) {
-    flutter::EncodableMap emap = std::get<flutter::EncodableMap>(value);
+    flutter::EncodableMap map = std::get<flutter::EncodableMap>(value);
     flutter::EncodableValue &mixWithOthers =
-        emap[flutter::EncodableValue("mixWithOthers")];
+        map[flutter::EncodableValue("mixWithOthers")];
     if (std::holds_alternative<bool>(mixWithOthers)) {
       fromMapResult.setMixWithOthers(std::get<bool>(mixWithOthers));
     }
@@ -262,14 +262,14 @@ MixWithOthersMessage MixWithOthersMessage::fromMap(
   return fromMapResult;
 }
 
-void VideoPlayerApi::setup(flutter::BinaryMessenger *binaryMessenger,
+void VideoPlayerApi::SetUp(flutter::BinaryMessenger *messenger,
                            VideoPlayerApi *api) {
-  auto initChannel =
+  auto init_channel =
       std::make_unique<flutter::BasicMessageChannel<flutter::EncodableValue>>(
-          binaryMessenger, "dev.flutter.pigeon.VideoPlayerApi.initialize",
+          messenger, "dev.flutter.pigeon.VideoPlayerApi.initialize",
           &flutter::StandardMessageCodec::GetInstance());
   if (api != nullptr) {
-    initChannel->SetMessageHandler(
+    init_channel->SetMessageHandler(
         [api](const flutter::EncodableValue &message,
               flutter::MessageReply<flutter::EncodableValue> reply) {
           flutter::EncodableMap wrapped;
@@ -277,20 +277,20 @@ void VideoPlayerApi::setup(flutter::BinaryMessenger *binaryMessenger,
             api->initialize();
             wrapped.emplace(flutter::EncodableValue("result"),
                             flutter::EncodableValue());
-          } catch (const VideoPlayerError &e) {
+          } catch (const VideoPlayerError &error) {
             wrapped.emplace(flutter::EncodableValue("error"),
-                            VideoPlayerApi::wrapError(e));
+                            VideoPlayerApi::WrapError(error));
           }
           reply(flutter::EncodableValue(wrapped));
         });
   }
 
-  auto createChannel =
+  auto create_channel =
       std::make_unique<flutter::BasicMessageChannel<flutter::EncodableValue>>(
-          binaryMessenger, "dev.flutter.pigeon.VideoPlayerApi.create",
+          messenger, "dev.flutter.pigeon.VideoPlayerApi.create",
           &flutter::StandardMessageCodec::GetInstance());
   if (api != nullptr) {
-    createChannel->SetMessageHandler(
+    create_channel->SetMessageHandler(
         [api](const flutter::EncodableValue &message,
               flutter::MessageReply<flutter::EncodableValue> reply) {
           CreateMessage input = CreateMessage::fromMap(message);
@@ -298,20 +298,20 @@ void VideoPlayerApi::setup(flutter::BinaryMessenger *binaryMessenger,
           try {
             TextureMessage output = api->create(input);
             wrapped.emplace(flutter::EncodableValue("result"), output.toMap());
-          } catch (const VideoPlayerError &e) {
+          } catch (const VideoPlayerError &error) {
             wrapped.emplace(flutter::EncodableValue("error"),
-                            VideoPlayerApi::wrapError(e));
+                            VideoPlayerApi::WrapError(error));
           }
           reply(flutter::EncodableValue(wrapped));
         });
   }
 
-  auto disposeChannel =
+  auto dispose_channel =
       std::make_unique<flutter::BasicMessageChannel<flutter::EncodableValue>>(
-          binaryMessenger, "dev.flutter.pigeon.VideoPlayerApi.dispose",
+          messenger, "dev.flutter.pigeon.VideoPlayerApi.dispose",
           &flutter::StandardMessageCodec::GetInstance());
   if (api != nullptr) {
-    disposeChannel->SetMessageHandler(
+    dispose_channel->SetMessageHandler(
         [api](const flutter::EncodableValue &message,
               flutter::MessageReply<flutter::EncodableValue> reply) {
           TextureMessage input = TextureMessage::fromMap(message);
@@ -320,20 +320,20 @@ void VideoPlayerApi::setup(flutter::BinaryMessenger *binaryMessenger,
             api->dispose(input);
             wrapped.emplace(flutter::EncodableValue("result"),
                             flutter::EncodableValue());
-          } catch (const VideoPlayerError &e) {
+          } catch (const VideoPlayerError &error) {
             wrapped.emplace(flutter::EncodableValue("error"),
-                            VideoPlayerApi::wrapError(e));
+                            VideoPlayerApi::WrapError(error));
           }
           reply(flutter::EncodableValue(wrapped));
         });
   }
 
-  auto loopingChannel =
+  auto looping_channel =
       std::make_unique<flutter::BasicMessageChannel<flutter::EncodableValue>>(
-          binaryMessenger, "dev.flutter.pigeon.VideoPlayerApi.setLooping",
+          messenger, "dev.flutter.pigeon.VideoPlayerApi.setLooping",
           &flutter::StandardMessageCodec::GetInstance());
   if (api != nullptr) {
-    loopingChannel->SetMessageHandler(
+    looping_channel->SetMessageHandler(
         [api](const flutter::EncodableValue &message,
               flutter::MessageReply<flutter::EncodableValue> reply) {
           LoopingMessage input = LoopingMessage::fromMap(message);
@@ -342,20 +342,20 @@ void VideoPlayerApi::setup(flutter::BinaryMessenger *binaryMessenger,
             api->setLooping(input);
             wrapped.emplace(flutter::EncodableValue("result"),
                             flutter::EncodableValue());
-          } catch (const VideoPlayerError &e) {
+          } catch (const VideoPlayerError &error) {
             wrapped.emplace(flutter::EncodableValue("error"),
-                            VideoPlayerApi::wrapError(e));
+                            VideoPlayerApi::WrapError(error));
           }
           reply(flutter::EncodableValue(wrapped));
         });
   }
 
-  auto volumeChannel =
+  auto volume_channel =
       std::make_unique<flutter::BasicMessageChannel<flutter::EncodableValue>>(
-          binaryMessenger, "dev.flutter.pigeon.VideoPlayerApi.setVolume",
+          messenger, "dev.flutter.pigeon.VideoPlayerApi.setVolume",
           &flutter::StandardMessageCodec::GetInstance());
   if (api != nullptr) {
-    volumeChannel->SetMessageHandler(
+    volume_channel->SetMessageHandler(
         [api](const flutter::EncodableValue &message,
               flutter::MessageReply<flutter::EncodableValue> reply) {
           VolumeMessage input = VolumeMessage::fromMap(message);
@@ -364,20 +364,20 @@ void VideoPlayerApi::setup(flutter::BinaryMessenger *binaryMessenger,
             api->setVolume(input);
             wrapped.emplace(flutter::EncodableValue("result"),
                             flutter::EncodableValue());
-          } catch (const VideoPlayerError &e) {
+          } catch (const VideoPlayerError &error) {
             wrapped.emplace(flutter::EncodableValue("error"),
-                            VideoPlayerApi::wrapError(e));
+                            VideoPlayerApi::WrapError(error));
           }
           reply(flutter::EncodableValue(wrapped));
         });
   }
 
-  auto speedChannel =
+  auto speed_channel =
       std::make_unique<flutter::BasicMessageChannel<flutter::EncodableValue>>(
-          binaryMessenger, "dev.flutter.pigeon.VideoPlayerApi.setPlaybackSpeed",
+          messenger, "dev.flutter.pigeon.VideoPlayerApi.setPlaybackSpeed",
           &flutter::StandardMessageCodec::GetInstance());
   if (api != nullptr) {
-    speedChannel->SetMessageHandler(
+    speed_channel->SetMessageHandler(
         [api](const flutter::EncodableValue &message,
               flutter::MessageReply<flutter::EncodableValue> reply) {
           PlaybackSpeedMessage input = PlaybackSpeedMessage::fromMap(message);
@@ -386,20 +386,20 @@ void VideoPlayerApi::setup(flutter::BinaryMessenger *binaryMessenger,
             api->setPlaybackSpeed(input);
             wrapped.emplace(flutter::EncodableValue("result"),
                             flutter::EncodableValue());
-          } catch (const VideoPlayerError &e) {
+          } catch (const VideoPlayerError &error) {
             wrapped.emplace(flutter::EncodableValue("error"),
-                            VideoPlayerApi::wrapError(e));
+                            VideoPlayerApi::WrapError(error));
           }
           reply(flutter::EncodableValue(wrapped));
         });
   }
 
-  auto playChannel =
+  auto play_channel =
       std::make_unique<flutter::BasicMessageChannel<flutter::EncodableValue>>(
-          binaryMessenger, "dev.flutter.pigeon.VideoPlayerApi.play",
+          messenger, "dev.flutter.pigeon.VideoPlayerApi.play",
           &flutter::StandardMessageCodec::GetInstance());
   if (api != nullptr) {
-    playChannel->SetMessageHandler(
+    play_channel->SetMessageHandler(
         [api](const flutter::EncodableValue &message,
               flutter::MessageReply<flutter::EncodableValue> reply) {
           TextureMessage input = TextureMessage::fromMap(message);
@@ -408,20 +408,20 @@ void VideoPlayerApi::setup(flutter::BinaryMessenger *binaryMessenger,
             api->play(input);
             wrapped.emplace(flutter::EncodableValue("result"),
                             flutter::EncodableValue());
-          } catch (const VideoPlayerError &e) {
+          } catch (const VideoPlayerError &error) {
             wrapped.emplace(flutter::EncodableValue("error"),
-                            VideoPlayerApi::wrapError(e));
+                            VideoPlayerApi::WrapError(error));
           }
           reply(flutter::EncodableValue(wrapped));
         });
   }
 
-  auto positionChannel =
+  auto position_channel =
       std::make_unique<flutter::BasicMessageChannel<flutter::EncodableValue>>(
-          binaryMessenger, "dev.flutter.pigeon.VideoPlayerApi.position",
+          messenger, "dev.flutter.pigeon.VideoPlayerApi.position",
           &flutter::StandardMessageCodec::GetInstance());
   if (api != nullptr) {
-    positionChannel->SetMessageHandler(
+    position_channel->SetMessageHandler(
         [api](const flutter::EncodableValue &message,
               flutter::MessageReply<flutter::EncodableValue> reply) {
           TextureMessage input = TextureMessage::fromMap(message);
@@ -429,20 +429,20 @@ void VideoPlayerApi::setup(flutter::BinaryMessenger *binaryMessenger,
           try {
             PositionMessage output = api->position(input);
             wrapped.emplace(flutter::EncodableValue("result"), output.toMap());
-          } catch (const VideoPlayerError &e) {
+          } catch (const VideoPlayerError &error) {
             wrapped.emplace(flutter::EncodableValue("error"),
-                            VideoPlayerApi::wrapError(e));
+                            VideoPlayerApi::WrapError(error));
           }
           reply(flutter::EncodableValue(wrapped));
         });
   }
 
-  auto seekToChannel =
+  auto seek_to_channel =
       std::make_unique<flutter::BasicMessageChannel<flutter::EncodableValue>>(
-          binaryMessenger, "dev.flutter.pigeon.VideoPlayerApi.seekTo",
+          messenger, "dev.flutter.pigeon.VideoPlayerApi.seekTo",
           &flutter::StandardMessageCodec::GetInstance());
   if (api != nullptr) {
-    seekToChannel->SetMessageHandler(
+    seek_to_channel->SetMessageHandler(
         [api](const flutter::EncodableValue &message,
               flutter::MessageReply<flutter::EncodableValue> reply) {
           PositionMessage input = PositionMessage::fromMap(message);
@@ -453,20 +453,21 @@ void VideoPlayerApi::setup(flutter::BinaryMessenger *binaryMessenger,
                    flutter::EncodableValue()}};
               reply(flutter::EncodableValue(wrapped));
             });
-          } catch (const VideoPlayerError &e) {
-            flutter::EncodableMap error = {{flutter::EncodableValue("error"),
-                                            VideoPlayerApi::wrapError(e)}};
-            reply(flutter::EncodableValue(error));
+          } catch (const VideoPlayerError &error) {
+            flutter::EncodableMap wrapped = {
+                {flutter::EncodableValue("error"),
+                 VideoPlayerApi::WrapError(error)}};
+            reply(flutter::EncodableValue(wrapped));
           }
         });
   }
 
-  auto pauseChannel =
+  auto pause_channel =
       std::make_unique<flutter::BasicMessageChannel<flutter::EncodableValue>>(
-          binaryMessenger, "dev.flutter.pigeon.VideoPlayerApi.pause",
+          messenger, "dev.flutter.pigeon.VideoPlayerApi.pause",
           &flutter::StandardMessageCodec::GetInstance());
   if (api != nullptr) {
-    pauseChannel->SetMessageHandler(
+    pause_channel->SetMessageHandler(
         [api](const flutter::EncodableValue &message,
               flutter::MessageReply<flutter::EncodableValue> reply) {
           TextureMessage input = TextureMessage::fromMap(message);
@@ -475,20 +476,20 @@ void VideoPlayerApi::setup(flutter::BinaryMessenger *binaryMessenger,
             api->pause(input);
             wrapped.emplace(flutter::EncodableValue("result"),
                             flutter::EncodableValue());
-          } catch (const VideoPlayerError &e) {
+          } catch (const VideoPlayerError &error) {
             wrapped.emplace(flutter::EncodableValue("error"),
-                            VideoPlayerApi::wrapError(e));
+                            VideoPlayerApi::WrapError(error));
           }
           reply(flutter::EncodableValue(wrapped));
         });
   }
 
-  auto mixChannel =
+  auto mix_channel =
       std::make_unique<flutter::BasicMessageChannel<flutter::EncodableValue>>(
-          binaryMessenger, "dev.flutter.pigeon.VideoPlayerApi.setMixWithOthers",
+          messenger, "dev.flutter.pigeon.VideoPlayerApi.setMixWithOthers",
           &flutter::StandardMessageCodec::GetInstance());
   if (api != nullptr) {
-    mixChannel->SetMessageHandler(
+    mix_channel->SetMessageHandler(
         [api](const flutter::EncodableValue &message,
               flutter::MessageReply<flutter::EncodableValue> reply) {
           MixWithOthersMessage input = MixWithOthersMessage::fromMap(message);
@@ -497,16 +498,16 @@ void VideoPlayerApi::setup(flutter::BinaryMessenger *binaryMessenger,
             api->setMixWithOthers(input);
             wrapped.emplace(flutter::EncodableValue("result"),
                             flutter::EncodableValue());
-          } catch (const VideoPlayerError &e) {
+          } catch (const VideoPlayerError &error) {
             wrapped.emplace(flutter::EncodableValue("error"),
-                            VideoPlayerApi::wrapError(e));
+                            VideoPlayerApi::WrapError(error));
           }
           reply(flutter::EncodableValue(wrapped));
         });
   }
 }
 
-flutter::EncodableValue VideoPlayerApi::wrapError(
+flutter::EncodableValue VideoPlayerApi::WrapError(
     const VideoPlayerError &error) {
   flutter::EncodableMap wrapped = {
       {flutter::EncodableValue("message"),

--- a/packages/video_player/tizen/src/message.cc
+++ b/packages/video_player/tizen/src/message.cc
@@ -5,15 +5,14 @@
 
 #include "log.h"
 
-long TextureMessage::getTextureId() const { return textureId_; }
+int64_t TextureMessage::getTextureId() const { return textureId_; }
 
-void TextureMessage::setTextureId(long textureId) { textureId_ = textureId; }
+void TextureMessage::setTextureId(int64_t textureId) { textureId_ = textureId; }
 
 flutter::EncodableValue TextureMessage::toMap() {
   LOG_DEBUG("[TextureMessage.toMap] textureId: %ld", textureId_);
-  flutter::EncodableMap toMapResult = {
-      {flutter::EncodableValue("textureId"),
-       flutter::EncodableValue((int64_t)textureId_)}};
+  flutter::EncodableMap toMapResult = {{flutter::EncodableValue("textureId"),
+                                        flutter::EncodableValue(textureId_)}};
   return flutter::EncodableValue(toMapResult);
 }
 
@@ -108,9 +107,9 @@ CreateMessage CreateMessage::fromMap(const flutter::EncodableValue &value) {
   return fromMapResult;
 }
 
-long LoopingMessage::getTextureId() const { return textureId_; }
+int64_t LoopingMessage::getTextureId() const { return textureId_; }
 
-void LoopingMessage::setTextureId(long textureId) { textureId_ = textureId; }
+void LoopingMessage::setTextureId(int64_t textureId) { textureId_ = textureId; }
 
 bool LoopingMessage::getIsLooping() const { return isLooping_; }
 
@@ -120,11 +119,10 @@ flutter::EncodableValue LoopingMessage::toMap() {
   LOG_DEBUG("[LoopingMessage.toMap] textureId: %ld", textureId_);
   LOG_DEBUG("[LoopingMessage.toMap] isLooping: %d", isLooping_);
 
-  flutter::EncodableMap toMapResult = {
-      {flutter::EncodableValue("textureId"),
-       flutter::EncodableValue((int64_t)textureId_)},
-      {flutter::EncodableValue("isLooping"),
-       flutter::EncodableValue(isLooping_)}};
+  flutter::EncodableMap toMapResult = {{flutter::EncodableValue("textureId"),
+                                        flutter::EncodableValue(textureId_)},
+                                       {flutter::EncodableValue("isLooping"),
+                                        flutter::EncodableValue(isLooping_)}};
 
   return flutter::EncodableValue(toMapResult);
 }
@@ -154,9 +152,9 @@ LoopingMessage LoopingMessage::fromMap(const flutter::EncodableValue &value) {
   return fromMapResult;
 }
 
-long VolumeMessage::getTextureId() const { return textureId_; }
+int64_t VolumeMessage::getTextureId() const { return textureId_; }
 
-void VolumeMessage::setTextureId(long textureId) { textureId_ = textureId; }
+void VolumeMessage::setTextureId(int64_t textureId) { textureId_ = textureId; }
 
 double VolumeMessage::getVolume() const { return volume_; }
 
@@ -168,7 +166,7 @@ flutter::EncodableValue VolumeMessage::toMap() {
 
   flutter::EncodableMap toMapResult = {
       {flutter::EncodableValue("textureId"),
-       flutter::EncodableValue((int64_t)textureId_)},
+       flutter::EncodableValue(textureId_)},
       {flutter::EncodableValue("volume"), flutter::EncodableValue(volume_)}};
 
   return flutter::EncodableValue(toMapResult);
@@ -198,9 +196,9 @@ VolumeMessage VolumeMessage::fromMap(const flutter::EncodableValue &value) {
   return fromMapResult;
 }
 
-long PlaybackSpeedMessage::getTextureId() const { return textureId_; }
+int64_t PlaybackSpeedMessage::getTextureId() const { return textureId_; }
 
-void PlaybackSpeedMessage::setTextureId(long textureId) {
+void PlaybackSpeedMessage::setTextureId(int64_t textureId) {
   textureId_ = textureId;
 }
 
@@ -214,7 +212,7 @@ flutter::EncodableValue PlaybackSpeedMessage::toMap() {
 
   flutter::EncodableMap toMapResult = {
       {flutter::EncodableValue("textureId"),
-       flutter::EncodableValue((int64_t)textureId_)},
+       flutter::EncodableValue(textureId_)},
       {flutter::EncodableValue("speed"), flutter::EncodableValue(speed_)}};
 
   return flutter::EncodableValue(toMapResult);
@@ -244,23 +242,24 @@ PlaybackSpeedMessage PlaybackSpeedMessage::fromMap(
   return fromMapResult;
 }
 
-long PositionMessage::getTextureId() const { return textureId_; }
+int64_t PositionMessage::getTextureId() const { return textureId_; }
 
-void PositionMessage::setTextureId(long textureId) { textureId_ = textureId; }
+void PositionMessage::setTextureId(int64_t textureId) {
+  textureId_ = textureId;
+}
 
-long PositionMessage::getPosition() const { return position_; }
+int64_t PositionMessage::getPosition() const { return position_; }
 
-void PositionMessage::setPosition(long position) { position_ = position; }
+void PositionMessage::setPosition(int64_t position) { position_ = position; }
 
 flutter::EncodableValue PositionMessage::toMap() {
   LOG_DEBUG("[PositionMessage.toMap] textureId: %ld", textureId_);
   LOG_DEBUG("[PositionMessage.toMap] position: %ld", position_);
 
-  flutter::EncodableMap toMapResult = {
-      {flutter::EncodableValue("textureId"),
-       flutter::EncodableValue((int64_t)textureId_)},
-      {flutter::EncodableValue("position"),
-       flutter::EncodableValue((int64_t)position_)}};
+  flutter::EncodableMap toMapResult = {{flutter::EncodableValue("textureId"),
+                                        flutter::EncodableValue(textureId_)},
+                                       {flutter::EncodableValue("position"),
+                                        flutter::EncodableValue(position_)}};
 
   return flutter::EncodableValue(toMapResult);
 }

--- a/packages/video_player/tizen/src/message.h
+++ b/packages/video_player/tizen/src/message.h
@@ -160,9 +160,8 @@ class VideoPlayerApi {
   virtual void setMixWithOthers(
       const MixWithOthersMessage &mixWithOthersMsg) = 0;
 
-  static void setup(flutter::BinaryMessenger *binaryMessenger,
-                    VideoPlayerApi *api);
-  static flutter::EncodableValue wrapError(const VideoPlayerError &error);
+  static void SetUp(flutter::BinaryMessenger *messenger, VideoPlayerApi *api);
+  static flutter::EncodableValue WrapError(const VideoPlayerError &error);
 };
 
 #endif  // VIDEO_PLAYER_MESSAGE_H_

--- a/packages/video_player/tizen/src/message.h
+++ b/packages/video_player/tizen/src/message.h
@@ -142,10 +142,10 @@ class MixWithOthersMessage {
   bool mixWithOthers_;
 };
 
-using SeekCompletedCb = std::function<void()>;
-
 class VideoPlayerApi {
  public:
+  using SeekCompletedCallback = std::function<void()>;
+
   virtual void initialize() = 0;
   virtual TextureMessage create(const CreateMessage &createMsg) = 0;
   virtual void dispose(const TextureMessage &textureMsg) = 0;
@@ -156,7 +156,7 @@ class VideoPlayerApi {
   virtual void pause(const TextureMessage &textureMsg) = 0;
   virtual PositionMessage position(const TextureMessage &textureMsg) = 0;
   virtual void seekTo(const PositionMessage &positionMsg,
-                      const SeekCompletedCb &onSeekCompleted) = 0;
+                      const SeekCompletedCallback &onSeekCompleted) = 0;
   virtual void setMixWithOthers(
       const MixWithOthersMessage &mixWithOthersMsg) = 0;
 

--- a/packages/video_player/tizen/src/message.h
+++ b/packages/video_player/tizen/src/message.h
@@ -16,13 +16,13 @@ class TextureMessage {
   TextureMessage(TextureMessage const &) = default;
   TextureMessage &operator=(TextureMessage const &) = default;
 
-  long getTextureId() const;
-  void setTextureId(long textureId);
+  int64_t getTextureId() const;
+  void setTextureId(int64_t textureId);
   flutter::EncodableValue toMap();
   static TextureMessage fromMap(const flutter::EncodableValue &value);
 
  private:
-  long textureId_;
+  int64_t textureId_;
 };
 
 class CreateMessage {
@@ -57,15 +57,15 @@ class LoopingMessage {
   LoopingMessage(LoopingMessage const &) = default;
   LoopingMessage &operator=(LoopingMessage const &) = default;
 
-  long getTextureId() const;
-  void setTextureId(long textureId);
+  int64_t getTextureId() const;
+  void setTextureId(int64_t textureId);
   bool getIsLooping() const;
   void setIsLooping(bool isLooping);
   flutter::EncodableValue toMap();
   static LoopingMessage fromMap(const flutter::EncodableValue &value);
 
  private:
-  long textureId_;
+  int64_t textureId_;
   bool isLooping_;
 };
 
@@ -76,15 +76,15 @@ class VolumeMessage {
   VolumeMessage(VolumeMessage const &) = default;
   VolumeMessage &operator=(VolumeMessage const &) = default;
 
-  long getTextureId() const;
-  void setTextureId(long textureId);
+  int64_t getTextureId() const;
+  void setTextureId(int64_t textureId);
   double getVolume() const;
   void setVolume(double volume);
   flutter::EncodableValue toMap();
   static VolumeMessage fromMap(const flutter::EncodableValue &value);
 
  private:
-  long textureId_;
+  int64_t textureId_;
   double volume_;
 };
 
@@ -95,15 +95,15 @@ class PlaybackSpeedMessage {
   PlaybackSpeedMessage(PlaybackSpeedMessage const &) = default;
   PlaybackSpeedMessage &operator=(PlaybackSpeedMessage const &) = default;
 
-  long getTextureId() const;
-  void setTextureId(long textureId);
+  int64_t getTextureId() const;
+  void setTextureId(int64_t textureId);
   double getSpeed() const;
   void setSpeed(double speed);
   flutter::EncodableValue toMap();
   static PlaybackSpeedMessage fromMap(const flutter::EncodableValue &value);
 
  private:
-  long textureId_;
+  int64_t textureId_;
   double speed_;
 };
 
@@ -114,16 +114,16 @@ class PositionMessage {
   PositionMessage(PositionMessage const &) = default;
   PositionMessage &operator=(PositionMessage const &) = default;
 
-  long getTextureId() const;
-  void setTextureId(long textureId);
-  long getPosition() const;
-  void setPosition(long position);
+  int64_t getTextureId() const;
+  void setTextureId(int64_t textureId);
+  int64_t getPosition() const;
+  void setPosition(int64_t position);
   flutter::EncodableValue toMap();
   static PositionMessage fromMap(const flutter::EncodableValue &value);
 
  private:
-  long textureId_;
-  long position_;
+  int64_t textureId_;
+  int64_t position_;
 };
 
 class MixWithOthersMessage {

--- a/packages/video_player/tizen/src/message.h
+++ b/packages/video_player/tizen/src/message.h
@@ -1,5 +1,5 @@
-#ifndef VIDEO_PLAYER_MESSAGE_H_
-#define VIDEO_PLAYER_MESSAGE_H_
+#ifndef FLUTTER_PLUGIN_VIDEO_PLAYER_MESSAGE_H_
+#define FLUTTER_PLUGIN_VIDEO_PLAYER_MESSAGE_H_
 
 #include <flutter/binary_messenger.h>
 #include <flutter/encodable_value.h>
@@ -164,4 +164,4 @@ class VideoPlayerApi {
   static flutter::EncodableValue WrapError(const VideoPlayerError &error);
 };
 
-#endif  // VIDEO_PLAYER_MESSAGE_H_
+#endif  // FLUTTER_PLUGIN_VIDEO_PLAYER_MESSAGE_H_

--- a/packages/video_player/tizen/src/video_player.cc
+++ b/packages/video_player/tizen/src/video_player.cc
@@ -128,7 +128,7 @@ VideoPlayer::VideoPlayer(flutter::PluginRegistrar *plugin_registrar,
   LOG_DEBUG(
       "[VideoPlayer] call player_set_media_packet_video_frame_decoded_cb");
   ret = player_set_media_packet_video_frame_decoded_cb(
-      player_, onVideoFrameDecoded, (void *)this);
+      player_, OnVideoFrameDecoded, (void *)this);
   if (ret != PLAYER_ERROR_NONE) {
     player_destroy(player_);
     LOG_ERROR(
@@ -141,7 +141,7 @@ VideoPlayer::VideoPlayer(flutter::PluginRegistrar *plugin_registrar,
   }
 
   LOG_DEBUG("[VideoPlayer] call player_set_buffering_cb");
-  ret = player_set_buffering_cb(player_, onBuffering, (void *)this);
+  ret = player_set_buffering_cb(player_, OnBuffering, (void *)this);
   if (ret != PLAYER_ERROR_NONE) {
     player_destroy(player_);
     LOG_ERROR("[VideoPlayer] player_set_buffering_cb failed: %s",
@@ -151,7 +151,7 @@ VideoPlayer::VideoPlayer(flutter::PluginRegistrar *plugin_registrar,
   }
 
   LOG_DEBUG("[VideoPlayer] call player_set_completed_cb");
-  ret = player_set_completed_cb(player_, onPlayCompleted, (void *)this);
+  ret = player_set_completed_cb(player_, OnPlayCompleted, (void *)this);
   if (ret != PLAYER_ERROR_NONE) {
     player_destroy(player_);
     LOG_ERROR("[VideoPlayer] player_set_completed_cb failed: %s",
@@ -161,7 +161,7 @@ VideoPlayer::VideoPlayer(flutter::PluginRegistrar *plugin_registrar,
   }
 
   LOG_DEBUG("[VideoPlayer] call player_set_interrupted_cb");
-  ret = player_set_interrupted_cb(player_, onInterrupted, (void *)this);
+  ret = player_set_interrupted_cb(player_, OnInterrupted, (void *)this);
   if (ret != PLAYER_ERROR_NONE) {
     player_destroy(player_);
     LOG_ERROR("[VideoPlayer] player_set_interrupted_cb failed: %s",
@@ -171,7 +171,7 @@ VideoPlayer::VideoPlayer(flutter::PluginRegistrar *plugin_registrar,
   }
 
   LOG_DEBUG("[VideoPlayer] call player_set_error_cb");
-  ret = player_set_error_cb(player_, onErrorOccurred, (void *)this);
+  ret = player_set_error_cb(player_, OnErrorOccurred, (void *)this);
   if (ret != PLAYER_ERROR_NONE) {
     player_destroy(player_);
     LOG_ERROR("[VideoPlayer] player_set_error_cb failed: %s",
@@ -181,7 +181,7 @@ VideoPlayer::VideoPlayer(flutter::PluginRegistrar *plugin_registrar,
   }
 
   LOG_DEBUG("[VideoPlayer] call player_prepare_async");
-  ret = player_prepare_async(player_, onPrepared, (void *)this);
+  ret = player_prepare_async(player_, OnPrepared, (void *)this);
   if (ret != PLAYER_ERROR_NONE) {
     player_destroy(player_);
     LOG_ERROR("[VideoPlayer] player_prepare_async failed: %s",
@@ -190,22 +190,22 @@ VideoPlayer::VideoPlayer(flutter::PluginRegistrar *plugin_registrar,
                            get_error_message(ret));
   }
 
-  setupEventChannel(plugin_registrar->messenger());
+  SetupEventChannel(plugin_registrar->messenger());
 }
 
 VideoPlayer::~VideoPlayer() {
   LOG_INFO("[VideoPlayer] destructor");
-  dispose();
+  Dispose();
 }
 
-int64_t VideoPlayer::getTextureId() { return texture_id_; }
+int64_t VideoPlayer::GetTextureId() { return texture_id_; }
 
-void VideoPlayer::play() {
-  LOG_DEBUG("[VideoPlayer.play] start player");
+void VideoPlayer::Play() {
+  LOG_DEBUG("[VideoPlayer.Play] start player");
   player_state_e state;
   int ret = player_get_state(player_, &state);
   if (ret == PLAYER_ERROR_NONE) {
-    LOG_INFO("[VideoPlayer.play] player state: %s",
+    LOG_INFO("[VideoPlayer.Play] player state: %s",
              StateToString(state).c_str());
     if (state != PLAYER_STATE_PAUSED && state != PLAYER_STATE_READY) {
       return;
@@ -214,18 +214,18 @@ void VideoPlayer::play() {
 
   ret = player_start(player_);
   if (ret != PLAYER_ERROR_NONE) {
-    LOG_ERROR("[VideoPlayer.play] player_start failed: %s",
+    LOG_ERROR("[VideoPlayer.Play] player_start failed: %s",
               get_error_message(ret));
     throw VideoPlayerError("player_start failed", get_error_message(ret));
   }
 }
 
-void VideoPlayer::pause() {
-  LOG_DEBUG("[VideoPlayer.pause] pause player");
+void VideoPlayer::Pause() {
+  LOG_DEBUG("[VideoPlayer.Pause] pause player");
   player_state_e state;
   int ret = player_get_state(player_, &state);
   if (ret == PLAYER_ERROR_NONE) {
-    LOG_INFO("[VideoPlayer.pause] player state: %s",
+    LOG_INFO("[VideoPlayer.Pause] player state: %s",
              StateToString(state).c_str());
     if (state != PLAYER_STATE_PLAYING) {
       return;
@@ -234,76 +234,76 @@ void VideoPlayer::pause() {
 
   ret = player_pause(player_);
   if (ret != PLAYER_ERROR_NONE) {
-    LOG_ERROR("[VideoPlayer.pause] player_pause failed: %s",
+    LOG_ERROR("[VideoPlayer.Pause] player_pause failed: %s",
               get_error_message(ret));
     throw VideoPlayerError("player_pause failed", get_error_message(ret));
   }
 }
 
-void VideoPlayer::setLooping(bool is_looping) {
-  LOG_DEBUG("[VideoPlayer.setLooping] isLooping: %d", is_looping);
+void VideoPlayer::SetLooping(bool is_looping) {
+  LOG_DEBUG("[VideoPlayer.SetLooping] isLooping: %d", is_looping);
   int ret = player_set_looping(player_, is_looping);
   if (ret != PLAYER_ERROR_NONE) {
-    LOG_ERROR("[VideoPlayer.setLooping] player_set_looping failed: %s",
+    LOG_ERROR("[VideoPlayer.SetLooping] player_set_looping failed: %s",
               get_error_message(ret));
     throw VideoPlayerError("player_set_looping failed", get_error_message(ret));
   }
 }
 
-void VideoPlayer::setVolume(double volume) {
-  LOG_DEBUG("[VideoPlayer.setVolume] volume: %f", volume);
+void VideoPlayer::SetVolume(double volume) {
+  LOG_DEBUG("[VideoPlayer.SetVolume] volume: %f", volume);
   int ret = player_set_volume(player_, volume, volume);
   if (ret != PLAYER_ERROR_NONE) {
-    LOG_ERROR("[VideoPlayer.setVolume] player_set_volume failed: %s",
+    LOG_ERROR("[VideoPlayer.SetVolume] player_set_volume failed: %s",
               get_error_message(ret));
     throw VideoPlayerError("player_set_volume failed", get_error_message(ret));
   }
 }
 
-void VideoPlayer::setPlaybackSpeed(double speed) {
-  LOG_DEBUG("[VideoPlayer.setPlaybackSpeed] speed: %f", speed);
+void VideoPlayer::SetPlaybackSpeed(double speed) {
+  LOG_DEBUG("[VideoPlayer.SetPlaybackSpeed] speed: %f", speed);
   int ret = player_set_playback_rate(player_, speed);
   if (ret != PLAYER_ERROR_NONE) {
     LOG_ERROR(
-        "[VideoPlayer.setPlaybackSpeed] player_set_playback_rate failed: %s",
+        "[VideoPlayer.SetPlaybackSpeed] player_set_playback_rate failed: %s",
         get_error_message(ret));
     throw VideoPlayerError("player_set_playback_rate failed",
                            get_error_message(ret));
   }
 }
 
-void VideoPlayer::seekTo(int position,
+void VideoPlayer::SeekTo(int position,
                          const SeekCompletedCallback &seek_completed_cb) {
-  LOG_DEBUG("[VideoPlayer.seekTo] position: %d", position);
+  LOG_DEBUG("[VideoPlayer.SeekTo] position: %d", position);
   on_seek_completed_ = seek_completed_cb;
   int ret =
-      player_set_play_position(player_, position, true, onSeekCompleted, this);
+      player_set_play_position(player_, position, true, OnSeekCompleted, this);
   if (ret != PLAYER_ERROR_NONE) {
     on_seek_completed_ = nullptr;
-    LOG_ERROR("[VideoPlayer.seekTo] player_set_play_position failed: %s",
+    LOG_ERROR("[VideoPlayer.SeekTo] player_set_play_position failed: %s",
               get_error_message(ret));
     throw VideoPlayerError("player_set_play_position failed",
                            get_error_message(ret));
   }
 }
 
-int VideoPlayer::getPosition() {
-  LOG_DEBUG("[VideoPlayer.getPosition] get video player position");
+int VideoPlayer::GetPosition() {
+  LOG_DEBUG("[VideoPlayer.GetPosition] get video player position");
   int position;
   int ret = player_get_play_position(player_, &position);
   if (ret != PLAYER_ERROR_NONE) {
-    LOG_ERROR("[VideoPlayer.getPosition] player_get_play_position failed: %s",
+    LOG_ERROR("[VideoPlayer.GetPosition] player_get_play_position failed: %s",
               get_error_message(ret));
     throw VideoPlayerError("player_get_play_position failed",
                            get_error_message(ret));
   }
 
-  LOG_DEBUG("[VideoPlayer.getPosition] position: %d", position);
+  LOG_DEBUG("[VideoPlayer.GetPosition] position: %d", position);
   return position;
 }
 
-void VideoPlayer::dispose() {
-  LOG_DEBUG("[VideoPlayer.dispose] dispose video player");
+void VideoPlayer::Dispose() {
+  LOG_DEBUG("[VideoPlayer.Dispose] dispose video player");
   is_initialized_ = false;
   event_sink_ = nullptr;
   event_channel_->SetStreamHandler(nullptr);
@@ -330,8 +330,8 @@ void VideoPlayer::dispose() {
   }
 }
 
-void VideoPlayer::setupEventChannel(flutter::BinaryMessenger *messenger) {
-  LOG_DEBUG("[VideoPlayer.setupEventChannel] setup event channel");
+void VideoPlayer::SetupEventChannel(flutter::BinaryMessenger *messenger) {
+  LOG_DEBUG("[VideoPlayer.SetupEventChannel] setup event channel");
   std::string name =
       "flutter.io/videoPlayer/videoEvents" + std::to_string(texture_id_);
   auto channel =
@@ -346,16 +346,16 @@ void VideoPlayer::setupEventChannel(flutter::BinaryMessenger *messenger) {
           -> std::unique_ptr<
               flutter::StreamHandlerError<flutter::EncodableValue>> {
         LOG_DEBUG(
-            "[VideoPlayer.setupEventChannel] call listen of StreamHandler");
+            "[VideoPlayer.SetupEventChannel] call listen of StreamHandler");
         event_sink_ = std::move(events);
-        initialize();
+        Initialize();
         return nullptr;
       },
       [&](const flutter::EncodableValue *arguments)
           -> std::unique_ptr<
               flutter::StreamHandlerError<flutter::EncodableValue>> {
         LOG_DEBUG(
-            "[VideoPlayer.setupEventChannel] call cancel of StreamHandler");
+            "[VideoPlayer.SetupEventChannel] call cancel of StreamHandler");
         event_sink_ = nullptr;
         return nullptr;
       });
@@ -363,55 +363,55 @@ void VideoPlayer::setupEventChannel(flutter::BinaryMessenger *messenger) {
   event_channel_ = std::move(channel);
 }
 
-void VideoPlayer::initialize() {
+void VideoPlayer::Initialize() {
   player_state_e state;
   int ret = player_get_state(player_, &state);
   if (ret == PLAYER_ERROR_NONE) {
-    LOG_INFO("[VideoPlayer.initialize] player state: %s",
+    LOG_INFO("[VideoPlayer.Initialize] player state: %s",
              StateToString(state).c_str());
     if (state == PLAYER_STATE_READY && !is_initialized_) {
-      sendInitialized();
+      SendInitialized();
     }
   } else {
-    LOG_ERROR("[VideoPlayer.initialize] player_get_state failed: %s",
+    LOG_ERROR("[VideoPlayer.Initialize] player_get_state failed: %s",
               get_error_message(ret));
   }
 }
 
-void VideoPlayer::sendInitialized() {
+void VideoPlayer::SendInitialized() {
   if (!is_initialized_ && event_sink_ != nullptr) {
     int duration;
     int ret = player_get_duration(player_, &duration);
     if (ret != PLAYER_ERROR_NONE) {
-      LOG_ERROR("[VideoPlayer.sendInitialized] player_get_duration failed: %s",
+      LOG_ERROR("[VideoPlayer.SendInitialized] player_get_duration failed: %s",
                 get_error_message(ret));
       event_sink_->Error("player_get_duration failed", get_error_message(ret));
       return;
     }
-    LOG_DEBUG("[VideoPlayer.sendInitialized] video duration: %d", duration);
+    LOG_DEBUG("[VideoPlayer.SendInitialized] video duration: %d", duration);
 
     int width, height;
     ret = player_get_video_size(player_, &width, &height);
     if (ret != PLAYER_ERROR_NONE) {
       LOG_ERROR(
-          "[VideoPlayer.sendInitialized] player_get_video_size failed: %s",
+          "[VideoPlayer.SendInitialized] player_get_video_size failed: %s",
           get_error_message(ret));
       event_sink_->Error("player_get_video_size failed",
                          get_error_message(ret));
       return;
     }
-    LOG_DEBUG("[VideoPlayer.sendInitialized] video width: %d, height: %d",
+    LOG_DEBUG("[VideoPlayer.SendInitialized] video width: %d, height: %d",
               width, height);
 
     player_display_rotation_e rotation;
     ret = player_get_display_rotation(player_, &rotation);
     if (ret != PLAYER_ERROR_NONE) {
       LOG_ERROR(
-          "[VideoPlayer.sendInitialized] player_get_display_rotation "
+          "[VideoPlayer.SendInitialized] player_get_display_rotation "
           "failed: %s",
           get_error_message(ret));
     } else {
-      LOG_DEBUG("[VideoPlayer.sendInitialized] rotation: %s",
+      LOG_DEBUG("[VideoPlayer.SendInitialized] rotation: %s",
                 RotationToString(rotation).c_str());
       if (rotation == PLAYER_DISPLAY_ROTATION_90 ||
           rotation == PLAYER_DISPLAY_ROTATION_270) {
@@ -430,23 +430,23 @@ void VideoPlayer::sendInitialized() {
         {flutter::EncodableValue("width"), flutter::EncodableValue(width)},
         {flutter::EncodableValue("height"), flutter::EncodableValue(height)}};
     flutter::EncodableValue eventValue(encodables);
-    LOG_INFO("[VideoPlayer.sendInitialized] send initialized event");
+    LOG_INFO("[VideoPlayer.SendInitialized] send initialized event");
     event_sink_->Success(eventValue);
   }
 }
 
-void VideoPlayer::sendBufferingStart() {
+void VideoPlayer::SendBufferingStart() {
   if (event_sink_) {
     flutter::EncodableMap encodables = {
         {flutter::EncodableValue("event"),
          flutter::EncodableValue("bufferingStart")}};
     flutter::EncodableValue eventValue(encodables);
-    LOG_INFO("[VideoPlayer.onBuffering] send bufferingStart event");
+    LOG_INFO("[VideoPlayer.OnBuffering] send bufferingStart event");
     event_sink_->Success(eventValue);
   }
 }
 
-void VideoPlayer::sendBufferingUpdate(int position) {
+void VideoPlayer::SendBufferingUpdate(int position) {
   if (event_sink_) {
     flutter::EncodableList range = {flutter::EncodableValue(0),
                                     flutter::EncodableValue(position)};
@@ -457,39 +457,39 @@ void VideoPlayer::sendBufferingUpdate(int position) {
         {flutter::EncodableValue("values"),
          flutter::EncodableValue(rangeList)}};
     flutter::EncodableValue eventValue(encodables);
-    LOG_INFO("[VideoPlayer.onBuffering] send bufferingUpdate event");
+    LOG_INFO("[VideoPlayer.OnBuffering] send bufferingUpdate event");
     event_sink_->Success(eventValue);
   }
 }
 
-void VideoPlayer::sendBufferingEnd() {
+void VideoPlayer::SendBufferingEnd() {
   if (event_sink_) {
     flutter::EncodableMap encodables = {
         {flutter::EncodableValue("event"),
          flutter::EncodableValue("bufferingEnd")}};
     flutter::EncodableValue eventValue(encodables);
-    LOG_INFO("[VideoPlayer.onBuffering] send bufferingEnd event");
+    LOG_INFO("[VideoPlayer.OnBuffering] send bufferingEnd event");
     event_sink_->Success(eventValue);
   }
 }
 
-void VideoPlayer::onPrepared(void *data) {
+void VideoPlayer::OnPrepared(void *data) {
   VideoPlayer *player = (VideoPlayer *)data;
-  LOG_DEBUG("[VideoPlayer.onPrepared] video player is prepared");
+  LOG_DEBUG("[VideoPlayer.OnPrepared] video player is prepared");
 
   if (!player->is_initialized_) {
-    player->sendInitialized();
+    player->SendInitialized();
   }
 }
 
-void VideoPlayer::onBuffering(int percent, void *data) {
+void VideoPlayer::OnBuffering(int percent, void *data) {
   // percent isn't used for video size, it's the used storage of buffer
-  LOG_DEBUG("[VideoPlayer.onBuffering] percent: %d", percent);
+  LOG_DEBUG("[VideoPlayer.OnBuffering] percent: %d", percent);
 }
 
-void VideoPlayer::onSeekCompleted(void *data) {
+void VideoPlayer::OnSeekCompleted(void *data) {
   VideoPlayer *player = (VideoPlayer *)data;
-  LOG_DEBUG("[VideoPlayer.onSeekCompleted] completed to seek");
+  LOG_DEBUG("[VideoPlayer.OnSeekCompleted] completed to seek");
 
   if (player->on_seek_completed_) {
     player->on_seek_completed_();
@@ -497,45 +497,45 @@ void VideoPlayer::onSeekCompleted(void *data) {
   }
 }
 
-void VideoPlayer::onPlayCompleted(void *data) {
+void VideoPlayer::OnPlayCompleted(void *data) {
   VideoPlayer *player = (VideoPlayer *)data;
-  LOG_DEBUG("[VideoPlayer.onPlayCompleted] completed to playe video");
+  LOG_DEBUG("[VideoPlayer.OnPlayCompleted] completed to playe video");
 
   if (player->event_sink_) {
     flutter::EncodableMap encodables = {{flutter::EncodableValue("event"),
                                          flutter::EncodableValue("completed")}};
     flutter::EncodableValue eventValue(encodables);
-    LOG_INFO("[VideoPlayer.onPlayCompleted] send completed event");
+    LOG_INFO("[VideoPlayer.OnPlayCompleted] send completed event");
     player->event_sink_->Success(eventValue);
 
-    LOG_DEBUG("[VideoPlayer.onPlayCompleted] change player state to pause");
-    player->pause();
+    LOG_DEBUG("[VideoPlayer.OnPlayCompleted] change player state to pause");
+    player->Pause();
   }
 }
 
-void VideoPlayer::onInterrupted(player_interrupted_code_e code, void *data) {
+void VideoPlayer::OnInterrupted(player_interrupted_code_e code, void *data) {
   VideoPlayer *player = (VideoPlayer *)data;
-  LOG_DEBUG("[VideoPlayer.onInterrupted] interrupted code: %d", code);
+  LOG_DEBUG("[VideoPlayer.OnInterrupted] interrupted code: %d", code);
 
   if (player->event_sink_) {
-    LOG_INFO("[VideoPlayer.onInterrupted] send error event");
+    LOG_INFO("[VideoPlayer.OnInterrupted] send error event");
     player->event_sink_->Error("Interrupted error",
                                "Video player has been interrupted.");
   }
 }
 
-void VideoPlayer::onErrorOccurred(int code, void *data) {
+void VideoPlayer::OnErrorOccurred(int code, void *data) {
   VideoPlayer *player = (VideoPlayer *)data;
-  LOG_DEBUG("[VideoPlayer.onErrorOccurred] error code: %s",
+  LOG_DEBUG("[VideoPlayer.OnErrorOccurred] error code: %s",
             get_error_message(code));
 
   if (player->event_sink_) {
-    LOG_INFO("[VideoPlayer.onErrorOccurred] send error event");
+    LOG_INFO("[VideoPlayer.OnErrorOccurred] send error event");
     player->event_sink_->Error("Player error", get_error_message(code));
   }
 }
 
-void VideoPlayer::onVideoFrameDecoded(media_packet_h packet, void *data) {
+void VideoPlayer::OnVideoFrameDecoded(media_packet_h packet, void *data) {
   VideoPlayer *player = (VideoPlayer *)data;
   std::lock_guard<std::mutex> lock(player->mutex_);
   if (player->current_media_packet_) {

--- a/packages/video_player/tizen/src/video_player.cc
+++ b/packages/video_player/tizen/src/video_player.cc
@@ -9,44 +9,33 @@
 #include "video_player_error.h"
 
 static std::string RotationToString(player_display_rotation_e rotation) {
-  std::string ret;
   switch (rotation) {
     case PLAYER_DISPLAY_ROTATION_NONE:
-      ret = "PLAYER_DISPLAY_ROTATION_NONE";
-      break;
+      return "PLAYER_DISPLAY_ROTATION_NONE";
     case PLAYER_DISPLAY_ROTATION_90:
-      ret = "PLAYER_DISPLAY_ROTATION_90";
-      break;
+      return "PLAYER_DISPLAY_ROTATION_90";
     case PLAYER_DISPLAY_ROTATION_180:
-      ret = "PLAYER_DISPLAY_ROTATION_180";
-      break;
+      return "PLAYER_DISPLAY_ROTATION_180";
     case PLAYER_DISPLAY_ROTATION_270:
-      ret = "PLAYER_DISPLAY_ROTATION_270";
-      break;
+      return "PLAYER_DISPLAY_ROTATION_270";
   }
-  return ret;
+  return std::string();
 }
 
 static std::string StateToString(player_state_e state) {
-  std::string ret;
   switch (state) {
     case PLAYER_STATE_NONE:
-      ret = "PLAYER_STATE_NONE";
-      break;
+      return "PLAYER_STATE_NONE";
     case PLAYER_STATE_IDLE:
-      ret = "PLAYER_STATE_IDLE";
-      break;
+      return "PLAYER_STATE_IDLE";
     case PLAYER_STATE_READY:
-      ret = "PLAYER_STATE_READY";
-      break;
+      return "PLAYER_STATE_READY";
     case PLAYER_STATE_PLAYING:
-      ret = "PLAYER_STATE_PLAYING";
-      break;
+      return "PLAYER_STATE_PLAYING";
     case PLAYER_STATE_PAUSED:
-      ret = "PLAYER_STATE_PAUSED";
-      break;
+      return "PLAYER_STATE_PAUSED";
   }
-  return ret;
+  return std::string();
 }
 
 void VideoPlayer::ReleaseMediaPacket(void *data) {
@@ -197,8 +186,6 @@ VideoPlayer::~VideoPlayer() {
   LOG_INFO("[VideoPlayer] destructor");
   Dispose();
 }
-
-int64_t VideoPlayer::GetTextureId() { return texture_id_; }
 
 void VideoPlayer::Play() {
   LOG_DEBUG("[VideoPlayer.Play] start player");

--- a/packages/video_player/tizen/src/video_player.cc
+++ b/packages/video_player/tizen/src/video_player.cc
@@ -273,7 +273,7 @@ void VideoPlayer::setPlaybackSpeed(double speed) {
 }
 
 void VideoPlayer::seekTo(int position,
-                         const SeekCompletedCb &seek_completed_cb) {
+                         const SeekCompletedCallback &seek_completed_cb) {
   LOG_DEBUG("[VideoPlayer.seekTo] position: %d", position);
   on_seek_completed_ = seek_completed_cb;
   int ret =

--- a/packages/video_player/tizen/src/video_player.cc
+++ b/packages/video_player/tizen/src/video_player.cc
@@ -198,7 +198,7 @@ VideoPlayer::~VideoPlayer() {
   dispose();
 }
 
-long VideoPlayer::getTextureId() { return texture_id_; }
+int64_t VideoPlayer::getTextureId() { return texture_id_; }
 
 void VideoPlayer::play() {
   LOG_DEBUG("[VideoPlayer.play] start player");

--- a/packages/video_player/tizen/src/video_player.cc
+++ b/packages/video_player/tizen/src/video_player.cc
@@ -51,13 +51,13 @@ FlutterDesktopGpuBuffer *VideoPlayer::ObtainGpuBuffer(size_t width,
                                                       size_t height) {
   std::lock_guard<std::mutex> lock(mutex_);
   if (!current_media_packet_) {
-    LOG_ERROR("No vaild media packet");
+    LOG_ERROR("[VideoPlayer] No vaild media packet");
     return nullptr;
   }
   tbm_surface_h surface;
   int ret = media_packet_get_tbm_surface(current_media_packet_, &surface);
   if (ret != MEDIA_PACKET_ERROR_NONE || surface == nullptr) {
-    LOG_ERROR("get tbm surface failed, error: %d", ret);
+    LOG_ERROR("[VideoPlayer] Failed to get TBM surface, error: %d", ret);
     media_packet_destroy(current_media_packet_);
     current_media_packet_ = nullptr;
     return nullptr;
@@ -188,12 +188,11 @@ VideoPlayer::~VideoPlayer() {
 }
 
 void VideoPlayer::Play() {
-  LOG_DEBUG("[VideoPlayer.Play] start player");
+  LOG_DEBUG("[VideoPlayer] start player");
   player_state_e state;
   int ret = player_get_state(player_, &state);
   if (ret == PLAYER_ERROR_NONE) {
-    LOG_INFO("[VideoPlayer.Play] player state: %s",
-             StateToString(state).c_str());
+    LOG_INFO("[VideoPlayer] player state: %s", StateToString(state).c_str());
     if (state != PLAYER_STATE_PAUSED && state != PLAYER_STATE_READY) {
       return;
     }
@@ -201,19 +200,17 @@ void VideoPlayer::Play() {
 
   ret = player_start(player_);
   if (ret != PLAYER_ERROR_NONE) {
-    LOG_ERROR("[VideoPlayer.Play] player_start failed: %s",
-              get_error_message(ret));
+    LOG_ERROR("[VideoPlayer] player_start failed: %s", get_error_message(ret));
     throw VideoPlayerError("player_start failed", get_error_message(ret));
   }
 }
 
 void VideoPlayer::Pause() {
-  LOG_DEBUG("[VideoPlayer.Pause] pause player");
+  LOG_DEBUG("[VideoPlayer] pause player");
   player_state_e state;
   int ret = player_get_state(player_, &state);
   if (ret == PLAYER_ERROR_NONE) {
-    LOG_INFO("[VideoPlayer.Pause] player state: %s",
-             StateToString(state).c_str());
+    LOG_INFO("[VideoPlayer] player state: %s", StateToString(state).c_str());
     if (state != PLAYER_STATE_PLAYING) {
       return;
     }
@@ -221,39 +218,37 @@ void VideoPlayer::Pause() {
 
   ret = player_pause(player_);
   if (ret != PLAYER_ERROR_NONE) {
-    LOG_ERROR("[VideoPlayer.Pause] player_pause failed: %s",
-              get_error_message(ret));
+    LOG_ERROR("[VideoPlayer] player_pause failed: %s", get_error_message(ret));
     throw VideoPlayerError("player_pause failed", get_error_message(ret));
   }
 }
 
 void VideoPlayer::SetLooping(bool is_looping) {
-  LOG_DEBUG("[VideoPlayer.SetLooping] isLooping: %d", is_looping);
+  LOG_DEBUG("[VideoPlayer] isLooping: %d", is_looping);
   int ret = player_set_looping(player_, is_looping);
   if (ret != PLAYER_ERROR_NONE) {
-    LOG_ERROR("[VideoPlayer.SetLooping] player_set_looping failed: %s",
+    LOG_ERROR("[VideoPlayer] player_set_looping failed: %s",
               get_error_message(ret));
     throw VideoPlayerError("player_set_looping failed", get_error_message(ret));
   }
 }
 
 void VideoPlayer::SetVolume(double volume) {
-  LOG_DEBUG("[VideoPlayer.SetVolume] volume: %f", volume);
+  LOG_DEBUG("[VideoPlayer] volume: %f", volume);
   int ret = player_set_volume(player_, volume, volume);
   if (ret != PLAYER_ERROR_NONE) {
-    LOG_ERROR("[VideoPlayer.SetVolume] player_set_volume failed: %s",
+    LOG_ERROR("[VideoPlayer] player_set_volume failed: %s",
               get_error_message(ret));
     throw VideoPlayerError("player_set_volume failed", get_error_message(ret));
   }
 }
 
 void VideoPlayer::SetPlaybackSpeed(double speed) {
-  LOG_DEBUG("[VideoPlayer.SetPlaybackSpeed] speed: %f", speed);
+  LOG_DEBUG("[VideoPlayer] speed: %f", speed);
   int ret = player_set_playback_rate(player_, speed);
   if (ret != PLAYER_ERROR_NONE) {
-    LOG_ERROR(
-        "[VideoPlayer.SetPlaybackSpeed] player_set_playback_rate failed: %s",
-        get_error_message(ret));
+    LOG_ERROR("[VideoPlayer] player_set_playback_rate failed: %s",
+              get_error_message(ret));
     throw VideoPlayerError("player_set_playback_rate failed",
                            get_error_message(ret));
   }
@@ -261,13 +256,13 @@ void VideoPlayer::SetPlaybackSpeed(double speed) {
 
 void VideoPlayer::SeekTo(int position,
                          const SeekCompletedCallback &seek_completed_cb) {
-  LOG_DEBUG("[VideoPlayer.SeekTo] position: %d", position);
+  LOG_DEBUG("[VideoPlayer] position: %d", position);
   on_seek_completed_ = seek_completed_cb;
   int ret =
       player_set_play_position(player_, position, true, OnSeekCompleted, this);
   if (ret != PLAYER_ERROR_NONE) {
     on_seek_completed_ = nullptr;
-    LOG_ERROR("[VideoPlayer.SeekTo] player_set_play_position failed: %s",
+    LOG_ERROR("[VideoPlayer] player_set_play_position failed: %s",
               get_error_message(ret));
     throw VideoPlayerError("player_set_play_position failed",
                            get_error_message(ret));
@@ -275,22 +270,22 @@ void VideoPlayer::SeekTo(int position,
 }
 
 int VideoPlayer::GetPosition() {
-  LOG_DEBUG("[VideoPlayer.GetPosition] get video player position");
+  LOG_DEBUG("[VideoPlayer] get video player position");
   int position;
   int ret = player_get_play_position(player_, &position);
   if (ret != PLAYER_ERROR_NONE) {
-    LOG_ERROR("[VideoPlayer.GetPosition] player_get_play_position failed: %s",
+    LOG_ERROR("[VideoPlayer] player_get_play_position failed: %s",
               get_error_message(ret));
     throw VideoPlayerError("player_get_play_position failed",
                            get_error_message(ret));
   }
 
-  LOG_DEBUG("[VideoPlayer.GetPosition] position: %d", position);
+  LOG_DEBUG("[VideoPlayer] position: %d", position);
   return position;
 }
 
 void VideoPlayer::Dispose() {
-  LOG_DEBUG("[VideoPlayer.Dispose] dispose video player");
+  LOG_DEBUG("[VideoPlayer] dispose video player");
   is_initialized_ = false;
   event_sink_ = nullptr;
   event_channel_->SetStreamHandler(nullptr);
@@ -318,7 +313,7 @@ void VideoPlayer::Dispose() {
 }
 
 void VideoPlayer::SetupEventChannel(flutter::BinaryMessenger *messenger) {
-  LOG_DEBUG("[VideoPlayer.SetupEventChannel] setup event channel");
+  LOG_DEBUG("[VideoPlayer] setup event channel");
   std::string name =
       "flutter.io/videoPlayer/videoEvents" + std::to_string(texture_id_);
   auto channel =
@@ -332,8 +327,7 @@ void VideoPlayer::SetupEventChannel(flutter::BinaryMessenger *messenger) {
           std::unique_ptr<flutter::EventSink<flutter::EncodableValue>> &&events)
           -> std::unique_ptr<
               flutter::StreamHandlerError<flutter::EncodableValue>> {
-        LOG_DEBUG(
-            "[VideoPlayer.SetupEventChannel] call listen of StreamHandler");
+        LOG_DEBUG("[VideoPlayer] call listen of StreamHandler");
         event_sink_ = std::move(events);
         Initialize();
         return nullptr;
@@ -341,8 +335,7 @@ void VideoPlayer::SetupEventChannel(flutter::BinaryMessenger *messenger) {
       [&](const flutter::EncodableValue *arguments)
           -> std::unique_ptr<
               flutter::StreamHandlerError<flutter::EncodableValue>> {
-        LOG_DEBUG(
-            "[VideoPlayer.SetupEventChannel] call cancel of StreamHandler");
+        LOG_DEBUG("[VideoPlayer] call cancel of StreamHandler");
         event_sink_ = nullptr;
         return nullptr;
       });
@@ -354,13 +347,12 @@ void VideoPlayer::Initialize() {
   player_state_e state;
   int ret = player_get_state(player_, &state);
   if (ret == PLAYER_ERROR_NONE) {
-    LOG_INFO("[VideoPlayer.Initialize] player state: %s",
-             StateToString(state).c_str());
+    LOG_INFO("[VideoPlayer] player state: %s", StateToString(state).c_str());
     if (state == PLAYER_STATE_READY && !is_initialized_) {
       SendInitialized();
     }
   } else {
-    LOG_ERROR("[VideoPlayer.Initialize] player_get_state failed: %s",
+    LOG_ERROR("[VideoPlayer] player_get_state failed: %s",
               get_error_message(ret));
   }
 }
@@ -370,35 +362,33 @@ void VideoPlayer::SendInitialized() {
     int duration;
     int ret = player_get_duration(player_, &duration);
     if (ret != PLAYER_ERROR_NONE) {
-      LOG_ERROR("[VideoPlayer.SendInitialized] player_get_duration failed: %s",
+      LOG_ERROR("[VideoPlayer] player_get_duration failed: %s",
                 get_error_message(ret));
       event_sink_->Error("player_get_duration failed", get_error_message(ret));
       return;
     }
-    LOG_DEBUG("[VideoPlayer.SendInitialized] video duration: %d", duration);
+    LOG_DEBUG("[VideoPlayer] video duration: %d", duration);
 
     int width, height;
     ret = player_get_video_size(player_, &width, &height);
     if (ret != PLAYER_ERROR_NONE) {
-      LOG_ERROR(
-          "[VideoPlayer.SendInitialized] player_get_video_size failed: %s",
-          get_error_message(ret));
+      LOG_ERROR("[VideoPlayer] player_get_video_size failed: %s",
+                get_error_message(ret));
       event_sink_->Error("player_get_video_size failed",
                          get_error_message(ret));
       return;
     }
-    LOG_DEBUG("[VideoPlayer.SendInitialized] video width: %d, height: %d",
-              width, height);
+    LOG_DEBUG("[VideoPlayer] video width: %d, height: %d", width, height);
 
     player_display_rotation_e rotation;
     ret = player_get_display_rotation(player_, &rotation);
     if (ret != PLAYER_ERROR_NONE) {
       LOG_ERROR(
-          "[VideoPlayer.SendInitialized] player_get_display_rotation "
+          "[VideoPlayer] player_get_display_rotation "
           "failed: %s",
           get_error_message(ret));
     } else {
-      LOG_DEBUG("[VideoPlayer.SendInitialized] rotation: %s",
+      LOG_DEBUG("[VideoPlayer] rotation: %s",
                 RotationToString(rotation).c_str());
       if (rotation == PLAYER_DISPLAY_ROTATION_90 ||
           rotation == PLAYER_DISPLAY_ROTATION_270) {
@@ -417,7 +407,7 @@ void VideoPlayer::SendInitialized() {
         {flutter::EncodableValue("width"), flutter::EncodableValue(width)},
         {flutter::EncodableValue("height"), flutter::EncodableValue(height)}};
     flutter::EncodableValue eventValue(encodables);
-    LOG_INFO("[VideoPlayer.SendInitialized] send initialized event");
+    LOG_INFO("[VideoPlayer] send initialized event");
     event_sink_->Success(eventValue);
   }
 }
@@ -428,7 +418,7 @@ void VideoPlayer::SendBufferingStart() {
         {flutter::EncodableValue("event"),
          flutter::EncodableValue("bufferingStart")}};
     flutter::EncodableValue eventValue(encodables);
-    LOG_INFO("[VideoPlayer.OnBuffering] send bufferingStart event");
+    LOG_INFO("[VideoPlayer] send bufferingStart event");
     event_sink_->Success(eventValue);
   }
 }
@@ -444,7 +434,7 @@ void VideoPlayer::SendBufferingUpdate(int position) {
         {flutter::EncodableValue("values"),
          flutter::EncodableValue(rangeList)}};
     flutter::EncodableValue eventValue(encodables);
-    LOG_INFO("[VideoPlayer.OnBuffering] send bufferingUpdate event");
+    LOG_INFO("[VideoPlayer] send bufferingUpdate event");
     event_sink_->Success(eventValue);
   }
 }
@@ -455,14 +445,14 @@ void VideoPlayer::SendBufferingEnd() {
         {flutter::EncodableValue("event"),
          flutter::EncodableValue("bufferingEnd")}};
     flutter::EncodableValue eventValue(encodables);
-    LOG_INFO("[VideoPlayer.OnBuffering] send bufferingEnd event");
+    LOG_INFO("[VideoPlayer] send bufferingEnd event");
     event_sink_->Success(eventValue);
   }
 }
 
 void VideoPlayer::OnPrepared(void *data) {
   VideoPlayer *player = (VideoPlayer *)data;
-  LOG_DEBUG("[VideoPlayer.OnPrepared] video player is prepared");
+  LOG_DEBUG("[VideoPlayer] video player is prepared");
 
   if (!player->is_initialized_) {
     player->SendInitialized();
@@ -471,12 +461,12 @@ void VideoPlayer::OnPrepared(void *data) {
 
 void VideoPlayer::OnBuffering(int percent, void *data) {
   // percent isn't used for video size, it's the used storage of buffer
-  LOG_DEBUG("[VideoPlayer.OnBuffering] percent: %d", percent);
+  LOG_DEBUG("[VideoPlayer] percent: %d", percent);
 }
 
 void VideoPlayer::OnSeekCompleted(void *data) {
   VideoPlayer *player = (VideoPlayer *)data;
-  LOG_DEBUG("[VideoPlayer.OnSeekCompleted] completed to seek");
+  LOG_DEBUG("[VideoPlayer] completed to seek");
 
   if (player->on_seek_completed_) {
     player->on_seek_completed_();
@@ -486,26 +476,26 @@ void VideoPlayer::OnSeekCompleted(void *data) {
 
 void VideoPlayer::OnPlayCompleted(void *data) {
   VideoPlayer *player = (VideoPlayer *)data;
-  LOG_DEBUG("[VideoPlayer.OnPlayCompleted] completed to playe video");
+  LOG_DEBUG("[VideoPlayer] completed to playe video");
 
   if (player->event_sink_) {
     flutter::EncodableMap encodables = {{flutter::EncodableValue("event"),
                                          flutter::EncodableValue("completed")}};
     flutter::EncodableValue eventValue(encodables);
-    LOG_INFO("[VideoPlayer.OnPlayCompleted] send completed event");
+    LOG_INFO("[VideoPlayer] send completed event");
     player->event_sink_->Success(eventValue);
 
-    LOG_DEBUG("[VideoPlayer.OnPlayCompleted] change player state to pause");
+    LOG_DEBUG("[VideoPlayer] change player state to pause");
     player->Pause();
   }
 }
 
 void VideoPlayer::OnInterrupted(player_interrupted_code_e code, void *data) {
   VideoPlayer *player = (VideoPlayer *)data;
-  LOG_DEBUG("[VideoPlayer.OnInterrupted] interrupted code: %d", code);
+  LOG_DEBUG("[VideoPlayer] interrupted code: %d", code);
 
   if (player->event_sink_) {
-    LOG_INFO("[VideoPlayer.OnInterrupted] send error event");
+    LOG_INFO("[VideoPlayer] send error event");
     player->event_sink_->Error("Interrupted error",
                                "Video player has been interrupted.");
   }
@@ -513,11 +503,10 @@ void VideoPlayer::OnInterrupted(player_interrupted_code_e code, void *data) {
 
 void VideoPlayer::OnErrorOccurred(int code, void *data) {
   VideoPlayer *player = (VideoPlayer *)data;
-  LOG_DEBUG("[VideoPlayer.OnErrorOccurred] error code: %s",
-            get_error_message(code));
+  LOG_DEBUG("[VideoPlayer] error code: %s", get_error_message(code));
 
   if (player->event_sink_) {
-    LOG_INFO("[VideoPlayer.OnErrorOccurred] send error event");
+    LOG_INFO("[VideoPlayer] send error event");
     player->event_sink_->Error("Player error", get_error_message(code));
   }
 }

--- a/packages/video_player/tizen/src/video_player.cc
+++ b/packages/video_player/tizen/src/video_player.cc
@@ -367,37 +367,6 @@ void VideoPlayer::SendInitialized() {
   }
 }
 
-void VideoPlayer::SendBufferingStart() {
-  if (event_sink_) {
-    flutter::EncodableMap result = {
-        {flutter::EncodableValue("event"),
-         flutter::EncodableValue("bufferingStart")}};
-    event_sink_->Success(flutter::EncodableValue(result));
-  }
-}
-
-void VideoPlayer::SendBufferingUpdate(int position) {
-  if (event_sink_) {
-    flutter::EncodableList range = {flutter::EncodableValue(0),
-                                    flutter::EncodableValue(position)};
-    flutter::EncodableList rangeList = {flutter::EncodableValue(range)};
-    flutter::EncodableMap result = {
-        {flutter::EncodableValue("event"),
-         flutter::EncodableValue("bufferingUpdate")},
-        {flutter::EncodableValue("values"),
-         flutter::EncodableValue(rangeList)}};
-    event_sink_->Success(flutter::EncodableValue(result));
-  }
-}
-
-void VideoPlayer::SendBufferingEnd() {
-  if (event_sink_) {
-    flutter::EncodableMap result = {{flutter::EncodableValue("event"),
-                                     flutter::EncodableValue("bufferingEnd")}};
-    event_sink_->Success(flutter::EncodableValue(result));
-  }
-}
-
 void VideoPlayer::OnPrepared(void *data) {
   VideoPlayer *player = reinterpret_cast<VideoPlayer *>(data);
   LOG_DEBUG("[VideoPlayer] player prepared");

--- a/packages/video_player/tizen/src/video_player.h
+++ b/packages/video_player/tizen/src/video_player.h
@@ -38,9 +38,6 @@ class VideoPlayer {
   void Initialize();
   void SetupEventChannel(flutter::BinaryMessenger *messenger);
   void SendInitialized();
-  void SendBufferingStart();
-  void SendBufferingUpdate(int position);  // milliseconds
-  void SendBufferingEnd();
   FlutterDesktopGpuBuffer *ObtainGpuBuffer(size_t width, size_t height);
   static void ReleaseMediaPacket(void *packet);
 

--- a/packages/video_player/tizen/src/video_player.h
+++ b/packages/video_player/tizen/src/video_player.h
@@ -36,7 +36,7 @@ class VideoPlayer {
 
  private:
   void Initialize();
-  void SetupEventChannel(flutter::BinaryMessenger *messenger);
+  void SetUpEventChannel(flutter::BinaryMessenger *messenger);
   void SendInitialized();
   FlutterDesktopGpuBuffer *ObtainGpuBuffer(size_t width, size_t height);
   static void ReleaseMediaPacket(void *packet);

--- a/packages/video_player/tizen/src/video_player.h
+++ b/packages/video_player/tizen/src/video_player.h
@@ -13,43 +13,43 @@
 
 #include "video_player_options.h"
 
-using SeekCompletedCallback = std::function<void()>;
-
 class VideoPlayer {
  public:
+  using SeekCompletedCallback = std::function<void()>;
+
   VideoPlayer(flutter::PluginRegistrar *plugin_registrar,
               flutter::TextureRegistrar *texture_registrar,
               const std::string &uri, VideoPlayerOptions &options);
   ~VideoPlayer();
 
-  int64_t getTextureId();
-  void play();
-  void pause();
-  void setLooping(bool is_looping);
-  void setVolume(double volume);
-  void setPlaybackSpeed(double speed);
-  void seekTo(int position,  // milliseconds
+  int64_t GetTextureId();
+  void Play();
+  void Pause();
+  void SetLooping(bool is_looping);
+  void SetVolume(double volume);
+  void SetPlaybackSpeed(double speed);
+  void SeekTo(int position,  // milliseconds
               const SeekCompletedCallback &seek_completed_cb);
-  int getPosition();  // milliseconds
-  void dispose();
+  int GetPosition();  // milliseconds
+  void Dispose();
 
  private:
-  void initialize();
-  void setupEventChannel(flutter::BinaryMessenger *messenger);
-  void sendInitialized();
-  void sendBufferingStart();
-  void sendBufferingUpdate(int position);  // milliseconds
-  void sendBufferingEnd();
+  void Initialize();
+  void SetupEventChannel(flutter::BinaryMessenger *messenger);
+  void SendInitialized();
+  void SendBufferingStart();
+  void SendBufferingUpdate(int position);  // milliseconds
+  void SendBufferingEnd();
   FlutterDesktopGpuBuffer *ObtainGpuBuffer(size_t width, size_t height);
   static void ReleaseMediaPacket(void *packet);
 
-  static void onPrepared(void *data);
-  static void onBuffering(int percent, void *data);
-  static void onSeekCompleted(void *data);
-  static void onPlayCompleted(void *data);
-  static void onInterrupted(player_interrupted_code_e code, void *data);
-  static void onErrorOccurred(int code, void *data);
-  static void onVideoFrameDecoded(media_packet_h packet, void *data);
+  static void OnPrepared(void *data);
+  static void OnBuffering(int percent, void *data);
+  static void OnSeekCompleted(void *data);
+  static void OnPlayCompleted(void *data);
+  static void OnInterrupted(player_interrupted_code_e code, void *data);
+  static void OnErrorOccurred(int code, void *data);
+  static void OnVideoFrameDecoded(media_packet_h packet, void *data);
 
   bool is_initialized_;
   player_h player_;

--- a/packages/video_player/tizen/src/video_player.h
+++ b/packages/video_player/tizen/src/video_player.h
@@ -13,7 +13,7 @@
 
 #include "video_player_options.h"
 
-using SeekCompletedCb = std::function<void()>;
+using SeekCompletedCallback = std::function<void()>;
 
 class VideoPlayer {
  public:
@@ -28,9 +28,9 @@ class VideoPlayer {
   void setLooping(bool is_looping);
   void setVolume(double volume);
   void setPlaybackSpeed(double speed);
-  void seekTo(int position,
-              const SeekCompletedCb &seek_completed_cb);  // milliseconds
-  int getPosition();                                      // milliseconds
+  void seekTo(int position,  // milliseconds
+              const SeekCompletedCallback &seek_completed_cb);
+  int getPosition();  // milliseconds
   void dispose();
 
  private:
@@ -61,7 +61,7 @@ class VideoPlayer {
   std::unique_ptr<flutter::TextureVariant> texture_variant_;
   std::unique_ptr<FlutterDesktopGpuBuffer> flutter_desktop_gpu_buffer_;
   std::mutex mutex_;
-  SeekCompletedCb on_seek_completed_;
+  SeekCompletedCallback on_seek_completed_;
   media_packet_h current_media_packet_ = nullptr;
 };
 

--- a/packages/video_player/tizen/src/video_player.h
+++ b/packages/video_player/tizen/src/video_player.h
@@ -22,7 +22,8 @@ class VideoPlayer {
               const std::string &uri, VideoPlayerOptions &options);
   ~VideoPlayer();
 
-  int64_t GetTextureId();
+  int64_t GetTextureId() { return texture_id_; }
+
   void Play();
   void Pause();
   void SetLooping(bool is_looping);

--- a/packages/video_player/tizen/src/video_player.h
+++ b/packages/video_player/tizen/src/video_player.h
@@ -1,5 +1,5 @@
-#ifndef VIDEO_PLAYER_H_
-#define VIDEO_PLAYER_H_
+#ifndef FLUTTER_PLUGIN_VIDEO_PLAYER_H_
+#define FLUTTER_PLUGIN_VIDEO_PLAYER_H_
 
 #include <flutter/encodable_value.h>
 #include <flutter/event_channel.h>
@@ -65,4 +65,4 @@ class VideoPlayer {
   media_packet_h current_media_packet_ = nullptr;
 };
 
-#endif  // VIDEO_PLAYER_H_
+#endif  // FLUTTER_PLUGIN_VIDEO_PLAYER_H_

--- a/packages/video_player/tizen/src/video_player.h
+++ b/packages/video_player/tizen/src/video_player.h
@@ -22,7 +22,7 @@ class VideoPlayer {
               const std::string &uri, VideoPlayerOptions &options);
   ~VideoPlayer();
 
-  long getTextureId();
+  int64_t getTextureId();
   void play();
   void pause();
   void setLooping(bool is_looping);
@@ -56,7 +56,7 @@ class VideoPlayer {
   std::unique_ptr<flutter::EventChannel<flutter::EncodableValue>>
       event_channel_;
   std::unique_ptr<flutter::EventSink<flutter::EncodableValue>> event_sink_;
-  long texture_id_;
+  int64_t texture_id_;
   flutter::TextureRegistrar *texture_registrar_;
   std::unique_ptr<flutter::TextureVariant> texture_variant_;
   std::unique_ptr<FlutterDesktopGpuBuffer> flutter_desktop_gpu_buffer_;

--- a/packages/video_player/tizen/src/video_player_error.h
+++ b/packages/video_player/tizen/src/video_player_error.h
@@ -1,5 +1,5 @@
-#ifndef VIDEO_PLAYER_ERROR_H_
-#define VIDEO_PLAYER_ERROR_H_
+#ifndef FLUTTER_PLUGIN_VIDEO_PLAYER_ERROR_H_
+#define FLUTTER_PLUGIN_VIDEO_PLAYER_ERROR_H_
 
 #include <string>
 
@@ -27,4 +27,4 @@ class VideoPlayerError {
   std::string message_;
 };
 
-#endif  // VIDEO_PLAYER_ERROR_H_
+#endif  // FLUTTER_PLUGIN_VIDEO_PLAYER_ERROR_H_

--- a/packages/video_player/tizen/src/video_player_options.h
+++ b/packages/video_player/tizen/src/video_player_options.h
@@ -3,17 +3,19 @@
 
 class VideoPlayerOptions {
  public:
-  VideoPlayerOptions() : mixWithOthers_(true) {}
+  VideoPlayerOptions() {}
   ~VideoPlayerOptions() = default;
 
   VideoPlayerOptions(const VideoPlayerOptions &other) = default;
   VideoPlayerOptions &operator=(const VideoPlayerOptions &other) = default;
 
-  void setMixWithOthers(bool mixWithOthers) { mixWithOthers_ = mixWithOthers; }
-  bool getMixWithOthers() const { return mixWithOthers_; }
+  void setMixWithOthers(bool mix_with_others) {
+    mix_with_others_ = mix_with_others;
+  }
+  bool getMixWithOthers() const { return mix_with_others_; }
 
  private:
-  bool mixWithOthers_;
+  bool mix_with_others_ = true;
 };
 
 #endif  // FLUTTER_PLUGIN_VIDEO_PLAYER_OPTIONS_H_

--- a/packages/video_player/tizen/src/video_player_options.h
+++ b/packages/video_player/tizen/src/video_player_options.h
@@ -1,5 +1,5 @@
-#ifndef VIDEO_PLAYER_OPTIONS_H_
-#define VIDEO_PLAYER_OPTIONS_H_
+#ifndef FLUTTER_PLUGIN_VIDEO_PLAYER_OPTIONS_H_
+#define FLUTTER_PLUGIN_VIDEO_PLAYER_OPTIONS_H_
 
 class VideoPlayerOptions {
  public:
@@ -16,4 +16,4 @@ class VideoPlayerOptions {
   bool mixWithOthers_;
 };
 
-#endif  // VIDEO_PLAYER_OPTIONS_H_
+#endif  // FLUTTER_PLUGIN_VIDEO_PLAYER_OPTIONS_H_

--- a/packages/video_player/tizen/src/video_player_tizen_plugin.cc
+++ b/packages/video_player/tizen/src/video_player_tizen_plugin.cc
@@ -172,7 +172,7 @@ void VideoPlayerTizenPlugin::play(const TextureMessage &textureMsg) {
 
   auto iter = players_.find(textureMsg.getTextureId());
   if (iter != players_.end()) {
-    iter->second->play();
+    iter->second->Play();
   }
 }
 
@@ -182,7 +182,7 @@ void VideoPlayerTizenPlugin::pause(const TextureMessage &textureMsg) {
 
   auto iter = players_.find(textureMsg.getTextureId());
   if (iter != players_.end()) {
-    iter->second->pause();
+    iter->second->Pause();
   }
 }
 

--- a/packages/video_player/tizen/src/video_player_tizen_plugin.cc
+++ b/packages/video_player/tizen/src/video_player_tizen_plugin.cc
@@ -98,7 +98,6 @@ TextureMessage VideoPlayerTizenPlugin::create(const CreateMessage &createMsg) {
       uri = uri + res_path + "flutter_assets/" + createMsg.getAsset();
       free(res_path);
     } else {
-      LOG_ERROR("[VideoPlayerTizenPlugin] Failed to get app resource path.");
       throw VideoPlayerError("Internal error", "Failed to get resource path.");
     }
   }

--- a/packages/video_player/tizen/src/video_player_tizen_plugin.cc
+++ b/packages/video_player/tizen/src/video_player_tizen_plugin.cc
@@ -37,7 +37,7 @@ class VideoPlayerTizenPlugin : public flutter::Plugin, public VideoPlayerApi {
   virtual void pause(const TextureMessage &textureMsg) override;
   virtual PositionMessage position(const TextureMessage &textureMsg) override;
   virtual void seekTo(const PositionMessage &positionMsg,
-                      const SeekCompletedCb &onSeekCompleted) override;
+                      const SeekCompletedCallback &onSeekCompleted) override;
   virtual void setMixWithOthers(
       const MixWithOthersMessage &mixWithOthersMsg) override;
 
@@ -200,8 +200,9 @@ PositionMessage VideoPlayerTizenPlugin::position(
   return result;
 }
 
-void VideoPlayerTizenPlugin::seekTo(const PositionMessage &positionMsg,
-                                    const SeekCompletedCb &onSeekCompleted) {
+void VideoPlayerTizenPlugin::seekTo(
+    const PositionMessage &positionMsg,
+    const SeekCompletedCallback &onSeekCompleted) {
   LOG_DEBUG("[VideoPlayerTizenPlugin.seekTo] textureId: %ld",
             positionMsg.getTextureId());
   LOG_DEBUG("[VideoPlayerTizenPlugin.seekTo] position: %ld",

--- a/packages/video_player/tizen/src/video_player_tizen_plugin.cc
+++ b/packages/video_player/tizen/src/video_player_tizen_plugin.cc
@@ -67,29 +67,26 @@ VideoPlayerTizenPlugin::VideoPlayerTizenPlugin(
 VideoPlayerTizenPlugin::~VideoPlayerTizenPlugin() { DisposeAllPlayers(); }
 
 void VideoPlayerTizenPlugin::DisposeAllPlayers() {
-  LOG_DEBUG("[VideoPlayerTizenPlugin.DisposeAllPlayers] player count: %d",
-            players_.size());
+  LOG_DEBUG("[VideoPlayerTizenPlugin] player count: %d", players_.size());
 
   for (const auto &[id, player] : players_) {
-    player->dispose();
+    player->Dispose();
   }
   players_.clear();
 }
 
 void VideoPlayerTizenPlugin::initialize() {
-  LOG_DEBUG("[VideoPlayerTizenPlugin.initialize] initialize");
+  LOG_DEBUG("[VideoPlayerTizenPlugin] initialize");
 
   DisposeAllPlayers();
 }
 
 TextureMessage VideoPlayerTizenPlugin::create(const CreateMessage &createMsg) {
-  LOG_DEBUG("[VideoPlayerTizenPlugin.create] asset: %s",
-            createMsg.getAsset().c_str());
-  LOG_DEBUG("[VideoPlayerTizenPlugin.create] uri: %s",
-            createMsg.getUri().c_str());
-  LOG_DEBUG("[VideoPlayerTizenPlugin.create] packageName: %s",
+  LOG_DEBUG("[VideoPlayerTizenPlugin] asset: %s", createMsg.getAsset().c_str());
+  LOG_DEBUG("[VideoPlayerTizenPlugin] uri: %s", createMsg.getUri().c_str());
+  LOG_DEBUG("[VideoPlayerTizenPlugin] packageName: %s",
             createMsg.getPackageName().c_str());
-  LOG_DEBUG("[VideoPlayerTizenPlugin.create] formatHint: %s",
+  LOG_DEBUG("[VideoPlayerTizenPlugin] formatHint: %s",
             createMsg.getFormatHint().c_str());
 
   std::string uri;
@@ -101,16 +98,15 @@ TextureMessage VideoPlayerTizenPlugin::create(const CreateMessage &createMsg) {
       uri = uri + res_path + "flutter_assets/" + createMsg.getAsset();
       free(res_path);
     } else {
-      LOG_DEBUG(
-          "[VideoPlayerTizenPlugin.create] Failed to get app resource path.");
+      LOG_ERROR("[VideoPlayerTizenPlugin] Failed to get app resource path.");
       throw VideoPlayerError("Internal error", "Failed to get resource path.");
     }
   }
-  LOG_DEBUG("[VideoPlayerTizenPlugin.create] player uri: %s", uri.c_str());
+  LOG_DEBUG("[VideoPlayerTizenPlugin] player uri: %s", uri.c_str());
 
   auto player = std::make_unique<VideoPlayer>(
       plugin_registrar_, texture_registrar_, uri, options_);
-  int64_t texture_id = player->getTextureId();
+  int64_t texture_id = player->GetTextureId();
   players_[texture_id] = std::move(player);
 
   TextureMessage result;
@@ -119,55 +115,52 @@ TextureMessage VideoPlayerTizenPlugin::create(const CreateMessage &createMsg) {
 }
 
 void VideoPlayerTizenPlugin::dispose(const TextureMessage &textureMsg) {
-  LOG_DEBUG("[VideoPlayerTizenPlugin.dispose] textureId: %ld",
+  LOG_DEBUG("[VideoPlayerTizenPlugin] textureId: %ld",
             textureMsg.getTextureId());
 
   auto iter = players_.find(textureMsg.getTextureId());
   if (iter != players_.end()) {
-    iter->second->dispose();
+    iter->second->Dispose();
     players_.erase(iter);
   }
 }
 
 void VideoPlayerTizenPlugin::setLooping(const LoopingMessage &loopingMsg) {
-  LOG_DEBUG("[VideoPlayerTizenPlugin.setLooping] textureId: %ld",
+  LOG_DEBUG("[VideoPlayerTizenPlugin] textureId: %ld",
             loopingMsg.getTextureId());
-  LOG_DEBUG("[VideoPlayerTizenPlugin.setLooping] isLooping: %d",
+  LOG_DEBUG("[VideoPlayerTizenPlugin] isLooping: %d",
             loopingMsg.getIsLooping());
 
   auto iter = players_.find(loopingMsg.getTextureId());
   if (iter != players_.end()) {
-    iter->second->setLooping(loopingMsg.getIsLooping());
+    iter->second->SetLooping(loopingMsg.getIsLooping());
   }
 }
 
 void VideoPlayerTizenPlugin::setVolume(const VolumeMessage &volumeMsg) {
-  LOG_DEBUG("[VideoPlayerTizenPlugin.setVolume] textureId: %ld",
+  LOG_DEBUG("[VideoPlayerTizenPlugin] textureId: %ld",
             volumeMsg.getTextureId());
-  LOG_DEBUG("[VideoPlayerTizenPlugin.setVolume] volume: %f",
-            volumeMsg.getVolume());
+  LOG_DEBUG("[VideoPlayerTizenPlugin] volume: %f", volumeMsg.getVolume());
 
   auto iter = players_.find(volumeMsg.getTextureId());
   if (iter != players_.end()) {
-    iter->second->setVolume(volumeMsg.getVolume());
+    iter->second->SetVolume(volumeMsg.getVolume());
   }
 }
 
 void VideoPlayerTizenPlugin::setPlaybackSpeed(
     const PlaybackSpeedMessage &speedMsg) {
-  LOG_DEBUG("[VideoPlayerTizenPlugin.setPlaybackSpeed] textureId: %ld",
-            speedMsg.getTextureId());
-  LOG_DEBUG("[VideoPlayerTizenPlugin.setPlaybackSpeed] speed: %f",
-            speedMsg.getSpeed());
+  LOG_DEBUG("[VideoPlayerTizenPlugin] textureId: %ld", speedMsg.getTextureId());
+  LOG_DEBUG("[VideoPlayerTizenPlugin] speed: %f", speedMsg.getSpeed());
 
   auto iter = players_.find(speedMsg.getTextureId());
   if (iter != players_.end()) {
-    iter->second->setPlaybackSpeed(speedMsg.getSpeed());
+    iter->second->SetPlaybackSpeed(speedMsg.getSpeed());
   }
 }
 
 void VideoPlayerTizenPlugin::play(const TextureMessage &textureMsg) {
-  LOG_DEBUG("[VideoPlayerTizenPlugin.play] textureId: %ld",
+  LOG_DEBUG("[VideoPlayerTizenPlugin] textureId: %ld",
             textureMsg.getTextureId());
 
   auto iter = players_.find(textureMsg.getTextureId());
@@ -177,7 +170,7 @@ void VideoPlayerTizenPlugin::play(const TextureMessage &textureMsg) {
 }
 
 void VideoPlayerTizenPlugin::pause(const TextureMessage &textureMsg) {
-  LOG_DEBUG("[VideoPlayerTizenPlugin.pause] textureId: %ld",
+  LOG_DEBUG("[VideoPlayerTizenPlugin] textureId: %ld",
             textureMsg.getTextureId());
 
   auto iter = players_.find(textureMsg.getTextureId());
@@ -188,14 +181,14 @@ void VideoPlayerTizenPlugin::pause(const TextureMessage &textureMsg) {
 
 PositionMessage VideoPlayerTizenPlugin::position(
     const TextureMessage &textureMsg) {
-  LOG_DEBUG("[VideoPlayerTizenPlugin.position] textureId: %ld",
+  LOG_DEBUG("[VideoPlayerTizenPlugin] textureId: %ld",
             textureMsg.getTextureId());
 
   PositionMessage result;
   auto iter = players_.find(textureMsg.getTextureId());
   if (iter != players_.end()) {
     result.setTextureId(textureMsg.getTextureId());
-    result.setPosition(iter->second->getPosition());
+    result.setPosition(iter->second->GetPosition());
   }
   return result;
 }
@@ -203,20 +196,20 @@ PositionMessage VideoPlayerTizenPlugin::position(
 void VideoPlayerTizenPlugin::seekTo(
     const PositionMessage &positionMsg,
     const SeekCompletedCallback &onSeekCompleted) {
-  LOG_DEBUG("[VideoPlayerTizenPlugin.seekTo] textureId: %ld",
+  LOG_DEBUG("[VideoPlayerTizenPlugin] textureId: %ld",
             positionMsg.getTextureId());
-  LOG_DEBUG("[VideoPlayerTizenPlugin.seekTo] position: %ld",
+  LOG_DEBUG("[VideoPlayerTizenPlugin] position: %ld",
             positionMsg.getPosition());
 
   auto iter = players_.find(positionMsg.getTextureId());
   if (iter != players_.end()) {
-    iter->second->seekTo(positionMsg.getPosition(), onSeekCompleted);
+    iter->second->SeekTo(positionMsg.getPosition(), onSeekCompleted);
   }
 }
 
 void VideoPlayerTizenPlugin::setMixWithOthers(
     const MixWithOthersMessage &mixWithOthersMsg) {
-  LOG_DEBUG("[VideoPlayerTizenPlugin.setMixWithOthers] mixWithOthers: %d",
+  LOG_DEBUG("[VideoPlayerTizenPlugin] mixWithOthers: %d",
             mixWithOthersMsg.getMixWithOthers());
 
   options_.setMixWithOthers(mixWithOthersMsg.getMixWithOthers());

--- a/packages/video_player/tizen/src/video_player_tizen_plugin.cc
+++ b/packages/video_player/tizen/src/video_player_tizen_plugin.cc
@@ -61,7 +61,7 @@ VideoPlayerTizenPlugin::VideoPlayerTizenPlugin(
     : plugin_registrar_(registrar) {
   texture_registrar_ = registrar->texture_registrar();
 
-  VideoPlayerApi::setup(registrar->messenger(), this);
+  VideoPlayerApi::SetUp(registrar->messenger(), this);
 }
 
 VideoPlayerTizenPlugin::~VideoPlayerTizenPlugin() { DisposeAllPlayers(); }

--- a/packages/video_player/tizen/src/video_player_tizen_plugin.cc
+++ b/packages/video_player/tizen/src/video_player_tizen_plugin.cc
@@ -47,7 +47,7 @@ class VideoPlayerTizenPlugin : public flutter::Plugin, public VideoPlayerApi {
   flutter::PluginRegistrar *plugin_registrar_;
   flutter::TextureRegistrar *texture_registrar_;
   VideoPlayerOptions options_;
-  std::map<long, std::unique_ptr<VideoPlayer>> players_;
+  std::map<int64_t, std::unique_ptr<VideoPlayer>> players_;
 };
 
 void VideoPlayerTizenPlugin::RegisterWithRegistrar(
@@ -110,7 +110,7 @@ TextureMessage VideoPlayerTizenPlugin::create(const CreateMessage &createMsg) {
 
   auto player = std::make_unique<VideoPlayer>(
       plugin_registrar_, texture_registrar_, uri, options_);
-  long texture_id = player->getTextureId();
+  int64_t texture_id = player->getTextureId();
   players_[texture_id] = std::move(player);
 
   TextureMessage result;


### PR DESCRIPTION
Just some style fixes. Please see the commit history for details.

- Apply naming rules. See the below note for the exceptions.
- Use a fixed-width integer type `int64_t` instead of `long`.
- Remove unnecessary logs. See the below note for details.
- Remove unused buffering-related callbacks.

Notes:
- The types and methods in `message.h` are expected to be auto-generated from [the common interface definition](https://github.com/flutter/plugins/blob/main/packages/video_player/video_player_android/pigeons/messages.dart) and thus do not follow the language-specific naming convention.
- Not all debug logs have been removed because they can be useful for later debugging. I removed only redundant logs that do not carry extra information.
- This plugin does not follow the error code format in https://github.com/flutter-tizen/plugins/issues/354, because providing the failed API name helps identifying the underlying issue quickly.

Contributes to https://github.com/flutter-tizen/plugins/issues/354.