### PR TITLE
[tizen_app_control] Deprecate AppManager

### DIFF
--- a/packages/tizen_app_control/CHANGELOG.md
+++ b/packages/tizen_app_control/CHANGELOG.md
@@ -1,7 +1,13 @@
+## 0.1.2
+
+* Add the main exporter file `tizen_app_control.dart`.
+* Add dependency on tizen_app_manager and reimplement `AppManager`.
+* Deprecate `AppManager` in favor of tizen_app_manager's `AppManager`.
+* Update the example app and integration_test based on the changes.
+
 ## 0.1.1
 
-* Update messageport_tizen to 0.2.0 in example.
-* Replace deprecated members in example app.
+* Update messageport_tizen to 0.2.0 and replace deprecated members in the example app.
 
 ## 0.1.0
 

--- a/packages/tizen_app_control/README.md
+++ b/packages/tizen_app_control/README.md
@@ -10,7 +10,7 @@ To use this package, add `tizen_app_control` as a dependency in your `pubspec.ya
 
 ```yaml
 dependencies:
-  tizen_app_control: ^0.1.1
+  tizen_app_control: ^0.1.2
 ```
 
 ### Sending a launch request
@@ -18,7 +18,7 @@ dependencies:
 To send an explicit launch request, create an `AppControl` instance with an application ID as an argument.
 
 ```dart
-import 'package:tizen_app_control/app_control.dart';
+import 'package:tizen_app_control/tizen_app_control.dart';
 
 var request = AppControl(appId: 'com.example.app_id');
 await request.sendLaunchRequest();
@@ -27,7 +27,7 @@ await request.sendLaunchRequest();
 To send an implicit launch request, create an `AppControl` instance and specify necessary conditions, such as operation, URI, and MIME type. For example, if you want to open an image file with an image viewer app on your device,
 
 ```dart
-import 'package:tizen_app_control/app_control.dart';
+import 'package:tizen_app_control/tizen_app_control.dart';
 
 var request = AppControl(
   operation: 'http://tizen.org/appcontrol/operation/view',
@@ -44,7 +44,7 @@ For detailed information on Tizen application controls, see [Tizen Docs: Applica
 You can subscribe to incoming application controls using `AppControl.onAppControl`.
 
 ```dart
-import 'package:tizen_app_control/app_control.dart';
+import 'package:tizen_app_control/tizen_app_control.dart';
 
 var subscription = AppControl.onAppControl.listen((request) async {
   if (request.shouldReply) {
@@ -64,7 +64,6 @@ Privileges may be required to perform operations requested by your app. Add requ
 <privileges>
   <privilege>http://tizen.org/privilege/appmanager.launch</privilege>
   <!-- The below are optional. -->
-  <privilege>http://tizen.org/privilege/appmanager.kill.bgapp</privilege>
   <privilege>http://tizen.org/privilege/call</privilege>
   <privilege>http://tizen.org/privilege/download</privilege>
 </privileges>

--- a/packages/tizen_app_control/example/integration_test/tizen_app_control_test.dart
+++ b/packages/tizen_app_control/example/integration_test/tizen_app_control_test.dart
@@ -6,8 +6,7 @@ import 'package:flutter/services.dart';
 import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:integration_test/integration_test.dart';
-import 'package:tizen_app_control/app_control.dart';
-import 'package:tizen_app_control/app_manager.dart';
+import 'package:tizen_app_control/tizen_app_control.dart';
 
 const String kAppId = 'org.tizen.tizen_app_control_example';
 const String kServiceAppId = 'org.tizen.tizen_app_control_example_service';
@@ -103,19 +102,6 @@ void main() {
       request2.sendLaunchRequest,
       throwsA(isInstanceOf<PlatformException>()),
     );
-  }, timeout: kTimeout);
-
-  testWidgets('Can terminate service application', (WidgetTester _) async {
-    expect(AppManager.isRunning(kServiceAppId), isFalse);
-
-    final AppControl request = AppControl(appId: kServiceAppId);
-    await request.sendLaunchRequest();
-    await Future<void>.delayed(const Duration(seconds: 1));
-    expect(AppManager.isRunning(kServiceAppId), isTrue);
-
-    AppManager.terminateBackgroundApplication(kServiceAppId);
-    await Future<void>.delayed(const Duration(seconds: 1));
-    expect(AppManager.isRunning(kServiceAppId), isFalse);
   }, timeout: kTimeout);
 }
 

--- a/packages/tizen_app_control/example/lib/main.dart
+++ b/packages/tizen_app_control/example/lib/main.dart
@@ -7,8 +7,8 @@ import 'dart:async';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:messageport_tizen/messageport_tizen.dart';
-import 'package:tizen_app_control/app_control.dart';
-import 'package:tizen_app_control/app_manager.dart';
+import 'package:tizen_app_control/tizen_app_control.dart';
+import 'package:tizen_app_manager/tizen_app_manager.dart';
 
 const String _kAppId = 'org.tizen.tizen_app_control_example';
 const String _kServiceAppId = 'org.tizen.tizen_app_control_example_service';
@@ -163,9 +163,11 @@ class _MyAppState extends State<MyApp> {
   }
 
   Future<void> _terminateService() async {
-    AppManager.terminateBackgroundApplication(_kServiceAppId);
+    final AppRunningContext context = AppRunningContext(appId: _kServiceAppId);
+    context.terminate(background: true);
+    context.dispose();
     setState(() {
-      _isServiceStarted = AppManager.isRunning(_kServiceAppId);
+      _isServiceStarted = false;
     });
   }
 

--- a/packages/tizen_app_control/example/pubspec.yaml
+++ b/packages/tizen_app_control/example/pubspec.yaml
@@ -5,9 +5,11 @@ publish_to: "none"
 dependencies:
   flutter:
     sdk: flutter
-  messageport_tizen: ^0.2.0
+  messageport_tizen:
+    path: ../../messageport/
   tizen_app_control:
     path: ../
+  tizen_app_manager:
 
 dev_dependencies:
   flutter_driver:

--- a/packages/tizen_app_control/lib/app_control.dart
+++ b/packages/tizen_app_control/lib/app_control.dart
@@ -2,13 +2,11 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-library tizen_app_control;
-
 import 'dart:async';
 
 import 'package:flutter/services.dart';
+import 'package:tizen_app_manager/tizen_app_manager.dart';
 
-import 'app_manager.dart';
 import 'src/ffi.dart';
 import 'src/utils.dart';
 
@@ -197,10 +195,10 @@ class AppControl {
 
   /// Sends a terminate request to a running application.
   ///
-  /// This API can be only used to terminate sub applications launched by the
+  /// This API can be only used to terminate sub-applications launched by the
   /// caller application as a group. To terminate background applications not
-  /// launched as a group, use [AppManager.terminateBackgroundApplication]
-  /// instead.
+  /// launched as a group, use [AppRunningContext.terminate] of the
+  /// `tizen_app_manager` package instead.
   ///
   /// Applications that were launched by the callee application as a group will
   /// be terminated by this API as well.

--- a/packages/tizen_app_control/lib/src/ffi.dart
+++ b/packages/tizen_app_control/lib/src/ffi.dart
@@ -3,7 +3,6 @@
 // found in the LICENSE file.
 
 // ignore_for_file: public_member_api_docs
-// ignore_for_file: always_specify_types
 
 import 'dart:ffi';
 
@@ -68,12 +67,6 @@ typedef _AppManagerGetAppContextNative = Int32 Function(
     Pointer<Utf8>, Pointer<AppContextHandle>);
 typedef AppManagerGetAppContext = int Function(
     Pointer<Utf8>, Pointer<AppContextHandle>);
-typedef _AppManagerIsRunningNative = Int32 Function(
-    Pointer<Utf8>, Pointer<Uint8>);
-typedef AppManagerIsRunning = int Function(Pointer<Utf8>, Pointer<Uint8>);
-typedef _AppManagerRequestTerminateBgAppNative = Int32 Function(
-    AppContextHandle);
-typedef AppManagerRequestTerminateBgApp = int Function(AppContextHandle);
 
 final DynamicLibrary _libAppManager =
     DynamicLibrary.open('libcapi-appfw-app-manager.so.0');
@@ -85,14 +78,6 @@ final AppManagerGetAppContext appManagerGetAppContext = _libAppManager
 final AppContextDestroy appContextDestroy =
     _libAppManager.lookupFunction<_AppContextDestroyNative, AppContextDestroy>(
         'app_context_destroy');
-
-final AppManagerRequestTerminateBgApp appManagerRequestTerminateBgApp =
-    _libAppManager.lookupFunction<_AppManagerRequestTerminateBgAppNative,
-            AppManagerRequestTerminateBgApp>(
-        'app_manager_request_terminate_bg_app');
-
-final AppManagerIsRunning appManagerIsRunning = _libAppManager.lookupFunction<
-    _AppManagerIsRunningNative, AppManagerIsRunning>('app_manager_is_running');
 
 typedef _GetErrorMessageNative = Pointer<Utf8> Function(Int32);
 typedef GetErrorMessage = Pointer<Utf8> Function(int);

--- a/packages/tizen_app_control/lib/tizen_app_control.dart
+++ b/packages/tizen_app_control/lib/tizen_app_control.dart
@@ -1,0 +1,6 @@
+// Copyright 2022 Samsung Electronics Co., Ltd. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+export 'app_control.dart';
+export 'app_manager.dart';

--- a/packages/tizen_app_control/pubspec.yaml
+++ b/packages/tizen_app_control/pubspec.yaml
@@ -3,12 +3,13 @@ description: Tizen application control APIs. Used for launching and terminating
   applications on a Tizen device.
 homepage: https://github.com/flutter-tizen/plugins
 repository: https://github.com/flutter-tizen/plugins/tree/master/packages/tizen_app_control
-version: 0.1.1
+version: 0.1.2
 
 dependencies:
   ffi: ^1.1.2
   flutter:
     sdk: flutter
+  tizen_app_manager: ^0.1.1
 
 environment:
   sdk: ">=2.13.0 <3.0.0"


### PR DESCRIPTION
Please see the CHANGELOG for details.

tizen_app_manager 0.1.1 (https://github.com/flutter-tizen/plugins/commit/b0ad4c96c65484755412ca94a045604e95c3e1d8) must be released first for the CI to pass. @HakkyuKim Could you check the integration test server?