### PR TITLE
[tizen_app_manager] Refactor the code again

### DIFF
--- a/packages/tizen_app_manager/CHANGELOG.md
+++ b/packages/tizen_app_manager/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.1.3
+
+* Code refactoring.
+
 ## 0.1.2
 
 * Implement a Dart finalizer for `AppRunningContext`.

--- a/packages/tizen_app_manager/README.md
+++ b/packages/tizen_app_manager/README.md
@@ -10,7 +10,7 @@ To use this package, add `tizen_app_manager` as a dependency in your `pubspec.ya
 
 ```yaml
 dependencies:
-  tizen_app_manager: ^0.1.2
+  tizen_app_manager: ^0.1.3
 ```
 
 ### Retrieving current app info

--- a/packages/tizen_app_manager/pubspec.yaml
+++ b/packages/tizen_app_manager/pubspec.yaml
@@ -2,7 +2,7 @@ name: tizen_app_manager
 description: Tizen application manager APIs. Used for getting app info and getting app running context on a Tizen device.
 homepage: https://github.com/flutter-tizen/plugins
 repository: https://github.com/flutter-tizen/plugins/tree/master/packages/tizen_app_manager
-version: 0.1.2
+version: 0.1.3
 
 environment:
   sdk: ">=2.15.1 <3.0.0"

--- a/packages/tizen_app_manager/tizen/src/tizen_app_info.cc
+++ b/packages/tizen_app_manager/tizen/src/tizen_app_info.cc
@@ -12,90 +12,91 @@ TizenAppInfo::~TizenAppInfo() {
   }
 }
 
-std::string TizenAppInfo::GetAppId() {
+std::optional<std::string> TizenAppInfo::GetAppId() {
   char *app_id = nullptr;
   int ret = app_info_get_app_id(app_info_, &app_id);
   if (ret != APP_MANAGER_ERROR_NONE) {
     LOG_ERROR("Failed to get app ID: %s", get_error_message(ret));
     last_error_ = ret;
-    return std::string();
+    return std::nullopt;
   }
   std::string result = std::string(app_id);
   free(app_id);
   return result;
 }
 
-std::string TizenAppInfo::GetPackageId() {
+std::optional<std::string> TizenAppInfo::GetPackageId() {
   char *package_id = nullptr;
   int ret = app_info_get_package(app_info_, &package_id);
   if (ret != APP_MANAGER_ERROR_NONE) {
     LOG_ERROR("Failed to get package ID: %s", get_error_message(ret));
     last_error_ = ret;
-    return std::string();
+    return std::nullopt;
   }
   std::string result = std::string(package_id);
   free(package_id);
   return result;
 }
 
-std::string TizenAppInfo::GetLabel() {
+std::optional<std::string> TizenAppInfo::GetLabel() {
   char *label = nullptr;
   int ret = app_info_get_label(app_info_, &label);
   if (ret != APP_MANAGER_ERROR_NONE) {
     LOG_ERROR("Failed to get app label: %s", get_error_message(ret));
     last_error_ = ret;
-    return std::string();
+    return std::nullopt;
   }
   std::string result = std::string(label);
   free(label);
   return result;
 }
 
-std::string TizenAppInfo::GetType() {
+std::optional<std::string> TizenAppInfo::GetType() {
   char *type = nullptr;
   int ret = app_info_get_type(app_info_, &type);
   if (ret != APP_MANAGER_ERROR_NONE) {
     LOG_ERROR("Failed to get app type: %s", get_error_message(ret));
     last_error_ = ret;
-    return std::string();
+    return std::nullopt;
   }
   std::string result = std::string(type);
   free(type);
   return result;
 }
 
-std::string TizenAppInfo::GetIconPath() {
+std::optional<std::string> TizenAppInfo::GetIconPath() {
   char *path = nullptr;
   int ret = app_info_get_icon(app_info_, &path);
   if (ret != APP_MANAGER_ERROR_NONE) {
     // Some system apps and service apps may not have icons.
     LOG_INFO("Failed to get icon path: %s", get_error_message(ret));
-    return std::string();
+    return std::nullopt;
   }
   std::string result = std::string(path);
   free(path);
   return result;
 }
 
-std::string TizenAppInfo::GetExecutablePath() {
+std::optional<std::string> TizenAppInfo::GetExecutablePath() {
   char *path = nullptr;
   int ret = app_info_get_exec(app_info_, &path);
   if (ret != APP_MANAGER_ERROR_NONE) {
     LOG_ERROR("Failed to get app executable path: %s", get_error_message(ret));
     last_error_ = ret;
-    return std::string();
+    return std::nullopt;
   }
   std::string result = std::string(path);
   free(path);
   return result;
 }
 
-bool TizenAppInfo::IsNoDisplay() {
+std::optional<bool> TizenAppInfo::IsNoDisplay() {
   bool value = false;
   int ret = app_info_is_nodisplay(app_info_, &value);
   if (ret != APP_MANAGER_ERROR_NONE) {
     LOG_ERROR("Failed to get nodisplay info: %s", get_error_message(ret));
     last_error_ = ret;
+    return std::nullopt;
   }
   return value;
 }

--- a/packages/tizen_app_manager/tizen/src/tizen_app_info.h
+++ b/packages/tizen_app_manager/tizen/src/tizen_app_info.h
@@ -8,6 +8,7 @@
 #include <app_manager.h>
 
 #include <map>
+#include <optional>
 #include <string>
 
 class TizenAppInfo {
@@ -16,19 +17,19 @@ class TizenAppInfo {
 
   ~TizenAppInfo();
 
-  std::string GetAppId();
+  std::optional<std::string> GetAppId();
 
-  std::string GetPackageId();
+  std::optional<std::string> GetPackageId();
 
-  std::string GetLabel();
+  std::optional<std::string> GetLabel();
 
-  std::string GetType();
+  std::optional<std::string> GetType();
 
-  std::string GetIconPath();
+  std::optional<std::string> GetIconPath();
 
-  std::string GetExecutablePath();
+  std::optional<std::string> GetExecutablePath();
 
-  bool IsNoDisplay();
+  std::optional<bool> IsNoDisplay();
 
   std::map<std::string, std::string> GetMetadata();
 

--- a/packages/tizen_app_manager/tizen/src/tizen_app_info.h
+++ b/packages/tizen_app_manager/tizen/src/tizen_app_info.h
@@ -12,28 +12,33 @@
 
 class TizenAppInfo {
  public:
-  int GetLastError() { return last_error_; }
-
-  std::string GetLastErrorString() { return get_error_message(last_error_); }
-
   TizenAppInfo(app_info_h app_info) : app_info_(app_info) {}
 
   ~TizenAppInfo();
 
   std::string GetAppId();
+
   std::string GetPackageId();
+
   std::string GetLabel();
+
   std::string GetType();
+
   std::string GetIconPath();
+
   std::string GetExecutablePath();
-  std::string GetSharedResourcePath();
-  bool GetIsNoDisplay();
-  void GetForEachMetadata(app_info_metadata_cb callback, void *user_data);
+
+  bool IsNoDisplay();
+
+  std::map<std::string, std::string> GetMetadata();
+
+  int GetLastError() { return last_error_; }
+
+  std::string GetLastErrorString() { return get_error_message(last_error_); }
 
  private:
   app_info_h app_info_ = nullptr;
-  char *app_id_ = nullptr;
   int last_error_ = APP_MANAGER_ERROR_NONE;
 };
 
-#endif
+#endif  // FLUTTER_PLUGIN_TIZEN_APP_INFO_H_

--- a/packages/tizen_app_manager/tizen/src/tizen_app_manager.cc
+++ b/packages/tizen_app_manager/tizen/src/tizen_app_manager.cc
@@ -15,7 +15,7 @@ TizenAppManager::TizenAppManager() {
         char *app_id = nullptr;
         int ret = app_context_get_app_id(app_context, &app_id);
         if (ret != APP_MANAGER_ERROR_NONE) {
-          LOG_ERROR("Failed to get app ID from context: %s",
+          LOG_ERROR("Failed to get app ID from the context: %s",
                     get_error_message(ret));
           return;
         }
@@ -40,7 +40,7 @@ TizenAppManager::TizenAppManager() {
             return;
           }
         }
-        // No callback has been registered. Destroy immediately.
+        // No callback has been registered. Destroy the context immediately.
         app_context_destroy(clone_context);
       },
       this);
@@ -107,7 +107,7 @@ std::optional<std::string> TizenAppManager::GetSharedResourcePath(
 }
 
 std::optional<bool> TizenAppManager::IsAppRunning(const std::string &app_id) {
-  bool is_running;
+  bool is_running = false;
   int ret = app_manager_is_running(app_id.c_str(), &is_running);
   if (ret != APP_MANAGER_ERROR_NONE) {
     LOG_ERROR("Failed to check if app is running: %s", get_error_message(ret));

--- a/packages/tizen_app_manager/tizen/src/tizen_app_manager.cc
+++ b/packages/tizen_app_manager/tizen/src/tizen_app_manager.cc
@@ -81,13 +81,14 @@ std::vector<std::unique_ptr<TizenAppInfo>> TizenAppManager::GetAllAppsInfo() {
   return list;
 }
 
-std::string TizenAppManager::GetSharedResourcePath(const std::string &app_id) {
+std::optional<std::string> TizenAppManager::GetSharedResourcePath(
+    const std::string &app_id) {
   char *path = nullptr;
   int ret = app_manager_get_shared_resource_path(app_id.c_str(), &path);
   if (ret != APP_MANAGER_ERROR_NONE) {
     LOG_ERROR("Failed to get shared resource path: %s", get_error_message(ret));
     last_error_ = ret;
-    return std::string();
+    return std::nullopt;
   }
   std::string result = std::string(path);
   free(path);

--- a/packages/tizen_app_manager/tizen/src/tizen_app_manager.cc
+++ b/packages/tizen_app_manager/tizen/src/tizen_app_manager.cc
@@ -1,0 +1,106 @@
+// Copyright 2022 Samsung Electronics Co., Ltd. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "tizen_app_manager.h"
+
+#include "log.h"
+
+TizenAppManager::TizenAppManager() {
+  int ret = app_manager_set_app_context_event_cb(
+      [](app_context_h app_context, app_context_event_e event,
+         void *user_data) {
+        auto *self = static_cast<TizenAppManager *>(user_data);
+
+        char *app_id = nullptr;
+        app_context_h clone_context = nullptr;
+        int ret = app_context_get_app_id(app_context, &app_id);
+        if (ret != APP_MANAGER_ERROR_NONE) {
+          LOG_ERROR("Failed to get app ID: %s", get_error_message(ret));
+          return;
+        }
+        std::string app_id_str = std::string(app_id);
+        free(app_id);
+
+        ret = app_context_clone(&clone_context, app_context);
+        if (ret != APP_MANAGER_ERROR_NONE) {
+          LOG_ERROR("Failed to clone app context: %s", get_error_message(ret));
+          return;
+        }
+
+        if (event == APP_CONTEXT_EVENT_LAUNCHED) {
+          if (self->launch_callback_) {
+            self->launch_callback_(app_id_str, clone_context);
+            return;
+          }
+        } else if (event == APP_CONTEXT_EVENT_TERMINATED) {
+          if (self->terminate_callback_) {
+            self->terminate_callback_(app_id_str, clone_context);
+            return;
+          }
+        }
+        app_context_destroy(clone_context);
+      },
+      this);
+}
+
+TizenAppManager::~TizenAppManager() {
+  app_manager_unset_app_context_event_cb();
+}
+
+std::unique_ptr<TizenAppInfo> TizenAppManager::GetAppInfo(
+    const std::string &app_id) {
+  app_info_h app_info;
+  int ret = app_manager_get_app_info(app_id.c_str(), &app_info);
+  if (ret != APP_MANAGER_ERROR_NONE) {
+    LOG_ERROR("Failed to retrieve app info: %s", get_error_message(ret));
+    return nullptr;
+  }
+  return std::make_unique<TizenAppInfo>(app_info);
+}
+
+std::vector<std::unique_ptr<TizenAppInfo>> TizenAppManager::GetAllAppsInfo() {
+  std::vector<std::unique_ptr<TizenAppInfo>> list;
+  int ret = app_manager_foreach_app_info(
+      [](app_info_h app_info, void *user_data) {
+        auto *list = static_cast<std::vector<std::unique_ptr<TizenAppInfo>> *>(
+            user_data);
+        app_info_h clone_info = nullptr;
+        int ret = app_info_clone(&clone_info, app_info);
+        if (ret != APP_MANAGER_ERROR_NONE) {
+          LOG_ERROR("Failed to clone app info: %s", get_error_message(ret));
+        } else {
+          list->push_back(std::make_unique<TizenAppInfo>(clone_info));
+        }
+        return true;
+      },
+      &list);
+  if (ret != APP_MANAGER_ERROR_NONE) {
+    LOG_ERROR("Failed to retrieve all app info: %s", get_error_message(ret));
+  }
+  return list;
+}
+
+std::string TizenAppManager::GetSharedResourcePath(const std::string &app_id) {
+  char *path = nullptr;
+  int ret = app_manager_get_shared_resource_path(app_id.c_str(), &path);
+  if (ret != APP_MANAGER_ERROR_NONE) {
+    LOG_ERROR("Failed to get shared resource path: %s", get_error_message(ret));
+    last_error_ = ret;
+    return std::string();
+  }
+  std::string result = std::string(path);
+  free(path);
+  return result;
+}
+
+bool TizenAppManager::IsAppRunning(const std::string &app_id) {
+  bool is_running;
+  int ret = app_manager_is_running(app_id.c_str(), &is_running);
+  if (ret != APP_MANAGER_ERROR_NONE) {
+    LOG_ERROR("Failed to check if app is running: %s", get_error_message(ret));
+    last_error_ = ret;
+    return false;
+  }
+  return is_running;
+}

--- a/packages/tizen_app_manager/tizen/src/tizen_app_manager.h
+++ b/packages/tizen_app_manager/tizen/src/tizen_app_manager.h
@@ -30,7 +30,7 @@ class TizenAppManager {
 
   std::vector<std::unique_ptr<TizenAppInfo>> GetAllAppsInfo();
 
-  std::string GetSharedResourcePath(const std::string& app_id);
+  std::optional<std::string> GetSharedResourcePath(const std::string& app_id);
 
   bool IsAppRunning(const std::string& app_id);
 

--- a/packages/tizen_app_manager/tizen/src/tizen_app_manager.h
+++ b/packages/tizen_app_manager/tizen/src/tizen_app_manager.h
@@ -1,0 +1,57 @@
+// Copyright 2022 Samsung Electronics Co., Ltd. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef FLUTTER_PLUGIN_TIZEN_APP_MANAGER_H_
+#define FLUTTER_PLUGIN_TIZEN_APP_MANAGER_H_
+
+#include <app_manager.h>
+
+#include <functional>
+#include <memory>
+#include <string>
+
+#include "tizen_app_info.h"
+
+using OnAppContextEvent =
+    std::function<void(std::string app_id, void* app_context_handle)>;
+
+class TizenAppManager {
+ public:
+  ~TizenAppManager();
+
+  // Returns a unique instance of TizenAppManager.
+  static TizenAppManager& GetInstance() {
+    static TizenAppManager instance;
+    return instance;
+  }
+
+  std::unique_ptr<TizenAppInfo> GetAppInfo(const std::string& app_id);
+
+  std::vector<std::unique_ptr<TizenAppInfo>> GetAllAppsInfo();
+
+  std::string GetSharedResourcePath(const std::string& app_id);
+
+  bool IsAppRunning(const std::string& app_id);
+
+  void SetAppLaunchHandler(OnAppContextEvent on_launch) {
+    launch_callback_ = on_launch;
+  }
+
+  void SetAppTerminateHandler(OnAppContextEvent on_terminate) {
+    terminate_callback_ = on_terminate;
+  }
+
+  int GetLastError() { return last_error_; }
+
+  std::string GetLastErrorString() { return get_error_message(last_error_); }
+
+ private:
+  explicit TizenAppManager();
+
+  OnAppContextEvent launch_callback_;
+  OnAppContextEvent terminate_callback_;
+  int last_error_ = APP_MANAGER_ERROR_NONE;
+};
+
+#endif  // FLUTTER_PLUGIN_TIZEN_APP_MANAGER_H_

--- a/packages/tizen_app_manager/tizen/src/tizen_app_manager.h
+++ b/packages/tizen_app_manager/tizen/src/tizen_app_manager.h
@@ -9,7 +9,9 @@
 
 #include <functional>
 #include <memory>
+#include <optional>
 #include <string>
+#include <vector>
 
 #include "tizen_app_info.h"
 
@@ -32,7 +34,7 @@ class TizenAppManager {
 
   std::optional<std::string> GetSharedResourcePath(const std::string& app_id);
 
-  bool IsAppRunning(const std::string& app_id);
+  std::optional<bool> IsAppRunning(const std::string& app_id);
 
   void SetAppLaunchHandler(OnAppContextEvent on_launch) {
     launch_callback_ = on_launch;

--- a/packages/tizen_app_manager/tizen/src/tizen_app_manager_plugin.cc
+++ b/packages/tizen_app_manager/tizen/src/tizen_app_manager_plugin.cc
@@ -87,8 +87,6 @@ class AppContextStreamHandler : public FlStreamHandler {
 
 class TizenAppManagerPlugin : public flutter::Plugin {
  public:
-  using MethodResultPtr = std::unique_ptr<FlMethodResult>;
-
   static void RegisterWithRegistrar(flutter::PluginRegistrar *registrar) {
     auto plugin = std::make_unique<TizenAppManagerPlugin>();
 
@@ -216,7 +214,7 @@ class TizenAppManagerPlugin : public flutter::Plugin {
     }
   }
 
-  void GetCurrentAppId(MethodResultPtr result) {
+  void GetCurrentAppId(std::unique_ptr<FlMethodResult> result) {
     char *app_id = nullptr;
     int ret = app_get_id(&app_id);
     if (ret == APP_ERROR_NONE) {
@@ -228,7 +226,7 @@ class TizenAppManagerPlugin : public flutter::Plugin {
   }
 
   void GetAppInfo(const flutter::EncodableMap *arguments,
-                  MethodResultPtr result) {
+                  std::unique_ptr<FlMethodResult> result) {
     std::string app_id;
     if (!GetValueFromEncodableMap(arguments, "appId", app_id)) {
       result->Error("Invalid arguments", "No appId provided.");
@@ -248,7 +246,7 @@ class TizenAppManagerPlugin : public flutter::Plugin {
         });
   }
 
-  void GetInstalledApps(MethodResultPtr result) {
+  void GetInstalledApps(std::unique_ptr<FlMethodResult> result) {
     flutter::EncodableList list;
     for (const auto &app_info :
          TizenAppManager::GetInstance().GetAllAppsInfo()) {
@@ -269,7 +267,7 @@ class TizenAppManagerPlugin : public flutter::Plugin {
   }
 
   void IsAppRunning(const flutter::EncodableMap *arguments,
-                    MethodResultPtr result) {
+                    std::unique_ptr<FlMethodResult> result) {
     std::string app_id;
     if (!GetValueFromEncodableMap(arguments, "appId", app_id)) {
       result->Error("Invalid arguments", "No appId provided.");


### PR DESCRIPTION
This is a continuation of https://github.com/flutter-tizen/plugins/pull/408 (and also part of https://github.com/flutter-tizen/plugins/issues/354). All issues mentioned in the review comments have been addressed.

- Introduce the `TizenAppManager` class.
  - The class is a C++ wrapper of Tizen's App Manager API and always instantiated as a singleton object.
  - The app context event callback is registered in the constructor and unregistered in the destructor only once during the app lifetime.
  - `TizenAppInfo`'s `GetSharedResourcePath` has been moved to this class.
- Clean up `TizenAppInfo`.
  - Let the class own its associated `app_info` handle and destroy it on release.
  - Make use of `std::optional` aggressively. (An empty string cannot represent an error result.)
  - Let `GetIconPath` print an info (not error) log on failure (which is considered as a normal operation).
  - Let `GetMetadata` return an instance of `std::map`.
- Clean up `TizenAppManagerPlugin`.
  - Replace `ExtractValueFromMap` with the standard `GetValueFromEncodableMap` function widely used by other packages.
  - Create a dedicated stream handler class (`AppContextStreamHandler`) for launch and terminate event channels.
  - Remove `MethodResultPtr`.
  - Remove `SetupChannels` and move the logic to `RegisterWithRegistrar`.
  - Replace `GetApplicationInfoMap` with `AppInfoToEncodableMap` which takes `on_success` and `on_error` callbacks as arguments.
  - Let `GetInstalledApps` skip any error during iteration (thus never return an error response).
- Minor cleanups (e.g. format error messages and organize includes).

cc @Swanseo0