### PR TITLE
Precache tizen artifacts before test runs

### DIFF
--- a/tools/lib/src/integration_test_command.dart
+++ b/tools/lib/src/integration_test_command.dart
@@ -132,6 +132,15 @@ class IntegrationTestCommand extends PackageLoopingCommand {
         throw ToolExit(exitCommandFoundErrors);
       }
     }
+
+    final io.ProcessResult processResult = await processRunner.run(
+      'flutter-tizen',
+      <String>['precache', '--tizen'],
+    );
+    if (processResult.exitCode != 0) {
+      print('Cannot cache tizen artifacts used for integration-test.');
+      throw ToolExit(exitCommandFoundErrors);
+    }
   }
 
   /// See: [PluginCommand.getTargetPackages].


### PR DESCRIPTION
This PR runs the `flutter-tizen precache --tizen` command before the actual integration-test step so that artifact fetching time doesn't drain out the timeout limit of tests.