### PR TITLE
[webview_flutter] Change the project type to sharedLib

### DIFF
--- a/packages/webview_flutter/CHANGELOG.md
+++ b/packages/webview_flutter/CHANGELOG.md
@@ -1,4 +1,4 @@
-## NEXT
+## 0.5.4
 
 * Change the project type to sharedLib.
 

--- a/packages/webview_flutter/CHANGELOG.md
+++ b/packages/webview_flutter/CHANGELOG.md
@@ -1,11 +1,17 @@
+## NEXT
+
+* Change the project type to sharedLib.
+
 ## 0.5.3
 
 * Apply new texture APIs.
 
 ## 0.5.2
-* Add a back key handling.
+
+* Add back key handling.
 
 ## 0.5.1
+
 * Apply PlatformView API change.
 * Code refactoring.
 

--- a/packages/webview_flutter/README.md
+++ b/packages/webview_flutter/README.md
@@ -25,7 +25,7 @@ This package is not an _endorsed_ implementation of `webview_flutter`. Therefore
 ```yaml
 dependencies:
   webview_flutter: ^3.0.4
-  webview_flutter_tizen: ^0.5.3
+  webview_flutter_tizen: ^0.5.4
 ```
 
 ## Example

--- a/packages/webview_flutter/pubspec.yaml
+++ b/packages/webview_flutter/pubspec.yaml
@@ -2,7 +2,7 @@ name: webview_flutter_tizen
 description: Tizen implementation of the webview plugin
 homepage: https://github.com/flutter-tizen/plugins
 repository: https://github.com/flutter-tizen/plugins/tree/master/packages/webview_flutter
-version: 0.5.3
+version: 0.5.4
 
 environment:
   sdk: ">=2.17.0 <3.0.0"

--- a/packages/webview_flutter/tizen/project_def.prop
+++ b/packages/webview_flutter/tizen/project_def.prop
@@ -2,7 +2,7 @@
 # for details.
 
 APPNAME = webview_flutter_tizen_plugin
-type = staticLib
+type = sharedLib
 profile = common-5.5
 
 # Source files
@@ -22,3 +22,8 @@ USER_CPPFLAGS_MISC =
 USER_INC_DIRS = inc src
 USER_INC_FILES =
 USER_CPP_INC_FILES =
+
+# Linker options
+USER_LIBS = pthread lightweight-web-engine.flutter tuv
+USER_LIB_DIRS = lib/${BUILD_ARCH}
+USER_LFLAGS =


### PR DESCRIPTION
Based on https://github.com/flutter-tizen/flutter-tizen/pull/407.

With this change, the webview plugin will not be included in `libflutter_plugins.so` and instead `libwebview_flutter_tizen_plugin.so` will be generated and included in a TPK.

@flutter-tizen/maintainers The experimental "implicit user library linking" support for "staticLib" type plugins will be removed in the future. Please migrate to the "sharedLib" type if you have inhouse (or work-in-progress) plugins that use such an old configuration by referring to this change.