### PR TITLE
[tizen_app_manager] Support terminating background applications

### DIFF
--- a/packages/tizen_app_manager/CHANGELOG.md
+++ b/packages/tizen_app_manager/CHANGELOG.md
@@ -1,4 +1,8 @@
+## 0.1.1
+
+* Add an optional parameter `background` to `AppRunningContext.terminate()`
+  to support terminating background applications.
+
 ## 0.1.0
 
 * Initial release.
-

--- a/packages/tizen_app_manager/README.md
+++ b/packages/tizen_app_manager/README.md
@@ -10,7 +10,7 @@ To use this package, add `tizen_app_manager` as a dependency in your `pubspec.ya
 
 ```yaml
 dependencies:
-  tizen_app_manager: ^0.1.0
+  tizen_app_manager: ^0.1.1
 ```
 
 ### Retrieving current app info
@@ -79,10 +79,16 @@ void dispose() {
 
 ## Required privileges
 
-The following privilege is required to invoke `AppRunningContext.resume()`. Add required privileges in `tizen-manifest.xml` of your application.
+The following privileges may be required to use this plugin. Add required privileges to `tizen-manifest.xml` of your application.
 
 ```xml
 <privileges>
   <privilege>http://tizen.org/privilege/appmanager.launch</privilege>
+  <privilege>http://tizen.org/privilege/appmanager.kill.bgapp</privilege>
+  <privilege>http://tizen.org/privilege/appmanager.kill</privilege>
 </privileges>
 ```
+
+- The `http://tizen.org/privilege/appmanager.launch` privilege is required by `AppRunningContext.resume()`.
+- The `http://tizen.org/privilege/appmanager.kill.bgapp` privilege is required by `AppRunningContext.terminate(background: true)`.
+- The `http://tizen.org/privilege/appmanager.kill` privilege is required by `AppRunningContext.terminate(background: false)`. Note that this is a platform level privilege and cannot be granted to third-party applications.

--- a/packages/tizen_app_manager/lib/app_manager.dart
+++ b/packages/tizen_app_manager/lib/app_manager.dart
@@ -208,14 +208,22 @@ class AppRunningContext {
     }
   }
 
-  /// Sends a terminate request to the application if it is running in foreground
-  /// or in a paused state.
+  /// Sends a terminate request to the application.
   ///
-  /// The `http://tizen.org/privilege/appmanager.kill` partner privilege is required
-  /// to use this API.
-  void terminate() {
+  /// Set [background] to true if the application is running in background or
+  /// is a service application.
+  ///
+  /// The `http://tizen.org/privilege/appmanager.kill.bgapp` privilege is
+  /// required if [background] is true. Otherwise, the
+  /// `http://tizen.org/privilege/appmanager.kill` platform privilege is
+  /// required.
+  void terminate({bool background = false}) {
     if (!isTerminated) {
-      _context.terminate();
+      if (background) {
+        _context.requestTerminateBgApp();
+      } else {
+        _context.terminate();
+      }
     }
   }
 }

--- a/packages/tizen_app_manager/lib/src/app_context.dart
+++ b/packages/tizen_app_manager/lib/src/app_context.dart
@@ -19,6 +19,8 @@ typedef _AppContextGetPid = Int32 Function(
 typedef _AppContextGetAppState = Int32 Function(
     Pointer<_ContextHandle>, Pointer<Int32>);
 typedef _AppManagerTerminate = Int32 Function(Pointer<_ContextHandle>);
+typedef _AppManagerRequestTerminateBgApp = Int32 Function(
+    Pointer<_ContextHandle>);
 typedef _AppManagerResumeApp = Int32 Function(Pointer<_ContextHandle>);
 typedef _AppContextDestroy = Int32 Function(Pointer<_ContextHandle>);
 
@@ -61,6 +63,10 @@ class _AppManager {
         .lookup<NativeFunction<_AppManagerTerminate>>(
             'app_manager_terminate_app')
         .asFunction();
+    requestTerminateBgApp = libAppMananger
+        .lookup<NativeFunction<_AppManagerRequestTerminateBgApp>>(
+            'app_manager_request_terminate_bg_app')
+        .asFunction();
     resumeApp = libAppMananger
         .lookup<NativeFunction<_AppManagerResumeApp>>('app_manager_resume_app')
         .asFunction();
@@ -77,6 +83,7 @@ class _AppManager {
   late int Function(Pointer<_ContextHandle>, Pointer<Int32>) getProcessId;
   late int Function(Pointer<_ContextHandle>, Pointer<Int32>) getAppState;
   late int Function(Pointer<_ContextHandle>) terminateApp;
+  late int Function(Pointer<_ContextHandle>) requestTerminateBgApp;
   late int Function(Pointer<_ContextHandle>) resumeApp;
   late int Function(Pointer<_ContextHandle>) destroyContext;
 }
@@ -199,6 +206,17 @@ class AppContext {
   void terminate() {
     _checkHandle();
     final int ret = _appManager.terminateApp(_handle);
+    if (ret != 0) {
+      throw PlatformException(
+        code: ret.toString(),
+        message: getErrorMessage(ret).toDartString(),
+      );
+    }
+  }
+
+  void requestTerminateBgApp() {
+    _checkHandle();
+    final int ret = _appManager.requestTerminateBgApp(_handle);
     if (ret != 0) {
       throw PlatformException(
         code: ret.toString(),

--- a/packages/tizen_app_manager/pubspec.yaml
+++ b/packages/tizen_app_manager/pubspec.yaml
@@ -2,7 +2,7 @@ name: tizen_app_manager
 description: Tizen application manager APIs. Used to get application info and app running context on a Tizen device.
 homepage: https://github.com/flutter-tizen/plugins
 repository: https://github.com/flutter-tizen/plugins/tree/master/packages/tizen_app_manager
-version: 0.1.0
+version: 0.1.1
 
 environment:
   sdk: ">=2.15.1 <3.0.0"
@@ -19,4 +19,3 @@ flutter:
       tizen:
         pluginClass: TizenAppManagerPlugin
         fileName: tizen_app_manager_plugin.h
-


### PR DESCRIPTION
Adds an optional `background` parameter to `AppRunningContext.terminate()`. If `background` is true, the method internally invokes `app_manager_request_terminate_bg_app`, otherwise invokes `app_manager_terminate_app` as usual.

There's no test for the new API because testing the API requires a multi-project configuration. I'm planning to unify tizen_app_control and tizen_app_manager into a single package and the test will be added then.