### PR TITLE
[google_sign_in] Persist token on disk

### DIFF
--- a/.github/recipe.yaml
+++ b/.github/recipe.yaml
@@ -4,6 +4,7 @@ plugins:
   connectivity_plus: ["wearable-5.5", "tv-6.5"]
   device_info_plus: ["wearable-5.5", "tv-6.5"]
   flutter_tts: ["wearable-5.5", "tv-6.5"]
+  google_sign_in: ["wearable-5.5", "tv-6.5"]
   integration_test: ["wearable-5.5", "tv-6.5"]
   messageport: ["wearable-5.5", "tv-6.5"]
   package_info_plus: ["wearable-5.5", "tv-6.5"]
@@ -25,7 +26,6 @@ plugins:
   webview_flutter: []
 
   # No tests.
-  google_sign_in: []
   image_picker: []
   tizen_log: []
   tizen_notification: []

--- a/packages/google_sign_in/CHANGELOG.md
+++ b/packages/google_sign_in/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 0.1.1
+
+* Fix bug where token was always being refreshed.
+* Always request new sign-in for `signIn` method.
+* Implement `signInSilently` method.
+* Persist token securely on disk.
+
 ## 0.1.0
 
 * Initial release.

--- a/packages/google_sign_in/README.md
+++ b/packages/google_sign_in/README.md
@@ -11,7 +11,7 @@ This package is not an _endorsed_ implementation of `google_sign_in`. Therefore,
 ```yaml
 dependencies:
   google_sign_in: ^5.4.0
-  google_sign_in_tizen: ^0.1.0
+  google_sign_in_tizen: ^0.1.1
 ```
 
 For detailed usage on how to use `google_sign_in`, see https://pub.dev/packages/google_sign_in#usage.

--- a/packages/google_sign_in/README.md
+++ b/packages/google_sign_in/README.md
@@ -93,3 +93,7 @@ The `http://tizen.org/privilege/internet` privilege is required to perform netwo
   <privilege>http://tizen.org/privilege/internet</privilege>
 </privileges>
 ```
+
+## Supported devices
+
+All devices running Tizen 5.5 or later.

--- a/packages/google_sign_in/example/integration_test/secure_storage_test.dart
+++ b/packages/google_sign_in/example/integration_test/secure_storage_test.dart
@@ -1,0 +1,51 @@
+// Copyright 2022 Samsung Electronics Co., Ltd. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:google_sign_in_tizen/google_sign_in_tizen.dart';
+import 'package:integration_test/integration_test.dart';
+
+void main() {
+  IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+
+  late SecureStorage storage;
+  late Map<String, Object> data1;
+  late Map<String, Object> data2;
+
+  setUpAll(() async {
+    storage = SecureStorage();
+    data1 = <String, Object>{
+      'key11': 'value11',
+      'key12': 12,
+    };
+    data2 = <String, Object>{
+      'key21': 'value21',
+      'key22': 22,
+    };
+  });
+
+  tearDown(() async {
+    await storage.destroy();
+  });
+
+  testWidgets('Can save get and remove', (WidgetTester tester) async {
+    await storage.saveJson('a', data1);
+    await storage.saveJson('b', data2);
+
+    final Map<String, Object?>? retrievedData1 = await storage.getJson('a');
+    final Map<String, Object?>? retrievedData2 = await storage.getJson('b');
+    expect(retrievedData1, isNotNull);
+    expect(retrievedData2, isNotNull);
+
+    expect(true, mapEquals(data1, retrievedData1));
+    expect(true, mapEquals(data2, retrievedData2));
+
+    await storage.remove('a');
+    await storage.remove('b');
+
+    expect(await storage.getJson('a'), isNull);
+    expect(await storage.getJson('b'), isNull);
+  });
+}

--- a/packages/google_sign_in/example/pubspec.yaml
+++ b/packages/google_sign_in/example/pubspec.yaml
@@ -10,6 +10,16 @@ dependencies:
     path: ../
   http: ^0.13.0
 
+dev_dependencies:
+  flutter_driver:
+    sdk: flutter
+  flutter_test:
+    sdk: flutter
+  integration_test:
+    sdk: flutter
+  integration_test_tizen:
+    path: ../../integration_test/
+
 flutter:
   uses-material-design: true
 

--- a/packages/google_sign_in/lib/google_sign_in_tizen.dart
+++ b/packages/google_sign_in/lib/google_sign_in_tizen.dart
@@ -12,6 +12,7 @@ import 'src/device_flow_widget.dart' as device_flow_widget;
 import 'src/oauth2.dart';
 
 export 'src/authorization_exception.dart';
+export 'src/secure_storage.dart';
 
 /// Holds authentication data after Google sign in for Tizen.
 class _GoogleSignInTokenDataTizen extends GoogleSignInTokenData {

--- a/packages/google_sign_in/lib/google_sign_in_tizen.dart
+++ b/packages/google_sign_in/lib/google_sign_in_tizen.dart
@@ -43,7 +43,7 @@ class _GoogleSignInTokenDataTizen extends GoogleSignInTokenData {
     const Duration minimalTimeToExpire = Duration(minutes: 1);
     return accessTokenExpirationDate
         .add(minimalTimeToExpire)
-        .isAfter(DateTime.now());
+        .isBefore(DateTime.now());
   }
 
   /// Creates a [_GoogleSignInTokenDataTizen] from a json object.
@@ -363,7 +363,7 @@ class GoogleSignInTizen extends GoogleSignInPlatform {
     return _GoogleSignInTokenDataTizen(
       accessToken: tokenResponse.accessToken,
       accessTokenExpirationDate: DateTime.now().add(tokenResponse.expiresIn),
-      refreshToken: tokenResponse.refreshToken,
+      refreshToken: tokenResponse.refreshToken ?? token.refreshToken,
       idToken: tokenResponse.idToken,
     );
   }

--- a/packages/google_sign_in/lib/google_sign_in_tizen.dart
+++ b/packages/google_sign_in/lib/google_sign_in_tizen.dart
@@ -10,6 +10,7 @@ import 'package:google_sign_in_platform_interface/google_sign_in_platform_interf
 
 import 'src/device_flow_widget.dart' as device_flow_widget;
 import 'src/oauth2.dart';
+import 'src/secure_storage.dart';
 
 export 'src/authorization_exception.dart';
 export 'src/secure_storage.dart';
@@ -44,6 +45,28 @@ class _GoogleSignInTokenDataTizen extends GoogleSignInTokenData {
         .add(minimalTimeToExpire)
         .isAfter(DateTime.now());
   }
+
+  /// Creates a [_GoogleSignInTokenDataTizen] from a json object.
+  static _GoogleSignInTokenDataTizen fromJson(Map<String, Object?> json) {
+    return _GoogleSignInTokenDataTizen(
+      accessToken: json['access_token']! as String,
+      accessTokenExpirationDate: DateTime.fromMicrosecondsSinceEpoch(
+          json['access_token_expiration_date']! as int),
+      idToken: json['id_token']! as String,
+      refreshToken: json['refresh_token'] as String?,
+    );
+  }
+
+  /// Creates a json object from this token data.
+  Map<String, Object> toJson() {
+    return <String, Object>{
+      'access_token': accessToken,
+      'access_token_expiration_date':
+          accessTokenExpirationDate.microsecondsSinceEpoch,
+      'id_token': idToken,
+      if (refreshToken != null) 'refresh_token': refreshToken!,
+    };
+  }
 }
 
 /// The set of "Client ID" and "Client Secret" issued by the authorization server.
@@ -59,6 +82,34 @@ class _Credentials {
   final String clientSecret;
 }
 
+class _CachedTokenStorage {
+  // ignore: invalid_use_of_visible_for_testing_member
+  final SecureStorage _storage = SecureStorage();
+
+  final String _kToken = 'token';
+
+  /// Cached token.
+  _GoogleSignInTokenDataTizen? _token;
+
+  Future<void> saveToken(_GoogleSignInTokenDataTizen token) async {
+    await _storage.saveJson(_kToken, token.toJson());
+    _token = token;
+  }
+
+  Future<_GoogleSignInTokenDataTizen?> getToken() async {
+    if (_token != null) {
+      return _token!;
+    }
+    final Map<String, Object?>? json = await _storage.getJson(_kToken);
+    return json != null ? _GoogleSignInTokenDataTizen.fromJson(json) : null;
+  }
+
+  Future<void> removeToken() async {
+    await _storage.remove(_kToken);
+    _token = null;
+  }
+}
+
 /// Tizen implementation of [GoogleSignInPlatform].
 class GoogleSignInTizen extends GoogleSignInPlatform {
   /// Registers this class as the default instance of [GoogleSignInPlatform].
@@ -68,10 +119,9 @@ class GoogleSignInTizen extends GoogleSignInPlatform {
 
   static _Credentials? _credentials;
 
-  List<String> _scopes = <String>[];
+  final _CachedTokenStorage _storage = _CachedTokenStorage();
 
-  /// The current token data.
-  _GoogleSignInTokenDataTizen? _tokenData;
+  List<String> _scopes = <String>[];
 
   final DeviceAuthClient _authClient = DeviceAuthClient(
     authorizationEndPoint:
@@ -161,8 +211,10 @@ class GoogleSignInTizen extends GoogleSignInPlatform {
     _ensureSetCredentials();
     _ensureNavigatorKeyAssigned();
 
-    if (_tokenData != null) {
-      return _createUserData(_tokenData!.idToken);
+    final _GoogleSignInTokenDataTizen? existingToken =
+        await _storage.getToken();
+    if (existingToken != null) {
+      return _createUserData(existingToken.idToken);
     }
 
     final AuthorizationResponse authorizationResponse =
@@ -198,14 +250,15 @@ class GoogleSignInTizen extends GoogleSignInPlatform {
     }
     device_flow_widget.closeDeviceFlowWidget();
 
-    _tokenData = _GoogleSignInTokenDataTizen(
+    final _GoogleSignInTokenDataTizen token = _GoogleSignInTokenDataTizen(
       accessToken: tokenResponse.accessToken,
       accessTokenExpirationDate: DateTime.now().add(tokenResponse.expiresIn),
       refreshToken: tokenResponse.refreshToken,
       idToken: tokenResponse.idToken,
     );
+    await _storage.saveToken(token);
 
-    return _createUserData(_tokenData!.idToken);
+    return _createUserData(token.idToken);
   }
 
   @override
@@ -213,21 +266,22 @@ class GoogleSignInTizen extends GoogleSignInPlatform {
     required String email,
     bool? shouldRecoverAuth = true,
   }) async {
-    if (_tokenData == null) {
+    final _GoogleSignInTokenDataTizen? existingToken =
+        await _storage.getToken();
+    if (existingToken == null) {
       throw PlatformException(
           code: 'not-signed-in',
           message: 'Cannot get tokens as there is no signed in user.');
     }
-    final _GoogleSignInTokenDataTizen tokenData = _tokenData!;
 
     // Check if access token expired.
-    if (!tokenData.isExpired) {
-      return tokenData;
+    if (!existingToken.isExpired) {
+      return existingToken;
     }
 
     _ensureSetCredentials();
 
-    if (tokenData.refreshToken == null) {
+    if (existingToken.refreshToken == null) {
       throw PlatformException(
         code: 'refresh-token-missing',
         message: 'Cannot refresh tokens as refresh tokens are missing. '
@@ -238,40 +292,37 @@ class GoogleSignInTizen extends GoogleSignInPlatform {
     final TokenResponse tokenResponse = await _authClient.refreshToken(
       clientId: _credentials!.clientId,
       clientSecret: _credentials!.clientSecret,
-      refreshToken: tokenData.refreshToken!,
+      refreshToken: existingToken.refreshToken!,
     );
 
-    _tokenData = _GoogleSignInTokenDataTizen(
+    final _GoogleSignInTokenDataTizen token = _GoogleSignInTokenDataTizen(
       accessToken: tokenResponse.accessToken,
       accessTokenExpirationDate: DateTime.now().add(tokenResponse.expiresIn),
       refreshToken: tokenResponse.refreshToken,
       idToken: tokenResponse.idToken,
     );
+    await _storage.saveToken(token);
 
-    return _tokenData!;
+    return token;
   }
 
   @override
-  Future<void> signOut() async {
-    if (_tokenData != null) {
-      _tokenData = null;
-    }
-  }
+  Future<void> signOut() => _storage.removeToken();
 
   @override
   Future<void> disconnect() async {
-    if (_tokenData == null) {
+    final _GoogleSignInTokenDataTizen? existingToken =
+        await _storage.getToken();
+    if (existingToken == null) {
       return;
     }
 
-    final String accessToken = _tokenData!.accessToken;
+    await _authClient.revokeToken(existingToken.accessToken);
     await signOut();
-
-    _authClient.revokeToken(accessToken);
   }
 
   @override
-  Future<bool> isSignedIn() async => _tokenData != null;
+  Future<bool> isSignedIn() async => await _storage.getToken() != null;
 
   @override
   Future<void> clearAuthCache({String? token}) {

--- a/packages/google_sign_in/lib/src/secure_storage.dart
+++ b/packages/google_sign_in/lib/src/secure_storage.dart
@@ -38,7 +38,7 @@ class SecureStorage {
         .invokeMethod<Uint8List>('get', <String, String>{'name': name});
     if (bytes != null) {
       return convert.jsonDecode(String.fromCharCodes(bytes.toList()))
-          as Map<String, dynamic>;
+          as Map<String, Object?>;
     }
     return null;
   }

--- a/packages/google_sign_in/lib/src/secure_storage.dart
+++ b/packages/google_sign_in/lib/src/secure_storage.dart
@@ -1,0 +1,55 @@
+// Copyright 2022 Samsung Electronics Co., Ltd. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:convert' as convert;
+import 'dart:math';
+import 'dart:typed_data';
+
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+
+/// Storage that encrypts data using AES algorithm.
+///
+/// AES key is automatically created and removed internally.
+@visibleForTesting
+class SecureStorage {
+  final MethodChannel _channel = const MethodChannel('tizen/secure_storage');
+
+  final Random _random = Random.secure();
+
+  /// Saves json data with [name] to storage, data will be overwritten if it
+  /// already exists.
+  Future<void> saveJson(String name, Map<String, Object?> json) async {
+    final Uint8List bytes =
+        Uint8List.fromList(convert.jsonEncode(json).codeUnits);
+    final Uint8List iv =
+        Uint8List.fromList(List<int>.generate(16, (_) => _random.nextInt(256)));
+    await _channel.invokeMethod<void>('save', <String, Object>{
+      'name': name,
+      'data': bytes,
+      'iv': iv,
+    });
+  }
+
+  /// Gets the data [name] from storage, returns `null` if no data is present.
+  Future<Map<String, Object?>?> getJson(String name) async {
+    final Uint8List? bytes = await _channel
+        .invokeMethod<Uint8List>('get', <String, String>{'name': name});
+    if (bytes != null) {
+      return convert.jsonDecode(String.fromCharCodes(bytes.toList()))
+          as Map<String, dynamic>;
+    }
+    return null;
+  }
+
+  /// Removes the data [name] from storage.
+  ///
+  /// This method is safe to call multiple times, nothing will happen if [name]
+  /// doesn't exist in storage.
+  Future<void> remove(String name) =>
+      _channel.invokeMethod<void>('remove', <String, String>{'name': name});
+
+  /// Removes all data and key from storage.
+  Future<void> destroy() => _channel.invokeMethod<void>('destroy');
+}

--- a/packages/google_sign_in/lib/src/secure_storage.dart
+++ b/packages/google_sign_in/lib/src/secure_storage.dart
@@ -9,9 +9,10 @@ import 'dart:typed_data';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 
-/// Storage that encrypts data using AES algorithm.
-///
-/// AES key is automatically created and removed internally.
+// This value must match `kIvSizeBytes` in `secure_storage.cc`.
+const int _kIvSizeBytes = 12;
+
+/// Storage that encrypts/decrypts saved data.
 @visibleForTesting
 class SecureStorage {
   final MethodChannel _channel = const MethodChannel('tizen/secure_storage');
@@ -23,8 +24,8 @@ class SecureStorage {
   Future<void> saveJson(String name, Map<String, Object?> json) async {
     final Uint8List bytes =
         Uint8List.fromList(convert.jsonEncode(json).codeUnits);
-    final Uint8List initializationVector =
-        Uint8List.fromList(List<int>.generate(16, (_) => _random.nextInt(256)));
+    final Uint8List initializationVector = Uint8List.fromList(
+        List<int>.generate(_kIvSizeBytes, (_) => _random.nextInt(256)));
     await _channel.invokeMethod<void>('save', <String, Object>{
       'name': name,
       'data': bytes,

--- a/packages/google_sign_in/lib/src/secure_storage.dart
+++ b/packages/google_sign_in/lib/src/secure_storage.dart
@@ -29,7 +29,7 @@ class SecureStorage {
     await _channel.invokeMethod<void>('save', <String, Object>{
       'name': name,
       'data': bytes,
-      'initialization_vector': initializationVector,
+      'initializationVector': initializationVector,
     });
   }
 

--- a/packages/google_sign_in/lib/src/secure_storage.dart
+++ b/packages/google_sign_in/lib/src/secure_storage.dart
@@ -23,12 +23,12 @@ class SecureStorage {
   Future<void> saveJson(String name, Map<String, Object?> json) async {
     final Uint8List bytes =
         Uint8List.fromList(convert.jsonEncode(json).codeUnits);
-    final Uint8List iv =
+    final Uint8List initializationVector =
         Uint8List.fromList(List<int>.generate(16, (_) => _random.nextInt(256)));
     await _channel.invokeMethod<void>('save', <String, Object>{
       'name': name,
       'data': bytes,
-      'iv': iv,
+      'initialization_vector': initializationVector,
     });
   }
 

--- a/packages/google_sign_in/pubspec.yaml
+++ b/packages/google_sign_in/pubspec.yaml
@@ -9,6 +9,8 @@ flutter:
     platforms:
       tizen:
         dartPluginClass: GoogleSignInTizen
+        pluginClass: GoogleSignInTizenPlugin
+        fileName: google_sign_in_tizen_plugin.h
 
 dependencies:
   flutter:

--- a/packages/google_sign_in/pubspec.yaml
+++ b/packages/google_sign_in/pubspec.yaml
@@ -2,7 +2,7 @@ name: google_sign_in_tizen
 description: Tizen implementation of the google_sign_in plugin
 homepage: https://github.com/flutter-tizen/plugins
 repository: https://github.com/flutter-tizen/plugins/tree/master/packages/google_sign_in
-version: 0.1.0
+version: 0.1.1
 
 flutter:
   plugin:

--- a/packages/google_sign_in/tizen/.gitignore
+++ b/packages/google_sign_in/tizen/.gitignore
@@ -1,0 +1,5 @@
+.cproject
+.sign
+crash-info/
+Debug/
+Release/

--- a/packages/google_sign_in/tizen/inc/google_sign_in_tizen_plugin.h
+++ b/packages/google_sign_in/tizen/inc/google_sign_in_tizen_plugin.h
@@ -1,0 +1,23 @@
+#ifndef FLUTTER_PLUGIN_GOOGLE_SIGN_IN_TIZEN_PLUGIN_H_
+#define FLUTTER_PLUGIN_GOOGLE_SIGN_IN_TIZEN_PLUGIN_H_
+
+#include <flutter_plugin_registrar.h>
+
+#ifdef FLUTTER_PLUGIN_IMPL
+#define FLUTTER_PLUGIN_EXPORT __attribute__((visibility("default")))
+#else
+#define FLUTTER_PLUGIN_EXPORT
+#endif
+
+#if defined(__cplusplus)
+extern "C" {
+#endif
+
+FLUTTER_PLUGIN_EXPORT void GoogleSignInTizenPluginRegisterWithRegistrar(
+    FlutterDesktopPluginRegistrarRef registrar);
+
+#if defined(__cplusplus)
+}  // extern "C"
+#endif
+
+#endif  // FLUTTER_PLUGIN_GOOGLE_SIGN_IN_TIZEN_PLUGIN_H_

--- a/packages/google_sign_in/tizen/project_def.prop
+++ b/packages/google_sign_in/tizen/project_def.prop
@@ -1,0 +1,24 @@
+# See https://docs.tizen.org/application/tizen-studio/native-tools/project-conversion
+# for details.
+
+APPNAME = google_sign_in_tizen_plugin
+type = staticLib
+profile = common-4.0
+
+# Source files
+USER_SRCS += src/*.cc
+
+# User defines
+USER_DEFS =
+USER_UNDEFS =
+USER_CPP_DEFS = FLUTTER_PLUGIN_IMPL
+USER_CPP_UNDEFS =
+
+# Compiler flags
+USER_CFLAGS_MISC =
+USER_CPPFLAGS_MISC =
+
+# User includes
+USER_INC_DIRS = inc src
+USER_INC_FILES =
+USER_CPP_INC_FILES =

--- a/packages/google_sign_in/tizen/src/google_sign_in_tizen_plugin.cc
+++ b/packages/google_sign_in/tizen/src/google_sign_in_tizen_plugin.cc
@@ -74,10 +74,6 @@ class GoogleSignInTizenPlugin : public flutter::Plugin {
       return;
     }
 
-    if (!storage_.HasKey()) {
-      storage_.CreateKey();
-    }
-
     if (method_name == "save") {
       std::vector<uint8_t> data;
       if (!GetValueFromEncodableMap(arguments, "data", data)) {
@@ -85,7 +81,7 @@ class GoogleSignInTizenPlugin : public flutter::Plugin {
         return;
       }
       std::vector<uint8_t> initialization_vector;
-      if (!GetValueFromEncodableMap(arguments, "initialization_vector",
+      if (!GetValueFromEncodableMap(arguments, "initializationVector",
                                     initialization_vector)) {
         result->Error(kInvalidArgument, "No initialization_vector provided.");
         return;

--- a/packages/google_sign_in/tizen/src/google_sign_in_tizen_plugin.cc
+++ b/packages/google_sign_in/tizen/src/google_sign_in_tizen_plugin.cc
@@ -84,12 +84,13 @@ class GoogleSignInTizenPlugin : public flutter::Plugin {
         result->Error(kInvalidArgument, "No data provided.");
         return;
       }
-      std::vector<uint8_t> iv;
-      if (!GetValueFromEncodableMap(arguments, "iv", iv)) {
+      std::vector<uint8_t> initialization_vector;
+      if (!GetValueFromEncodableMap(arguments, "initialization_vector",
+                                    initialization_vector)) {
         result->Error(kInvalidArgument, "No initialization_vector provided.");
         return;
       }
-      storage_.SaveData(name, iv, data);
+      storage_.SaveData(name, data, initialization_vector);
       result->Success();
     } else if (method_name == "get") {
       std::optional<std::vector<uint8_t>> data = storage_.GetData(name);

--- a/packages/google_sign_in/tizen/src/google_sign_in_tizen_plugin.cc
+++ b/packages/google_sign_in/tizen/src/google_sign_in_tizen_plugin.cc
@@ -1,0 +1,120 @@
+// Copyright 2022 Samsung Electronics Co., Ltd. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "google_sign_in_tizen_plugin.h"
+
+#include <flutter/method_channel.h>
+#include <flutter/plugin_registrar.h>
+#include <flutter/standard_method_codec.h>
+
+#include <optional>
+
+#include "secure_storage.h"
+
+namespace {
+
+const char *kInvalidArgument = "Invalid argument";
+
+template <typename T>
+bool GetValueFromEncodableMap(const flutter::EncodableMap *map, const char *key,
+                              T &out) {
+  auto iter = map->find(flutter::EncodableValue(key));
+  if (iter != map->end() && !iter->second.IsNull()) {
+    if (auto *value = std::get_if<T>(&iter->second)) {
+      out = *value;
+      return true;
+    }
+  }
+  return false;
+}
+
+class GoogleSignInTizenPlugin : public flutter::Plugin {
+ public:
+  static void RegisterWithRegistrar(flutter::PluginRegistrar *registrar) {
+    auto channel =
+        std::make_unique<flutter::MethodChannel<flutter::EncodableValue>>(
+            registrar->messenger(), "tizen/secure_storage",
+            &flutter::StandardMethodCodec::GetInstance());
+
+    auto plugin = std::make_unique<GoogleSignInTizenPlugin>();
+
+    channel->SetMethodCallHandler(
+        [plugin_pointer = plugin.get()](const auto &call, auto result) {
+          plugin_pointer->HandleMethodCall(call, std::move(result));
+        });
+
+    registrar->AddPlugin(std::move(plugin));
+  }
+
+  GoogleSignInTizenPlugin() {}
+
+  virtual ~GoogleSignInTizenPlugin() {}
+
+ private:
+  void HandleMethodCall(
+      const flutter::MethodCall<flutter::EncodableValue> &method_call,
+      std::unique_ptr<flutter::MethodResult<flutter::EncodableValue>> result) {
+    const auto &method_name = method_call.method_name();
+    if (method_name == "destroy") {
+      storage_.Destroy();
+      result->Success();
+      return;
+    }
+
+    const auto *arguments =
+        std::get_if<flutter::EncodableMap>(method_call.arguments());
+    if (!arguments) {
+      result->Error(kInvalidArgument, "No arguments provided.");
+      return;
+    }
+    std::string name;
+    if (!GetValueFromEncodableMap(arguments, "name", name)) {
+      result->Error(kInvalidArgument, "No name provided.");
+      return;
+    }
+
+    if (!storage_.HasKey()) {
+      storage_.CreateKey();
+    }
+
+    if (method_name == "save") {
+      std::vector<uint8_t> data;
+      if (!GetValueFromEncodableMap(arguments, "data", data)) {
+        result->Error(kInvalidArgument, "No data provided.");
+        return;
+      }
+      std::vector<uint8_t> iv;
+      if (!GetValueFromEncodableMap(arguments, "iv", iv)) {
+        result->Error(kInvalidArgument, "No initialization_vector provided.");
+        return;
+      }
+      storage_.SaveData(name, iv, data);
+      result->Success();
+    } else if (method_name == "get") {
+      std::optional<std::vector<uint8_t>> data = storage_.GetData(name);
+      if (data.has_value()) {
+        result->Success(flutter::EncodableValue(data.value()));
+      } else {
+        // Sends `null` to dart side if data doesn't exist.
+        result->Success();
+      }
+    } else if (method_name == "remove") {
+      storage_.RemoveData(name);
+      result->Success();
+    } else {
+      result->NotImplemented();
+    }
+  }
+
+  SecureStorage storage_;
+};
+
+}  // namespace
+
+void GoogleSignInTizenPluginRegisterWithRegistrar(
+    FlutterDesktopPluginRegistrarRef registrar) {
+  GoogleSignInTizenPlugin::RegisterWithRegistrar(
+      flutter::PluginRegistrarManager::GetInstance()
+          ->GetRegistrar<flutter::PluginRegistrar>(registrar));
+}

--- a/packages/google_sign_in/tizen/src/log.h
+++ b/packages/google_sign_in/tizen/src/log.h
@@ -1,0 +1,24 @@
+#ifndef __LOG_H__
+#define __LOG_H__
+
+#include <dlog.h>
+
+#ifdef LOG_TAG
+#undef LOG_TAG
+#endif
+#define LOG_TAG "GoogleSignInTizenPlugin"
+
+#ifndef __MODULE__
+#define __MODULE__ strrchr("/" __FILE__, '/') + 1
+#endif
+
+#define LOG(prio, fmt, arg...)                                         \
+  dlog_print(prio, LOG_TAG, "%s: %s(%d) > " fmt, __MODULE__, __func__, \
+             __LINE__, ##arg)
+
+#define LOG_DEBUG(fmt, args...) LOG(DLOG_DEBUG, fmt, ##args)
+#define LOG_INFO(fmt, args...) LOG(DLOG_INFO, fmt, ##args)
+#define LOG_WARN(fmt, args...) LOG(DLOG_WARN, fmt, ##args)
+#define LOG_ERROR(fmt, args...) LOG(DLOG_ERROR, fmt, ##args)
+
+#endif  // __LOG_H__

--- a/packages/google_sign_in/tizen/src/secure_storage.cc
+++ b/packages/google_sign_in/tizen/src/secure_storage.cc
@@ -11,6 +11,9 @@
 
 namespace {
 
+// This value must match `_kIvSizeBytes` in `secure_storage.dart`.
+const size_t kIvSizeBytes = 12;
+
 const char *kAesKey = "AesKey";
 
 const ckmc_policy_s kDefaultKeyPolicy = {
@@ -55,13 +58,13 @@ std::vector<std::string> GetNames(NameType name_type) {
 }  // namespace
 
 SecureStorage::SecureStorage() {
-  ckmc_generate_new_params(CKMC_ALGO_AES_CTR, &params_);
+  ckmc_generate_new_params(CKMC_ALGO_AES_GCM, &params_);
 }
 
 SecureStorage::~SecureStorage() { ckmc_param_list_free(params_); }
 
 void SecureStorage::CreateKey() {
-  ckmc_create_key_aes(128, kAesKey, kDefaultKeyPolicy);
+  ckmc_create_key_aes(256, kAesKey, kDefaultKeyPolicy);
 }
 
 bool SecureStorage::HasKey() const {
@@ -149,8 +152,8 @@ std::vector<uint8_t> SecureStorage::DecryptData(std::vector<uint8_t> data) {
   ckmc_raw_buffer_s *buffer;
   ckmc_raw_buffer_s *decrypted_buffer;
 
-  std::vector<uint8_t> initialization_vector(16);
-  for (int i = 15; i >= 0; --i) {
+  std::vector<uint8_t> initialization_vector(kIvSizeBytes);
+  for (int i = kIvSizeBytes - 1; i >= 0; --i) {
     initialization_vector[i] = data.back();
     data.pop_back();
   }

--- a/packages/google_sign_in/tizen/src/secure_storage.cc
+++ b/packages/google_sign_in/tizen/src/secure_storage.cc
@@ -1,0 +1,172 @@
+// Copyright 2022 Samsung Electronics Co., Ltd. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "secure_storage.h"
+
+#include <ckmc/ckmc-manager.h>
+#include <ckmc/ckmc-type.h>
+
+#include <cassert>
+
+namespace {
+
+const char *kAesKey = "AesKey";
+
+const ckmc_policy_s kDefaultKeyPolicy = {
+    .password = nullptr,
+    .extractable = false,
+};
+
+const ckmc_policy_s kDefaultDataPolicy = {
+    .password = nullptr,
+    .extractable = true,
+};
+
+enum class NameType {
+  kKey,
+  kData,
+};
+
+std::vector<std::string> GetNames(NameType name_type) {
+  ckmc_alias_list_s *ckmc_alias_list;
+  switch (name_type) {
+    case NameType::kKey:
+      ckmc_get_key_alias_list(&ckmc_alias_list);
+      break;
+    case NameType::kData:
+      ckmc_get_data_alias_list(&ckmc_alias_list);
+      break;
+    default:
+      assert(false);
+  }
+
+  std::vector<std::string> names;
+  ckmc_alias_list_s *current = ckmc_alias_list;
+  while (current != nullptr) {
+    std::string name = current->alias;
+    names.push_back(name.substr(name.find(' ') + 1));
+    current = current->next;
+  }
+
+  ckmc_alias_list_all_free(ckmc_alias_list);
+  return names;
+}
+}  // namespace
+
+SecureStorage::SecureStorage() {
+  ckmc_generate_new_params(CKMC_ALGO_AES_CTR, &params_);
+}
+
+SecureStorage::~SecureStorage() { ckmc_param_list_free(params_); }
+
+void SecureStorage::CreateKey() {
+  ckmc_create_key_aes(128, kAesKey, kDefaultKeyPolicy);
+}
+
+bool SecureStorage::HasKey() const {
+  std::vector<std::string> names = GetNames(NameType::kKey);
+  for (const auto &name : names) {
+    if (name == kAesKey) {
+      return true;
+    }
+  }
+  return false;
+}
+
+void SecureStorage::Destroy() {
+  std::vector<std::string> names = GetDataNames();
+  for (const auto &name : names) {
+    RemoveData(name);
+  }
+  ckmc_remove_alias(kAesKey);
+}
+
+void SecureStorage::SaveData(const std::string &name, std::vector<uint8_t> iv,
+                             std::vector<uint8_t> data) {
+  std::vector<uint8_t> encrypted = EncryptData(data, iv);
+
+  ckmc_raw_buffer_s *buffer;
+  ckmc_buffer_new(encrypted.data(), encrypted.size(), &buffer);
+  int ret = ckmc_save_data(name.c_str(), *buffer, kDefaultDataPolicy);
+  if (ret == CKMC_ERROR_DB_ALIAS_EXISTS) {
+    RemoveData(name.c_str());
+    ckmc_save_data(name.c_str(), *buffer, kDefaultDataPolicy);
+  }
+  ckmc_buffer_free(buffer);
+}
+
+std::optional<std::vector<uint8_t>> SecureStorage::GetData(
+    const std::string &name) {
+  ckmc_raw_buffer_s *buffer;
+
+  int ret = ckmc_get_data(name.c_str(), nullptr, &buffer);
+  if (ret != CKMC_ERROR_NONE) {
+    return std::nullopt;
+  }
+  std::vector<uint8_t> data;
+  for (size_t i = 0; i < buffer->size; ++i) {
+    data.push_back(buffer->data[i]);
+  }
+  ckmc_buffer_free(buffer);
+  return DecryptData(data);
+}
+
+std::vector<std::string> SecureStorage::GetDataNames() const {
+  return GetNames(NameType::kData);
+}
+
+void SecureStorage::RemoveData(const std::string &name) {
+  ckmc_remove_alias(name.c_str());
+}
+
+std::vector<uint8_t> SecureStorage::EncryptData(std::vector<uint8_t> data,
+                                                std::vector<uint8_t> iv) {
+  ckmc_raw_buffer_s *buffer;
+  ckmc_raw_buffer_s *encrypted_buffer;
+
+  ckmc_buffer_new(iv.data(), iv.size(), &buffer);
+  ckmc_param_list_set_buffer(params_, CKMC_PARAM_ED_IV, buffer);
+  ckmc_buffer_free(buffer);
+
+  ckmc_buffer_new(data.data(), data.size(), &buffer);
+  ckmc_encrypt_data(params_, kAesKey, nullptr, *buffer, &encrypted_buffer);
+  ckmc_buffer_free(buffer);
+
+  std::vector<uint8_t> encrypted;
+  for (size_t i = 0; i < encrypted_buffer->size; ++i) {
+    encrypted.push_back(encrypted_buffer->data[i]);
+  }
+  ckmc_buffer_free(encrypted_buffer);
+  for (const auto &iv_element : iv) {
+    encrypted.push_back(iv_element);
+  }
+  return encrypted;
+}
+
+std::vector<uint8_t> SecureStorage::DecryptData(std::vector<uint8_t> data) {
+  ckmc_raw_buffer_s *buffer;
+  ckmc_raw_buffer_s *decrypted_buffer;
+
+  std::vector<uint8_t> iv(16);
+  for (int i = 15; i >= 0; --i) {
+    iv[i] = data.back();
+    data.pop_back();
+  }
+
+  ckmc_buffer_new(iv.data(), iv.size(), &buffer);
+  ckmc_param_list_set_buffer(params_, CKMC_PARAM_ED_IV, buffer);
+  ckmc_buffer_free(buffer);
+
+  ckmc_buffer_new(data.data(), data.size(), &buffer);
+  ckmc_decrypt_data(params_, kAesKey, nullptr, *buffer, &decrypted_buffer);
+  ckmc_buffer_free(buffer);
+
+  std::vector<uint8_t> decrypted;
+  for (size_t i = 0; i < decrypted_buffer->size; ++i) {
+    decrypted.push_back(decrypted_buffer->data[i]);
+  }
+  ckmc_buffer_free(decrypted_buffer);
+
+  return decrypted;
+}

--- a/packages/google_sign_in/tizen/src/secure_storage.cc
+++ b/packages/google_sign_in/tizen/src/secure_storage.cc
@@ -12,9 +12,9 @@
 namespace {
 
 // This value must match `_kIvSizeBytes` in `secure_storage.dart`.
-const size_t kIvSizeBytes = 12;
+constexpr size_t kIvSizeBytes = 12;
 
-const char *kAesKey = "AesKey";
+constexpr char kAesKey[] = "AesKey";
 
 const ckmc_policy_s kDefaultKeyPolicy = {
     .password = nullptr,
@@ -32,7 +32,7 @@ enum class NameType {
 };
 
 std::vector<std::string> GetNames(NameType name_type) {
-  ckmc_alias_list_s *ckmc_alias_list;
+  ckmc_alias_list_s *ckmc_alias_list = nullptr;
   switch (name_type) {
     case NameType::kKey:
       ckmc_get_key_alias_list(&ckmc_alias_list);
@@ -48,6 +48,10 @@ std::vector<std::string> GetNames(NameType name_type) {
   ckmc_alias_list_s *current = ckmc_alias_list;
   while (current != nullptr) {
     std::string name = current->alias;
+    // The ckmc module returns all aliases prefixed with application id.
+    // For example, if 'some_alias' is saved for 'some_app',
+    // the returned alias would be 'some_app some_alias'.
+    // So we need to remove prefix from the returned alias.
     names.push_back(name.substr(name.find(' ') + 1));
     current = current->next;
   }
@@ -59,23 +63,16 @@ std::vector<std::string> GetNames(NameType name_type) {
 
 SecureStorage::SecureStorage() {
   ckmc_generate_new_params(CKMC_ALGO_AES_GCM, &params_);
-}
-
-SecureStorage::~SecureStorage() { ckmc_param_list_free(params_); }
-
-void SecureStorage::CreateKey() {
-  ckmc_create_key_aes(256, kAesKey, kDefaultKeyPolicy);
-}
-
-bool SecureStorage::HasKey() const {
   std::vector<std::string> names = GetNames(NameType::kKey);
   for (const auto &name : names) {
     if (name == kAesKey) {
-      return true;
+      return;
     }
   }
-  return false;
+  ckmc_create_key_aes(256, kAesKey, kDefaultKeyPolicy);
 }
+
+SecureStorage::~SecureStorage() { ckmc_param_list_free(params_); }
 
 void SecureStorage::Destroy() {
   std::vector<std::string> names = GetDataNames();
@@ -89,7 +86,7 @@ void SecureStorage::SaveData(const std::string &name, std::vector<uint8_t> data,
                              std::vector<uint8_t> initialization_vector) {
   std::vector<uint8_t> encrypted = EncryptData(data, initialization_vector);
 
-  ckmc_raw_buffer_s *buffer;
+  ckmc_raw_buffer_s *buffer = nullptr;
   ckmc_buffer_new(encrypted.data(), encrypted.size(), &buffer);
   int ret = ckmc_save_data(name.c_str(), *buffer, kDefaultDataPolicy);
   if (ret == CKMC_ERROR_DB_ALIAS_EXISTS) {
@@ -101,16 +98,13 @@ void SecureStorage::SaveData(const std::string &name, std::vector<uint8_t> data,
 
 std::optional<std::vector<uint8_t>> SecureStorage::GetData(
     const std::string &name) {
-  ckmc_raw_buffer_s *buffer;
+  ckmc_raw_buffer_s *buffer = nullptr;
 
   int ret = ckmc_get_data(name.c_str(), nullptr, &buffer);
   if (ret != CKMC_ERROR_NONE) {
     return std::nullopt;
   }
-  std::vector<uint8_t> data;
-  for (size_t i = 0; i < buffer->size; ++i) {
-    data.push_back(buffer->data[i]);
-  }
+  std::vector<uint8_t> data(buffer->data, buffer->data + buffer->size);
   ckmc_buffer_free(buffer);
   return DecryptData(data);
 }
@@ -125,8 +119,8 @@ void SecureStorage::RemoveData(const std::string &name) {
 
 std::vector<uint8_t> SecureStorage::EncryptData(
     std::vector<uint8_t> data, std::vector<uint8_t> initialization_vector) {
-  ckmc_raw_buffer_s *buffer;
-  ckmc_raw_buffer_s *encrypted_buffer;
+  ckmc_raw_buffer_s *buffer = nullptr;
+  ckmc_raw_buffer_s *encrypted_buffer = nullptr;
 
   ckmc_buffer_new(initialization_vector.data(), initialization_vector.size(),
                   &buffer);
@@ -137,26 +131,21 @@ std::vector<uint8_t> SecureStorage::EncryptData(
   ckmc_encrypt_data(params_, kAesKey, nullptr, *buffer, &encrypted_buffer);
   ckmc_buffer_free(buffer);
 
-  std::vector<uint8_t> encrypted;
-  for (size_t i = 0; i < encrypted_buffer->size; ++i) {
-    encrypted.push_back(encrypted_buffer->data[i]);
-  }
+  std::vector<uint8_t> encrypted(
+      encrypted_buffer->data, encrypted_buffer->data + encrypted_buffer->size);
   ckmc_buffer_free(encrypted_buffer);
-  for (const auto &element : initialization_vector) {
-    encrypted.push_back(element);
-  }
+  encrypted.insert(encrypted.end(), initialization_vector.begin(),
+                   initialization_vector.end());
   return encrypted;
 }
 
 std::vector<uint8_t> SecureStorage::DecryptData(std::vector<uint8_t> data) {
-  ckmc_raw_buffer_s *buffer;
-  ckmc_raw_buffer_s *decrypted_buffer;
+  ckmc_raw_buffer_s *buffer = nullptr;
+  ckmc_raw_buffer_s *decrypted_buffer = nullptr;
 
-  std::vector<uint8_t> initialization_vector(kIvSizeBytes);
-  for (int i = kIvSizeBytes - 1; i >= 0; --i) {
-    initialization_vector[i] = data.back();
-    data.pop_back();
-  }
+  std::vector<uint8_t> initialization_vector(data.end() - kIvSizeBytes,
+                                             data.end());
+  data.erase(data.end() - kIvSizeBytes, data.end());
 
   ckmc_buffer_new(initialization_vector.data(), initialization_vector.size(),
                   &buffer);
@@ -167,10 +156,8 @@ std::vector<uint8_t> SecureStorage::DecryptData(std::vector<uint8_t> data) {
   ckmc_decrypt_data(params_, kAesKey, nullptr, *buffer, &decrypted_buffer);
   ckmc_buffer_free(buffer);
 
-  std::vector<uint8_t> decrypted;
-  for (size_t i = 0; i < decrypted_buffer->size; ++i) {
-    decrypted.push_back(decrypted_buffer->data[i]);
-  }
+  std::vector<uint8_t> decrypted(
+      decrypted_buffer->data, decrypted_buffer->data + decrypted_buffer->size);
   ckmc_buffer_free(decrypted_buffer);
 
   return decrypted;

--- a/packages/google_sign_in/tizen/src/secure_storage.h
+++ b/packages/google_sign_in/tizen/src/secure_storage.h
@@ -24,8 +24,8 @@ class SecureStorage {
 
   void Destroy();
 
-  void SaveData(const std::string& name, std::vector<uint8_t> iv,
-                std::vector<uint8_t> data);
+  void SaveData(const std::string& name, std::vector<uint8_t> data,
+                std::vector<uint8_t> initialization_vector);
 
   std::optional<std::vector<uint8_t>> GetData(const std::string& name);
 
@@ -37,7 +37,7 @@ class SecureStorage {
   std::vector<std::string> GetDataNames() const;
 
   std::vector<uint8_t> EncryptData(std::vector<uint8_t> data,
-                                   std::vector<uint8_t> iv);
+                                   std::vector<uint8_t> initialization_vector);
 
   std::vector<uint8_t> DecryptData(std::vector<uint8_t> data);
 };

--- a/packages/google_sign_in/tizen/src/secure_storage.h
+++ b/packages/google_sign_in/tizen/src/secure_storage.h
@@ -20,7 +20,7 @@ class SecureStorage {
   void Destroy();
 
   void SaveData(const std::string& name, const std::vector<uint8_t>& data,
-                std::vector<uint8_t> initialization_vector);
+                const std::vector<uint8_t>& initialization_vector);
 
   std::optional<std::vector<uint8_t>> GetData(const std::string& name);
 
@@ -29,7 +29,7 @@ class SecureStorage {
  private:
   ckmc_param_list_h params_;
 
-  std::vector<uint8_t> EncryptData(const std::vector<uint8_t>& data,
+  std::vector<uint8_t> EncryptData(std::vector<uint8_t> data,
                                    std::vector<uint8_t> initialization_vector);
 
   std::vector<uint8_t> DecryptData(std::vector<uint8_t> data);

--- a/packages/google_sign_in/tizen/src/secure_storage.h
+++ b/packages/google_sign_in/tizen/src/secure_storage.h
@@ -1,0 +1,45 @@
+// Copyright 2022 Samsung Electronics Co., Ltd. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef FLUTTER_PLUGIN_SECURE_STORAGE_H_
+#define FLUTTER_PLUGIN_SECURE_STORAGE_H_
+
+#include <ckmc/ckmc-type.h>
+
+#include <optional>
+#include <string>
+#include <variant>
+#include <vector>
+
+class SecureStorage {
+ public:
+  SecureStorage();
+
+  virtual ~SecureStorage();
+
+  void CreateKey();
+
+  bool HasKey() const;
+
+  void Destroy();
+
+  void SaveData(const std::string& name, std::vector<uint8_t> iv,
+                std::vector<uint8_t> data);
+
+  std::optional<std::vector<uint8_t>> GetData(const std::string& name);
+
+  void RemoveData(const std::string& name);
+
+ private:
+  ckmc_param_list_h params_;
+
+  std::vector<std::string> GetDataNames() const;
+
+  std::vector<uint8_t> EncryptData(std::vector<uint8_t> data,
+                                   std::vector<uint8_t> iv);
+
+  std::vector<uint8_t> DecryptData(std::vector<uint8_t> data);
+};
+
+#endif  // FLUTTER_PLUGIN_SECURE_STORAGE_H_

--- a/packages/google_sign_in/tizen/src/secure_storage.h
+++ b/packages/google_sign_in/tizen/src/secure_storage.h
@@ -9,18 +9,13 @@
 
 #include <optional>
 #include <string>
-#include <variant>
 #include <vector>
 
 class SecureStorage {
  public:
   SecureStorage();
 
-  virtual ~SecureStorage();
-
-  void CreateKey();
-
-  bool HasKey() const;
+  ~SecureStorage();
 
   void Destroy();
 

--- a/packages/google_sign_in/tizen/src/secure_storage.h
+++ b/packages/google_sign_in/tizen/src/secure_storage.h
@@ -19,7 +19,7 @@ class SecureStorage {
 
   void Destroy();
 
-  void SaveData(const std::string& name, std::vector<uint8_t> data,
+  void SaveData(const std::string& name, const std::vector<uint8_t>& data,
                 std::vector<uint8_t> initialization_vector);
 
   std::optional<std::vector<uint8_t>> GetData(const std::string& name);
@@ -29,9 +29,7 @@ class SecureStorage {
  private:
   ckmc_param_list_h params_;
 
-  std::vector<std::string> GetDataNames() const;
-
-  std::vector<uint8_t> EncryptData(std::vector<uint8_t> data,
+  std::vector<uint8_t> EncryptData(const std::vector<uint8_t>& data,
                                    std::vector<uint8_t> initialization_vector);
 
   std::vector<uint8_t> DecryptData(std::vector<uint8_t> data);


### PR DESCRIPTION
Authorization token is saved on disk, users don't have to request new authorization between app sessions unless user has explicitly signed out from the app.

- Used [KeyManager](https://docs.tizen.org/application/native/guides/security/secure-key/) API which supports data encryption with various cipher algorithms.
- Decision on encryption algorithm and mode is based on Android's implementation of [flutter_secure_storage](https://pub.dev/packages/flutter_secure_storage) and [relevant issue](https://github.com/mogol/flutter_secure_storage/issues/69), though it's not entirely same due to API limitation.