### PR TITLE
[flutter_tts] Make speech speed proportional to speech rate

### DIFF
--- a/packages/flutter_tts/CHANGELOG.md
+++ b/packages/flutter_tts/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 1.3.0
+
+* Limit the range of `setSpeechRate` to be between 0.0 and 1.0.
+* Unsupport `getSpeechRateValidRange`.
+* Update flutter_tts to 3.5.0.
+* Update the example app.
+
 ## 1.2.1
 
 * Refactor the C++ code.

--- a/packages/flutter_tts/README.md
+++ b/packages/flutter_tts/README.md
@@ -2,7 +2,7 @@
 
 [![pub package](https://img.shields.io/pub/v/flutter_tts_tizen.svg)](https://pub.dev/packages/flutter_tts_tizen)
 
-The tizen implementation of [`flutter_tts`](https://github.com/dlutton/flutter_tts).
+The Tizen implementation of [`flutter_tts`](https://github.com/dlutton/flutter_tts).
 
 ## Getting Started
 
@@ -10,8 +10,8 @@ This package is not an _endorsed_ implementation of `flutter_tts`. Therefore, yo
 
 ```yaml
 dependencies:
-  flutter_tts: ^3.2.2
-  flutter_tts_tizen: ^1.2.0
+  flutter_tts: ^3.5.0
+  flutter_tts_tizen: ^1.3.0
 ```
 
 Then you can import `flutter_tts` in your Dart code:

--- a/packages/flutter_tts/example/lib/main.dart
+++ b/packages/flutter_tts/example/lib/main.dart
@@ -37,6 +37,8 @@ class _MyAppState extends State<MyApp> {
   initTts() {
     flutterTts = FlutterTts();
 
+    _setAwaitOptions();
+
     flutterTts.setStartHandler(() {
       setState(() {
         print("Playing");
@@ -88,10 +90,13 @@ class _MyAppState extends State<MyApp> {
 
     if (_newVoiceText != null) {
       if (_newVoiceText!.isNotEmpty) {
-        await flutterTts.awaitSpeakCompletion(true);
         await flutterTts.speak(_newVoiceText!);
       }
     }
+  }
+
+  Future _setAwaitOptions() async {
+    await flutterTts.awaitSpeakCompletion(true);
   }
 
   Future _stop() async {
@@ -241,8 +246,8 @@ class _MyAppState extends State<MyApp> {
         setState(() => rate = newRate);
       },
       min: 0.0,
-      max: 15.0,
-      divisions: 15,
+      max: 1.0,
+      divisions: 10,
       label: "Rate: $rate",
       activeColor: Colors.green,
     );

--- a/packages/flutter_tts/example/pubspec.yaml
+++ b/packages/flutter_tts/example/pubspec.yaml
@@ -5,7 +5,7 @@ publish_to: "none"
 dependencies:
   flutter:
     sdk: flutter
-  flutter_tts: ^3.2.2
+  flutter_tts: ^3.5.0
   flutter_tts_tizen:
     path: ../
 

--- a/packages/flutter_tts/pubspec.yaml
+++ b/packages/flutter_tts/pubspec.yaml
@@ -1,8 +1,8 @@
 name: flutter_tts_tizen
-description: The tizen implementation of flutter_tts plugin.
+description: The Tizen implementation of flutter_tts plugin.
 homepage: https://github.com/flutter-tizen/plugins
 repository: https://github.com/flutter-tizen/plugins/tree/master/packages/flutter_tts
-version: 1.2.1
+version: 1.3.0
 
 dependencies:
   flutter:

--- a/packages/flutter_tts/tizen/src/text_to_speech.cc
+++ b/packages/flutter_tts/tizen/src/text_to_speech.cc
@@ -64,7 +64,6 @@ void TextToSpeech::RegisterCallbacks() {
         self->OnStateChanged(previous, current);
       },
       this);
-
   tts_set_utterance_completed_cb(
       tts_,
       [](tts_h tts, int32_t utt_id, void *user_data) {

--- a/packages/flutter_tts/tizen/src/text_to_speech.cc
+++ b/packages/flutter_tts/tizen/src/text_to_speech.cc
@@ -8,6 +8,23 @@
 
 #include "log.h"
 
+namespace {
+
+TtsState ConvertTtsState(tts_state_e state) {
+  switch (state) {
+    case TTS_STATE_CREATED:
+      return TtsState::kCreated;
+    case TTS_STATE_READY:
+      return TtsState::kReady;
+    case TTS_STATE_PLAYING:
+      return TtsState::kPlaying;
+    case TTS_STATE_PAUSED:
+      return TtsState::kPaused;
+  }
+}
+
+}  // namespace
+
 TextToSpeech::~TextToSpeech() {
   UnregisterCallbacks();
 
@@ -61,23 +78,25 @@ void TextToSpeech::RegisterCallbacks() {
       [](tts_h tts, tts_state_e previous, tts_state_e current,
          void *user_data) {
         TextToSpeech *self = static_cast<TextToSpeech *>(user_data);
-        self->OnStateChanged(previous, current);
+        self->SwitchVolumeOnStateChange(previous, current);
+        self->state_changed_callback_(ConvertTtsState(previous),
+                                      ConvertTtsState(current));
       },
       this);
   tts_set_utterance_completed_cb(
       tts_,
       [](tts_h tts, int32_t utt_id, void *user_data) {
         TextToSpeech *self = static_cast<TextToSpeech *>(user_data);
-        self->OnUtteranceCompleted(utt_id);
-        // Explicitly call stop method to change the tts state to ready.
+        self->utterance_completed_callback_(utt_id);
+        self->ClearUttId();
+        // Explicitly call Stop() to change the TTS state to ready.
         self->Stop();
       },
       this);
   tts_set_error_cb(
       tts_,
       [](tts_h tts, int32_t utt_id, tts_error_e reason, void *user_data) {
-        TextToSpeech *self = static_cast<TextToSpeech *>(user_data);
-        self->OnError(utt_id, reason);
+        LOG_ERROR("TTS error: utt_id(%d), reason(%d)", utt_id, reason);
       },
       this);
 }
@@ -99,7 +118,7 @@ std::vector<std::string> &TextToSpeech::GetSupportedLanaguages() {
           }
           TextToSpeech *self = static_cast<TextToSpeech *>(user_data);
           self->supported_lanaguages_.push_back(std::string(language));
-          LOG_INFO("Supported Voices - Language(%s), Type(%d)", language,
+          LOG_INFO("Supported voice: language(%s), type(%d)", language,
                    voice_type);
           return true;
         },
@@ -119,21 +138,10 @@ std::optional<TtsState> TextToSpeech::GetState() {
     LOG_ERROR("tts_get_state failed: %s", get_error_message(ret));
     return std::nullopt;
   }
-  switch (state) {
-    case TTS_STATE_CREATED:
-      return TtsState::kCreated;
-    case TTS_STATE_READY:
-      return TtsState::kReady;
-    case TTS_STATE_PLAYING:
-      return TtsState::kPlaying;
-    case TTS_STATE_PAUSED:
-      return TtsState::kPaused;
-    default:
-      return std::nullopt;
-  }
+  return ConvertTtsState(state);
 }
 
-bool TextToSpeech::AddText(std::string text) {
+bool TextToSpeech::AddText(const std::string &text) {
   int ret = tts_add_text(tts_, text.c_str(), default_language_.c_str(),
                          default_voice_type_, tts_speed_, &utt_id_);
   if (ret != TTS_ERROR_NONE) {

--- a/packages/flutter_tts/tizen/src/text_to_speech.h
+++ b/packages/flutter_tts/tizen/src/text_to_speech.h
@@ -15,9 +15,8 @@
 enum class TtsState { kCreated, kReady, kPlaying, kPaused };
 
 using StateChangedCallback =
-    std::function<void(tts_state_e previous, tts_state_e current)>;
+    std::function<void(TtsState previous, TtsState current)>;
 using UtteranceCompletedCallback = std::function<void(int32_t utt_id)>;
-using ErrorCallback = std::function<void(int32_t utt_id, tts_error_e reason)>;
 
 class TextToSpeech {
  public:
@@ -35,25 +34,9 @@ class TextToSpeech {
     utterance_completed_callback_ = callback;
   }
 
-  void SetErrorCallback(ErrorCallback callback) { error_callback_ = callback; }
-
-  void OnStateChanged(tts_state_e previous, tts_state_e current) {
-    SwitchVolumeOnStateChange(previous, current);
-    state_changed_callback_(previous, current);
-  }
-
-  void OnUtteranceCompleted(int32_t utt_id) {
-    utterance_completed_callback_(utt_id);
-    ClearUttId();
-  }
-
-  void OnError(int32_t utt_id, tts_error_e reason) {
-    error_callback_(utt_id, reason);
-  }
-
   std::string GetDefaultLanguage() { return default_language_; }
 
-  void SetDefaultLanguage(std::string language) {
+  void SetDefaultLanguage(const std::string &language) {
     default_language_ = language;
   }
 
@@ -61,7 +44,7 @@ class TextToSpeech {
 
   std::optional<TtsState> GetState();
 
-  bool AddText(std::string text);
+  bool AddText(const std::string &text);
 
   bool Speak();
 
@@ -81,7 +64,7 @@ class TextToSpeech {
   void Prepare();
   void RegisterCallbacks();
   void UnregisterCallbacks();
-  void HandleAwaitSpeakCompletion(tts_state_e previous, tts_state_e current);
+
   void ClearUttId() { utt_id_ = 0; }
 
   void SwitchVolumeOnStateChange(tts_state_e previous, tts_state_e current);
@@ -100,7 +83,6 @@ class TextToSpeech {
 
   StateChangedCallback state_changed_callback_;
   UtteranceCompletedCallback utterance_completed_callback_;
-  ErrorCallback error_callback_;
 };
 
 #endif  // FLUTTER_PLUGIN_TEXT_TO_SPEACH_H_


### PR DESCRIPTION
- Let `setSpeechRate` compute the speech speed (between min-max) based on the given [normalized](https://github.com/dlutton/flutter_tts/blob/112b9317dd0397324cb1d8e4126cd772d583229b/lib/flutter_tts.dart#L171) speech rate (0-1).
- Unsupport `getSpeechRateValidRange` which returns an invalid `platform` value ("android") on Tizen.
- Update flutter_tts to 3.5.0 and update the example app.
- Some code refactoring.
  - Remove the unused TTS error callback.
  - Let `SetStateChanagedCallback` return values of type `TtsState`.
  - Simplify comments.
  - Let `HandleAwaitSpeakCompletion` take an argument of type `EncodableValue` for consistency.
  - Inline `OnStateChanged`and `OnUtteranceCompleted` into relevant callbacks.

Previous discussion: https://github.com/flutter-tizen/plugins/pull/401#issuecomment-1173396362