### PR TITLE
Clean up license in auto-generated file

### DIFF
--- a/packages/battery_plus/tizen/inc/battery_plus_tizen_plugin.h
+++ b/packages/battery_plus/tizen/inc/battery_plus_tizen_plugin.h
@@ -1,7 +1,3 @@
-// Copyright 2020 Samsung Electronics Co., Ltd. All rights reserved.
-// Use of this source code is governed by a BSD-style license that can be
-// found in the LICENSE file.
-
 #ifndef FLUTTER_PLUGIN_BATTERY_PLUS_TIZEN_PLUGIN_H_
 #define FLUTTER_PLUGIN_BATTERY_PLUS_TIZEN_PLUGIN_H_
 

--- a/packages/geolocator/tizen/inc/geolocator_tizen_plugin.h
+++ b/packages/geolocator/tizen/inc/geolocator_tizen_plugin.h
@@ -1,7 +1,3 @@
-// Copyright 2021 Samsung Electronics Co., Ltd. All rights reserved.
-// Use of this source code is governed by a BSD-style license that can be
-// found in the LICENSE file.
-
 #ifndef FLUTTER_PLUGIN_GEOLOCATOR_TIZEN_PLUGIN_H_
 #define FLUTTER_PLUGIN_GEOLOCATOR_TIZEN_PLUGIN_H_
 

--- a/packages/messageport/tizen/inc/messageport_tizen_plugin.h
+++ b/packages/messageport/tizen/inc/messageport_tizen_plugin.h
@@ -1,7 +1,3 @@
-// Copyright 2021 Samsung Electronics Co., Ltd. All rights reserved.
-// Use of this source code is governed by a BSD-style license that can be
-// found in the LICENSE file.
-
 #ifndef FLUTTER_PLUGIN_MESSAGEPORT_TIZEN_PLUGIN_H_
 #define FLUTTER_PLUGIN_MESSAGEPORT_TIZEN_PLUGIN_H_
 

--- a/packages/tizen_app_manager/tizen/inc/tizen_app_manager_plugin.h
+++ b/packages/tizen_app_manager/tizen/inc/tizen_app_manager_plugin.h
@@ -1,7 +1,3 @@
-// Copyright 2022 Samsung Electronics Co., Ltd. All rights reserved.
-// Use of this source code is governed by a BSD-style license that can be
-// found in the LICENSE file.
-
 #ifndef FLUTTER_PLUGIN_TIZEN_APP_MANAGER_PLUGIN_H_
 #define FLUTTER_PLUGIN_TIZEN_APP_MANAGER_PLUGIN_H_
 

--- a/packages/tizen_audio_manager/tizen/inc/tizen_audio_manager_plugin.h
+++ b/packages/tizen_audio_manager/tizen/inc/tizen_audio_manager_plugin.h
@@ -1,7 +1,3 @@
-// Copyright 2022 Samsung Electronics Co., Ltd. All rights reserved.
-// Use of this source code is governed by a BSD-style license that can be
-// found in the LICENSE file.
-
 #ifndef FLUTTER_PLUGIN_TIZEN_AUDIO_MANAGER_PLUGIN_H_
 #define FLUTTER_PLUGIN_TIZEN_AUDIO_MANAGER_PLUGIN_H_
 

--- a/packages/tizen_audio_manager/tizen/src/log.h
+++ b/packages/tizen_audio_manager/tizen/src/log.h
@@ -1,7 +1,3 @@
-// Copyright 2022 Samsung Electronics Co., Ltd. All rights reserved.
-// Use of this source code is governed by a BSD-style license that can be
-// found in the LICENSE file.
-
 #ifndef __LOG_H__
 #define __LOG_H__
 

--- a/packages/tizen_package_manager/tizen/inc/tizen_package_manager_plugin.h
+++ b/packages/tizen_package_manager/tizen/inc/tizen_package_manager_plugin.h
@@ -1,7 +1,3 @@
-// Copyright 2022 Samsung Electronics Co., Ltd. All rights reserved.
-// Use of this source code is governed by a BSD-style license that can be
-// found in the LICENSE file.
-
 #ifndef FLUTTER_PLUGIN_TIZEN_PACKAGE_MANAGER_PLUGIN_H_
 #define FLUTTER_PLUGIN_TIZEN_PACKAGE_MANAGER_PLUGIN_H_
 


### PR DESCRIPTION
In some packages, the automatically generated file has a license.
Removed for consistency with other packages.