### PR TITLE
Update Tizen Studio to 4.6

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,36 +21,11 @@ jobs:
               echo $CHANGED_PACKAGES
               echo "HAS_CHANGED_PACKAGES=true" >> $GITHUB_ENV
           fi
-      - name: Install prerequisite packages
-        if: ${{ env.HAS_CHANGED_PACKAGES == 'true' }}
-        run: |
-          sudo apt update
-          sudo apt install -y \
-            acl \
-            bridge-utils \
-            gettext \
-            openvpn \
-            libfontconfig1 \
-            libglib2.0-0 \
-            libjpeg-turbo8 \
-            libpixman-1-0 \
-            libpng16-16 \
-            libsdl1.2debian \
-            libsm6 \
-            libv4l-0 \
-            libx11-xcb1 \
-            libxcb-icccm4 \
-            libxcb-image0 \
-            libxcb-randr0 \
-            libxcb-render-util0 \
-            libxcb-shape0 \
-            libxcb-xfixes0 \
-            libxi6
       - name: Install Tizen Studio
         if: ${{ env.HAS_CHANGED_PACKAGES == 'true' }}
         run: |
-          sudo apt install -y pciutils zip libncurses5 python libpython2.7
-          curl http://download.tizen.org/sdk/Installer/tizen-studio_4.1/web-cli_Tizen_Studio_4.1_ubuntu-64.bin -o install.bin
+          sudo apt install -y pciutils zip libncurses5 python libpython2.7 make gettext
+          curl http://download.tizen.org/sdk/Installer/tizen-studio_4.6/web-cli_Tizen_Studio_4.6_ubuntu-64.bin -o install.bin
           chmod a+x install.bin
           ./install.bin --accept-license $HOME/tizen-studio
           rm install.bin
@@ -58,20 +33,18 @@ jobs:
         if: ${{ env.HAS_CHANGED_PACKAGES == 'true' }}
         run: |
           $HOME/tizen-studio/package-manager/package-manager-cli.bin install \
-          NativeCLI \
           NativeToolchain-Gcc-9.2 \
           WEARABLE-4.0-NativeAppDevelopment \
-          WEARABLE-5.5-NativeAppDevelopment \
-          WEARABLE-6.5-NativeAppDevelopment
+          WEARABLE-5.5-NativeAppDevelopment
       - name: Create a Tizen certificate profile
         if: ${{ env.HAS_CHANGED_PACKAGES == 'true' }}
         run: |
           export PATH=$PATH:$HOME/tizen-studio/tools/ide/bin
-          tizen certificate -a platform -p platform -f platform
+          tizen certificate -a tizen -p tizen -f tizen
           tizen security-profiles add \
-            -n platform \
-            -a $HOME/tizen-studio-data/keystore/author/platform.p12 \
-            -p platform
+            -n tizen \
+            -a $HOME/tizen-studio-data/keystore/author/tizen.p12 \
+            -p tizen
       - name: Install flutter-tizen
         if: ${{ env.HAS_CHANGED_PACKAGES == 'true' }}
         uses: actions/checkout@v2


### PR DESCRIPTION
- Increase the Tizen Studio version to 4.6.
- Skip installing unnecessary dependencies.
- Revert https://github.com/flutter-tizen/plugins/pull/315.
- Change the certificate profile name to `tizen` to avoid any confusion.

Using the latest Tizen Studio reduces the total build time because there's no need to install updates.