### PR TITLE
[permission_handler] Refactor the C++ code

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,10 +60,10 @@ The _"non-endorsed"_ status means that the plugin is not endorsed by the origina
 | [**image_picker_tizen**](packages/image_picker) | ⚠️ | ❌ | ❌ | ❌ | No camera<br>No file manager app |
 | [**integration_test_tizen**](packages/integration_test) | ✔️ | ✔️ | ✔️ | ✔️ |
 | [**messageport_tizen**](packages/messageport) | ✔️ | ✔️ | ✔️ | ✔️ |
-| [**network_info_plus_tizen**](packages/network_info_plus) | ✔️ | ❌ | ✔️ | ❌ | API unsupported by emulators |
+| [**network_info_plus_tizen**](packages/network_info_plus) | ✔️ | ❌ | ✔️ | ❌ | API not supported on emulator |
 | [**package_info_plus_tizen**](packages/package_info_plus) | ✔️ | ✔️ | ✔️ | ✔️ |
-| [**path_provider_tizen**](packages/path_provider) | ⚠️ | ⚠️ | ⚠️ | ⚠️ | No external storage |
-| [**permission_handler_tizen**](packages/permission_handler) | ✔️ | ✔️ | ❌ | ❌ | Not applicable for TV |
+| [**path_provider_tizen**](packages/path_provider) | ✔️ | ✔️ | ✔️ | ✔️ |
+| [**permission_handler_tizen**](packages/permission_handler) | ✔️ | ✔️ | ⚠️ | ⚠️ | Not applicable for TV |
 | [**sensors_plus_tizen**](packages/sensors_plus) | ✔️ | ✔️ | ❌ | ❌ | No sensor hardware |
 | [**share_plus_tizen**](packages/share_plus) | ⚠️ | ⚠️ | ❌ | ❌ | No SMS or e-mail app |
 | [**shared_preferences_tizen**](packages/shared_preferences) | ✔️ | ✔️ | ✔️ | ✔️ |

--- a/packages/permission_handler/CHANGELOG.md
+++ b/packages/permission_handler/CHANGELOG.md
@@ -1,3 +1,7 @@
+## NEXT
+
+* Code refactoring.
+
 ## 1.2.0
 
 * Update permission_handler to 8.3.0.

--- a/packages/permission_handler/tizen/src/app_settings_manager.h
+++ b/packages/permission_handler/tizen/src/app_settings_manager.h
@@ -1,24 +1,16 @@
-#ifndef APP_SETTINGS_MANAGER_H_
-#define APP_SETTINGS_MANAGER_H_
+// Copyright 2021 Samsung Electronics Co., Ltd. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
 
-#include <functional>
-#include <memory>
-#include <string>
-
-namespace {
-class AppPermissions;
-}
+#ifndef FLUTTER_PLUGIN_APP_SETTINGS_MANAGER_H_
+#define FLUTTER_PLUGIN_APP_SETTINGS_MANAGER_H_
 
 class AppSettingsManager {
  public:
-  AppSettingsManager();
-  ~AppSettingsManager();
+  AppSettingsManager() {}
+  ~AppSettingsManager() {}
 
   bool OpenAppSettings();
-
- private:
-  std::unique_ptr<AppPermissions> app_permissions_;
-  std::string package_name_;
 };
 
-#endif  // APP_SETTINGS_MANAGER_H_
+#endif  // FLUTTER_PLUGIN_APP_SETTINGS_MANAGER_H_

--- a/packages/permission_handler/tizen/src/permission_manager.cc
+++ b/packages/permission_handler/tizen/src/permission_manager.cc
@@ -1,297 +1,86 @@
+// Copyright 2022 Samsung Electronics Co., Ltd. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
 #include "permission_manager.h"
 
+#ifndef TV_PROFILE
 #include <Ecore.h>
+#include <privacy_privilege_manager.h>
+#include <tizen.h>
+#endif
 
 #include "log.h"
-#include "type.h"
 
-namespace {
+PermissionStatus PermissionManager::CheckPermission(
+    const std::string &privilege) {
+#ifdef TV_PROFILE
+  return PermissionStatus::kGranted;
+#else
+  ppm_check_result_e result;
+  int ret = ppm_check_permission(privilege.c_str(), &result);
+  if (ret != PRIVACY_PRIVILEGE_MANAGER_ERROR_NONE) {
+    LOG_ERROR("Permission check failed [%s]: %s", privilege.c_str(),
+              get_error_message(ret));
+    return PermissionStatus::kError;
+  }
 
-constexpr char kPrivilegeCalendarRead[] =
-    "http://tizen.org/privilege/calendar.read";
-constexpr char kPrivilegeCalendarWrite[] =
-    "http://tizen.org/privilege/calendar.write";
-constexpr char kPrivilegeCamera[] = "http://tizen.org/privilege/camera";
-constexpr char kPrivilegeContactRead[] =
-    "http://tizen.org/privilege/contact.read";
-constexpr char kPrivilegeContactWrite[] =
-    "http://tizen.org/privilege/contact.write";
-constexpr char kPrivilegeLocation[] = "http://tizen.org/privilege/location";
-constexpr char kPrivilegeLocationCoarse[] =
-    "http://tizen.org/privilege/location.coarse";
-constexpr char kPrivilegeRecorder[] = "http://tizen.org/privilege/recorder";
-constexpr char kPrivilegeCall[] = "http://tizen.org/privilege/call";
-constexpr char kPrivilegeSensors[] = "http://tizen.org/privilege/healthinfo";
-constexpr char kPrivilegeMessageRead[] =
-    "http://tizen.org/privilege/message.read";
-constexpr char kPrivilegeMessageWrite[] =
-    "http://tizen.org/privilege/message.write";
-constexpr char kPrivilegeExternalStorage[] =
-    "http://tizen.org/privilege/externalstorage";
-constexpr char kPrivilegeMediaStorage[] =
-    "http://tizen.org/privilege/mediastorage";
-
-struct Param {
-  PermissionManager* manager{nullptr};
-  bool is_done{false};
-  size_t remaining_request{0};
-};
-
-std::string CheckResultToString(int result) {
   switch (result) {
     case PRIVACY_PRIVILEGE_MANAGER_CHECK_RESULT_ALLOW:
-      return "CHECK_RESULT_ALLOW";
-    case PRIVACY_PRIVILEGE_MANAGER_CHECK_RESULT_DENY:
-      return "CHECK_RESULT_DENY";
+      return PermissionStatus::kGranted;
     case PRIVACY_PRIVILEGE_MANAGER_CHECK_RESULT_ASK:
-      return "CHECK_RESULT_ASK";
+    case PRIVACY_PRIVILEGE_MANAGER_CHECK_RESULT_DENY:
     default:
-      return "CHECK_RESULT_UNKNOWN";
+      return PermissionStatus::kDenied;
   }
+#endif
 }
 
-bool ConvertToPermission(const std::string& privilege,
-                         PermissionGroup* permission) {
-  if (privilege == kPrivilegeCalendarRead ||
-      privilege == kPrivilegeCalendarWrite) {
-    *permission = PermissionGroup::kCalendar;
-  } else if (privilege == kPrivilegeCamera) {
-    *permission = PermissionGroup::kCamera;
-  } else if (privilege == kPrivilegeContactRead ||
-             privilege == kPrivilegeContactWrite) {
-    *permission = PermissionGroup::kContacts;
-  } else if (privilege == kPrivilegeLocation ||
-             privilege == kPrivilegeLocationCoarse) {
-    *permission = PermissionGroup::kLocation;
-  } else if (privilege == kPrivilegeRecorder) {
-    *permission = PermissionGroup::kMicrophone;
-  } else if (privilege == kPrivilegeCall) {
-    *permission = PermissionGroup::kPhone;
-  } else if (privilege == kPrivilegeSensors) {
-    *permission = PermissionGroup::kSensors;
-  } else if (privilege == kPrivilegeMessageRead ||
-             privilege == kPrivilegeMessageWrite) {
-    *permission = PermissionGroup::kSMS;
-  } else if (privilege == kPrivilegeExternalStorage) {
-    *permission = PermissionGroup::kStorage;
-  } else if (privilege == kPrivilegeMediaStorage) {
-    *permission = PermissionGroup::kMediaLibrary;
-  } else {
-    LOG_WARN("Unknown Privilege!");
-    return false;
-  }
-  return true;
-}
+PermissionStatus PermissionManager::RequestPermssion(
+    const std::string &privilege) {
+#ifdef TV_PROFILE
+  return PermissionStatus::kGranted;
+#else
+  struct Response {
+    bool received = false;
+    ppm_call_cause_e cause;
+    ppm_request_result_e result;
+  } response;
 
-bool ConvertToPrivileges(PermissionGroup permission,
-                         std::vector<const char*>* privileges) {
-  switch (permission) {
-    case PermissionGroup::kCalendar:
-      privileges->push_back(kPrivilegeCalendarRead);
-      break;
-    case PermissionGroup::kCamera:
-      privileges->push_back(kPrivilegeCamera);
-      break;
-    case PermissionGroup::kContacts:
-      privileges->push_back(kPrivilegeContactRead);
-      break;
-    case PermissionGroup::kLocation:
-    case PermissionGroup::kLocationAlways:
-    case PermissionGroup::kLocationWhenInUse:
-      privileges->push_back(kPrivilegeLocation);
-      break;
-    case PermissionGroup::kMicrophone:
-      privileges->push_back(kPrivilegeRecorder);
-      break;
-    case PermissionGroup::kPhone:
-      privileges->push_back(kPrivilegeCall);
-      break;
-    case PermissionGroup::kSensors:
-      privileges->push_back(kPrivilegeSensors);
-      break;
-    case PermissionGroup::kSMS:
-      privileges->push_back(kPrivilegeMessageRead);
-      break;
-    case PermissionGroup::kStorage:
-      privileges->push_back(kPrivilegeExternalStorage);
-      break;
-    case PermissionGroup::kMediaLibrary:
-      privileges->push_back(kPrivilegeMediaStorage);
-      break;
+  int ret = ppm_request_permission(
+      privilege.c_str(),
+      [](ppm_call_cause_e cause, ppm_request_result_e result,
+         const char *privilege, void *user_data) {
+        auto *response = static_cast<Response *>(user_data);
+        response->received = true;
+        response->cause = cause;
+        response->result = result;
+      },
+      &response);
+  if (ret != PRIVACY_PRIVILEGE_MANAGER_ERROR_NONE) {
+    LOG_ERROR("Permission request failed [%s]: %s", privilege.c_str(),
+              get_error_message(ret));
+    return PermissionStatus::kError;
+  }
+
+  // Wait until ppm_request_permission() completes with a response.
+  while (!response.received) {
+    ecore_main_loop_iterate();
+  }
+
+  if (response.cause == PRIVACY_PRIVILEGE_MANAGER_CALL_CAUSE_ERROR) {
+    LOG_ERROR("Received an error response [%s].", privilege.c_str());
+    return PermissionStatus::kError;
+  }
+
+  switch (response.result) {
+    case PRIVACY_PRIVILEGE_MANAGER_REQUEST_RESULT_ALLOW_FOREVER:
+      return PermissionStatus::kGranted;
+    case PRIVACY_PRIVILEGE_MANAGER_REQUEST_RESULT_DENY_FOREVER:
+      return PermissionStatus::kPermanentlyDenied;
+    case PRIVACY_PRIVILEGE_MANAGER_REQUEST_RESULT_DENY_ONCE:
     default:
-      LOG_WARN("Unknown Permission!");
-      return false;
+      return PermissionStatus::kDenied;
   }
-  return true;
-}
-
-int DeterminePermissionStatus(PermissionGroup permission,
-                              PermissionStatus* status) {
-  std::vector<const char*> privileges;
-  ConvertToPrivileges(permission, &privileges);
-
-  if (privileges.size() == 0) {
-    LOG_DEBUG("No tizen specific privileges needed for permission %d",
-              permission);
-    *status = PermissionStatus::kGranted;
-    return PRIVACY_PRIVILEGE_MANAGER_ERROR_NONE;
-  }
-
-  int result;
-  ppm_check_result_e check_result;
-  for (auto iter : privileges) {
-    result = ppm_check_permission(iter, &check_result);
-    if (result != PRIVACY_PRIVILEGE_MANAGER_ERROR_NONE) {
-      LOG_ERROR("ppm_check_permission (%s) error: %s", iter,
-                get_error_message(result));
-      return result;
-    } else {
-      LOG_DEBUG("ppm_check_permission (%s) result: %s", iter,
-                CheckResultToString(check_result).c_str());
-      switch (check_result) {
-        case PRIVACY_PRIVILEGE_MANAGER_CHECK_RESULT_DENY:
-        case PRIVACY_PRIVILEGE_MANAGER_CHECK_RESULT_ASK:
-          *status = PermissionStatus::kDenied;
-          return result;
-        case PRIVACY_PRIVILEGE_MANAGER_CHECK_RESULT_ALLOW:
-        default:
-          *status = PermissionStatus::kGranted;
-          break;
-      }
-    }
-  }
-  return result;
-}
-
-void OnRequestPermissionResponse(ppm_call_cause_e cause,
-                                 ppm_request_result_e result,
-                                 const char* privilege, void* data) {
-  Param* param = (Param*)data;
-  PermissionManager* manager = param->manager;
-  PermissionGroup permission;
-
-  if (cause != PRIVACY_PRIVILEGE_MANAGER_CALL_CAUSE_ANSWER ||
-      !ConvertToPermission(privilege, &permission)) {
-    // abandon a request
-    LOG_ERROR("Privilege[%s] request failed with an error", privilege);
-    param->is_done = true;
-    return;
-  }
-
-  if (manager->RequestResults().count(permission) == 0) {
-    switch (result) {
-      case PRIVACY_PRIVILEGE_MANAGER_REQUEST_RESULT_ALLOW_FOREVER:
-        manager->RequestResults()[permission] = PermissionStatus::kGranted;
-        break;
-      case PRIVACY_PRIVILEGE_MANAGER_REQUEST_RESULT_DENY_ONCE:
-        manager->RequestResults()[permission] = PermissionStatus::kDenied;
-        break;
-      case PRIVACY_PRIVILEGE_MANAGER_REQUEST_RESULT_DENY_FOREVER:
-        manager->RequestResults()[permission] =
-            PermissionStatus::kPermanentlyDenied;
-        break;
-    }
-  }
-  LOG_DEBUG("permission %d status: %d", permission,
-            manager->RequestResults()[permission]);
-  auto location = manager->RequestResults().find(PermissionGroup::kLocation);
-  if (location != manager->RequestResults().end()) {
-    manager->RequestResults()[PermissionGroup::kLocationAlways] =
-        location->second;
-    manager->RequestResults()[PermissionGroup::kLocationWhenInUse] =
-        location->second;
-  }
-
-  param->remaining_request--;
-  param->is_done = true;
-}
-
-}  // namespace
-
-PermissionManager::PermissionManager() : on_going_(false) {}
-
-PermissionManager::~PermissionManager() {}
-
-void PermissionManager::CheckPermissionStatus(
-    PermissionGroup permission, OnPermissionChecked success_callback,
-    OnPermissionError error_callback) {
-  LOG_DEBUG("Check permission %d status", permission);
-
-  PermissionStatus status;
-  int result = DeterminePermissionStatus(permission, &status);
-  if (result != PRIVACY_PRIVILEGE_MANAGER_ERROR_NONE) {
-    error_callback(get_error_message(result),
-                   "An error occurred when call ppm_check_permission()");
-  } else {
-    success_callback(status);
-  }
-}
-
-void PermissionManager::RequestPermissions(
-    std::vector<PermissionGroup> permissions,
-    OnPermissionRequested success_callback, OnPermissionError error_callback) {
-  if (on_going_) {
-    error_callback("RequestPermissions - error",
-                   "A request for permissions is already running");
-    return;
-  }
-  int result;
-  PermissionStatus status;
-  request_results_.clear();
-  std::vector<const char*> permissions_to_request;
-  for (auto permission : permissions) {
-    result = DeterminePermissionStatus(permission, &status);
-    if (result != PRIVACY_PRIVILEGE_MANAGER_ERROR_NONE) {
-      error_callback(get_error_message(result),
-                     "An error occurred when call ppm_check_permission()");
-      return;
-    }
-
-    if (status == PermissionStatus::kGranted) {
-      if (request_results_.find(permission) == request_results_.end()) {
-        LOG_DEBUG("Request permission %d result: kGranted", permission);
-        request_results_[permission] = PermissionStatus::kGranted;
-      }
-      continue;
-    }
-
-    ConvertToPrivileges(permission, &permissions_to_request);
-  }
-
-  // no permission is needed to requested
-  if (permissions_to_request.size() == 0) {
-    success_callback(request_results_);
-    return;
-  }
-
-  on_going_ = true;
-
-  Param p;
-  p.manager = this;
-  p.remaining_request = permissions_to_request.size();
-
-  for (size_t i = 0; i < permissions_to_request.size(); i++) {
-    const char* permission = permissions_to_request[i];
-    p.is_done = false;
-    result =
-        ppm_request_permission(permission, OnRequestPermissionResponse, &p);
-
-    if (result != PRIVACY_PRIVILEGE_MANAGER_ERROR_NONE) {
-      LOG_ERROR("Failed to call ppm_request_permission with [%s]", permission);
-      continue;
-    }
-
-    // Wait until ppm_request_permission is done;
-    while (!p.is_done) {
-      ecore_main_loop_iterate();
-    }
-  }
-
-  if (p.remaining_request) {
-    error_callback(get_error_message(result),
-                   "some error occurred when call ppm_request_permission");
-  } else {
-    success_callback(request_results_);
-  }
-  on_going_ = false;
+#endif  // TV_PROFILE
 }

--- a/packages/permission_handler/tizen/src/permission_manager.h
+++ b/packages/permission_handler/tizen/src/permission_manager.h
@@ -1,39 +1,33 @@
-#ifndef PERMISSION_MANAGER_H_
-#define PERMISSION_MANAGER_H_
+// Copyright 2022 Samsung Electronics Co., Ltd. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
 
-#include <privacy_privilege_manager.h>
+#ifndef FLUTTER_PLUGIN_PERMISSION_MANAGER_H_
+#define FLUTTER_PLUGIN_PERMISSION_MANAGER_H_
 
-#include <functional>
-#include <map>
-#include <memory>
-#include <vector>
+#include <string>
 
-#include "type.h"
-
-using OnPermissionChecked = std::function<void(PermissionStatus status)>;
-using OnPermissionRequested = std::function<void(
-    const std::map<PermissionGroup, PermissionStatus> &results)>;
-using OnPermissionError =
-    std::function<void(const std::string &code, const std::string &message)>;
+// The result of permission check and request.
+//
+// Originally defined in permission_status.dart of the platform interface
+// package.
+enum class PermissionStatus {
+  kDenied = 0,
+  kGranted = 1,
+  kRestricted = 2,
+  kLimited = 3,
+  kPermanentlyDenied = 4,
+  kError = 5,
+};
 
 class PermissionManager {
  public:
-  PermissionManager();
-  ~PermissionManager();
+  PermissionManager() {}
+  ~PermissionManager() {}
 
-  void CheckPermissionStatus(PermissionGroup permission,
-                             OnPermissionChecked success_callback,
-                             OnPermissionError error_callback);
-  void RequestPermissions(std::vector<PermissionGroup> permissions,
-                          OnPermissionRequested success_callback,
-                          OnPermissionError error_callback);
-  inline std::map<PermissionGroup, PermissionStatus> &RequestResults() {
-    return request_results_;
-  }
+  PermissionStatus CheckPermission(const std::string &privilege);
 
- private:
-  bool on_going_;
-  std::map<PermissionGroup, PermissionStatus> request_results_;
+  PermissionStatus RequestPermssion(const std::string &privilege);
 };
 
-#endif  // PERMISSION_MANAGER_H_
+#endif  // FLUTTER_PLUGIN_PERMISSION_MANAGER_H_

--- a/packages/permission_handler/tizen/src/permissions.h
+++ b/packages/permission_handler/tizen/src/permissions.h
@@ -1,9 +1,14 @@
-#ifndef PERMISSION_HANDLER_TYPE_H_
-#define PERMISSION_HANDLER_TYPE_H_
+// Copyright 2021 Samsung Electronics Co., Ltd. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
 
-// Keep in sync with the values defined in:
-// https://github.com/Baseflow/flutter-permission-handler/blob/master/permission_handler_platform_interface/lib/src/permissions.dart
-enum class PermissionGroup {
+#ifndef FLUTTER_PLUGIN_PERMISSIONS_H_
+#define FLUTTER_PLUGIN_PERMISSIONS_H_
+
+// Permissions that can be checked and requested.
+//
+// Originally defined in permissions.dart of the platform interface package.
+enum class Permission {
   kCalendar = 0,
   kCamera = 1,
   kContacts = 2,
@@ -37,16 +42,4 @@ enum class PermissionGroup {
   kBluetoothConnect = 30
 };
 
-// permission status
-enum class PermissionStatus {
-  kDenied = 0,
-  kGranted,
-  kRestricted,
-  kLimited,
-  kPermanentlyDenied
-};
-
-// service status
-enum class ServiceStatus { kDisabled = 0, kEnabled, kNotApplicable };
-
-#endif  // PERMISSION_HANDLER_TYPE_H_
+#endif  // FLUTTER_PLUGIN_PERMISSIONS_H_

--- a/packages/permission_handler/tizen/src/service_manager.cc
+++ b/packages/permission_handler/tizen/src/service_manager.cc
@@ -1,20 +1,15 @@
+// Copyright 2021 Samsung Electronics Co., Ltd. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
 #include "service_manager.h"
 
 #include <locations.h>
 
-#include "log.h"
-#include "type.h"
-
-ServiceManager::ServiceManager() {}
-
-ServiceManager::~ServiceManager() {}
-
-void ServiceManager::CheckServiceStatus(PermissionGroup permission,
-                                        OnServiceChecked success_callback,
-                                        OnServiceError error_callback) {
-  if (permission == PermissionGroup::kLocation ||
-      permission == PermissionGroup::kLocationAlways ||
-      permission == PermissionGroup::kLocationWhenInUse) {
+ServiceStatus ServiceManager::CheckServiceStatus(Permission permission) {
+  if (permission == Permission::kLocation ||
+      permission == Permission::kLocationAlways ||
+      permission == Permission::kLocationWhenInUse) {
     bool gps_enabled, wps_enabled;
     if (location_manager_is_enabled_method(
             LOCATIONS_METHOD_GPS, &gps_enabled) != LOCATIONS_ERROR_NONE) {
@@ -26,12 +21,10 @@ void ServiceManager::CheckServiceStatus(PermissionGroup permission,
     }
 
     if (gps_enabled || wps_enabled) {
-      success_callback(ServiceStatus::kEnabled);
+      return ServiceStatus::kEnabled;
     } else {
-      success_callback(ServiceStatus::kDisabled);
+      return ServiceStatus::kDisabled;
     }
-    return;
   }
-
-  success_callback(ServiceStatus::kNotApplicable);
+  return ServiceStatus::kNotApplicable;
 }

--- a/packages/permission_handler/tizen/src/service_manager.h
+++ b/packages/permission_handler/tizen/src/service_manager.h
@@ -1,23 +1,27 @@
-#ifndef SERVICE_MANAGER_H_
-#define SERVICE_MANAGER_H_
+// Copyright 2021 Samsung Electronics Co., Ltd. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
 
-#include <functional>
-#include <memory>
+#ifndef FLUTTER_PLUGIN_SERVICE_MANAGER_H_
+#define FLUTTER_PLUGIN_SERVICE_MANAGER_H_
 
-#include "type.h"
+#include "permissions.h"
 
-using OnServiceChecked = std::function<void(ServiceStatus status)>;
-using OnServiceError =
-    std::function<void(const std::string &code, const std::string &message)>;
+// The status of a service associated with a specific permission.
+//
+// Originally defined in service_status.dart of the platform interface pacakge.
+enum class ServiceStatus {
+  kDisabled = 0,
+  kEnabled = 1,
+  kNotApplicable = 2,
+};
 
 class ServiceManager {
  public:
-  ServiceManager();
-  ~ServiceManager();
+  ServiceManager() {}
+  ~ServiceManager() {}
 
-  void CheckServiceStatus(PermissionGroup permission,
-                          OnServiceChecked success_callback,
-                          OnServiceError error_callback);
+  ServiceStatus CheckServiceStatus(Permission permission);
 };
 
-#endif  // SERVICE_MANAGER_H_
+#endif  // FLUTTER_PLUGIN_SERVICE_MANAGER_H_


### PR DESCRIPTION
Part of [the code refactoring project](https://github.com/flutter-tizen/plugins/issues/354).

`app_settings_manager.cc`:
- Remove the `AppPermissions` class and move its logic to `AppSettingsManager::OpenAppSettings`. The class has been first introduced in #142, but adds unnecessary complexity to the code.
- Replace the `PackageName` class with a simple function `GetPackageName`.

`permission_handler_tizen_plugin.cc` & `permission_manager.cc`:
- The code has almost been rewritten from scratch (reduced 200~ lines of code).
- The `PermissionManager` class is a copy of image_picker_tizen's `PermissionManager`. (See https://github.com/flutter-tizen/plugins/pull/353.)
  - The only difference is that `PermissionStatus` and `PermissionResult` are now a single type, in accordance with the type defined in the [platform interface package](https://github.com/Baseflow/flutter-permission-handler/blob/master/permission_handler_platform_interface/lib/src/permission_status.dart).
- Rename `PermissionGroup` to `Permission`.
- Remove all `on_success` and `on_error` callbacks as everything is now done synchronously.
- Iterating over requested permissions is done inside `HandleMethodCall`'s if-else block.
- Do not redundantly check for the permission status before requesting it.
- Remove [duplication](https://github.com/flutter-tizen/plugins/blob/dd5d56ac7449dc994b66b32ed3f4fc5b0e5af1cd/packages/permission_handler/tizen/src/permission_manager.cc#L197-L203) of `kLocation` results as it's not expected by anybody.

`service_manager.cc`:
- Make `ServiceManager::CheckServiceStatus` synchronous.