### PR TITLE
[tizen_app_manager] Deprecate AppRunningContext.dispose

### DIFF
--- a/packages/tizen_app_manager/CHANGELOG.md
+++ b/packages/tizen_app_manager/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.1.2
+
+* Implement a Dart finalizer for `AppRunningContext`.
+* Deprecate `AppRunningContext.dispose`.
+* Clean up README.
+
 ## 0.1.1
 
 * Add the main exporter file `tizen_app_manager.dart`.

--- a/packages/tizen_app_manager/README.md
+++ b/packages/tizen_app_manager/README.md
@@ -2,7 +2,7 @@
 
  [![pub package](https://img.shields.io/pub/v/tizen_app_manager.svg)](https://pub.dev/packages/tizen_app_manager)
 
-Tizen application manager API. Used for getting installed app info and getting running context info of specific app.
+Tizen application manager APIs. Used for getting app info and getting app running context on a Tizen device.
 
 ## Usage
 
@@ -10,41 +10,43 @@ To use this package, add `tizen_app_manager` as a dependency in your `pubspec.ya
 
 ```yaml
 dependencies:
-  tizen_app_manager: ^0.1.1
+  tizen_app_manager: ^0.1.2
 ```
 
 ### Retrieving current app info
 
-To retrieve information of the current app, get app ID with `currentAppId` and then get `AppInfo` with `getAppInfo` method.
+To retrieve information of the current app, get app ID with `AppManager.currentAppId` and then get `AppInfo` with `AppManager.getAppInfo`.
 
 ```dart
-var appId = await AppManager.currentAppId;
-var appInfo = await AppManager.getAppInfo(appId);
+import 'package:tizen_app_manager/tizen_app_manager.dart';
+
+String appId = await AppManager.currentAppId;
+AppInfo appInfo = await AppManager.getAppInfo(appId);
 ```
 
 ### Retrieving all apps info
 
-To retrieve information of all apps installed on a Tizen device, use `getInstalledApps` method.
+To retrieve information of all installed apps, use `AppManager.getInstalledApps`.
 
 ```dart
-var apps = await AppManager.getInstalledApps();
-for (var app in apps) {
+List<AppInfo> apps = await AppManager.getInstalledApps();
+for (AppInfo app in apps) {
   // Handle each app's info.
 }
 ```
 
 ### Getting app running context
 
-To get specific app running context, create `AppRunningContext` instance.
+To get a specific app's running context, create an `AppRunningContext` instance with the target app ID.
 
 ```dart
-var appId = await AppManager.currentAppId;
-var appContext = AppRunningContext(appId: appId);
+String appId = await AppManager.currentAppId;
+AppRunningContext appContext = AppRunningContext(appId: appId);
 ```
 
 ### Monitoring app events
 
-You can listen for app state change by subscribing to the stream.
+You can listen for app state changes by subscribing to `AppManager.onAppLaunched` and `AppManager.onAppTerminated`.
 
 ```dart
 final List<StreamSubscription<AppRunningContext>> _subscriptions =
@@ -54,17 +56,13 @@ final List<StreamSubscription<AppRunningContext>> _subscriptions =
 void initState() {
   super.initState();
 
-  _subscriptions.add(AppManager.onAppLaunched
-      .listen((AppRunningContext event) {
-      // Handle the launched event.
-      ...
-      event.dispose();
+  _subscriptions
+      .add(AppManager.onAppLaunched.listen((AppRunningContext context) {
+    ...
   }));
-  _subscriptions.add(AppManager.onAppTerminated
-      .listen((AppRunningContext event) {
-      // Handle the terminated event.
-      ...
-      event.dispose();
+  _subscriptions
+      .add(AppManager.onAppTerminated.listen((AppRunningContext context) {
+    ...
   }));
 }
 
@@ -72,7 +70,8 @@ void initState() {
 void dispose() {
   super.dispose();
 
-  _subscriptions.forEach((StreamSubscription subscription) => subscription.cancel());
+  _subscriptions
+      .forEach((StreamSubscription subscription) => subscription.cancel());
   _subscriptions.clear();
 }
 ```

--- a/packages/tizen_app_manager/example/lib/main.dart
+++ b/packages/tizen_app_manager/example/lib/main.dart
@@ -174,10 +174,9 @@ class _CurrentAppScreenState extends State<_CurrentAppScreen> {
           _infoTile('Execuatable path', _appInfo.executablePath),
           _infoTile('Shared res path', _appInfo.sharedResourcePath),
           _infoTile('App meta data', _appInfo.metadata.toString()),
-          _infoTile(
-              'App is terminated', _currentAppContext.isTerminated.toString()),
-          _infoTile('process id', _currentAppContext.processId.toString()),
-          _infoTile('state', _currentAppContext.appState.toString()),
+          _infoTile('Terminated', _currentAppContext.isTerminated.toString()),
+          _infoTile('Process ID', _currentAppContext.processId.toString()),
+          _infoTile('App state', _currentAppContext.appState.toString()),
         ],
       ),
     );
@@ -279,7 +278,6 @@ class _AppsEventScreenState extends State<_AppsEventScreen> {
           appId: event.appId,
           processId: event.processId,
         ));
-        event.dispose();
       });
     }));
     _subscriptions
@@ -290,7 +288,6 @@ class _AppsEventScreenState extends State<_AppsEventScreen> {
           appId: event.appId,
           processId: event.processId,
         ));
-        event.dispose();
       });
     }));
   }

--- a/packages/tizen_app_manager/example/lib/main.dart
+++ b/packages/tizen_app_manager/example/lib/main.dart
@@ -173,10 +173,10 @@ class _CurrentAppScreenState extends State<_CurrentAppScreen> {
           _infoTile('Application type', _appInfo.appType),
           _infoTile('Execuatable path', _appInfo.executablePath),
           _infoTile('Shared res path', _appInfo.sharedResourcePath),
-          _infoTile('App meta data', _appInfo.metadata.toString()),
+          _infoTile('Metadata', _appInfo.metadata.toString()),
           _infoTile('Terminated', _currentAppContext.isTerminated.toString()),
           _infoTile('Process ID', _currentAppContext.processId.toString()),
-          _infoTile('App state', _currentAppContext.appState.toString()),
+          _infoTile('State', _currentAppContext.appState.toString()),
         ],
       ),
     );

--- a/packages/tizen_app_manager/lib/app_manager.dart
+++ b/packages/tizen_app_manager/lib/app_manager.dart
@@ -164,9 +164,14 @@ class AppRunningContext {
   /// Creates an instance of [AppRunningContext] with application ID and handle address.
   AppRunningContext({required this.appId, int handleAddress = 0}) {
     _context = AppContext(appId, handleAddress);
+
+    _finalizer.attach(this, _context, detach: this);
   }
 
   late AppContext _context;
+
+  static final Finalizer<AppContext> _finalizer =
+      Finalizer<AppContext>((AppContext context) => context.destroy());
 
   /// The ID of the application.
   final String appId;
@@ -191,11 +196,11 @@ class AppRunningContext {
   }
 
   /// Releases all resources associated with this object.
-  ///
-  /// Note that [dispose] must be called on an instance of [AppRunningContext]
-  /// after use.
+  @Deprecated('Automatically disposed on GC')
   void dispose() {
     _context.destroy();
+
+    _finalizer.detach(this);
   }
 
   /// Sends a resume request to the application if it is not running.

--- a/packages/tizen_app_manager/pubspec.yaml
+++ b/packages/tizen_app_manager/pubspec.yaml
@@ -1,8 +1,8 @@
 name: tizen_app_manager
-description: Tizen application manager APIs. Used to get application info and app running context on a Tizen device.
+description: Tizen application manager APIs. Used for getting app info and getting app running context on a Tizen device.
 homepage: https://github.com/flutter-tizen/plugins
 repository: https://github.com/flutter-tizen/plugins/tree/master/packages/tizen_app_manager
-version: 0.1.1
+version: 0.1.2
 
 environment:
   sdk: ">=2.15.1 <3.0.0"


### PR DESCRIPTION
* Implement a Dart finalizer for `AppRunningContext`.
* Deprecate `AppRunningContext.dispose`.
* Clean up README.

When an `AppRunningContext` object goes out of scope, the platform resource (`AppContext`) associated with it is now automatically released by the garbage collector.