### PR TITLE
Bump ffi dependencies

### DIFF
--- a/packages/path_provider/CHANGELOG.md
+++ b/packages/path_provider/CHANGELOG.md
@@ -1,5 +1,6 @@
-## NEXT
+## 2.0.3
 
+* Bump ffi dependency.
 * Update the example app.
 
 ## 2.0.2

--- a/packages/path_provider/README.md
+++ b/packages/path_provider/README.md
@@ -11,7 +11,7 @@ This package is not an _endorsed_ implementation of `path_provider`. Therefore, 
 ```yaml
 dependencies:
   path_provider: ^2.0.7
-  path_provider_tizen: ^2.0.2
+  path_provider_tizen: ^2.0.3
 ```
 
 Then you can import `path_provider` in your Dart code:

--- a/packages/path_provider/pubspec.yaml
+++ b/packages/path_provider/pubspec.yaml
@@ -2,7 +2,7 @@ name: path_provider_tizen
 description: Tizen implementation of the path_provider plugin
 homepage: https://github.com/flutter-tizen/plugins
 repository: https://github.com/flutter-tizen/plugins/tree/master/packages/path_provider
-version: 2.0.2
+version: 2.0.3
 
 flutter:
   plugin:
@@ -11,7 +11,7 @@ flutter:
         dartPluginClass: PathProviderPlugin
 
 dependencies:
-  ffi: ^1.1.2
+  ffi: ">=1.1.2 <3.0.0"
   flutter:
     sdk: flutter
   path_provider_platform_interface: ^2.0.1

--- a/packages/shared_preferences/CHANGELOG.md
+++ b/packages/shared_preferences/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.0.3
+
+* Bump ffi dependency.
+
 ## 2.0.2
 
 * Update shared_preferences to 2.0.9.

--- a/packages/shared_preferences/README.md
+++ b/packages/shared_preferences/README.md
@@ -11,7 +11,7 @@ This package is not an _endorsed_ implementation of `shared_preferences`. Theref
 ```yaml
 dependencies:
   shared_preferences: ^2.0.9
-  shared_preferences_tizen: ^2.0.2
+  shared_preferences_tizen: ^2.0.3
 ```
 
 Then you can import `shared_preferences` in your Dart code:

--- a/packages/shared_preferences/pubspec.yaml
+++ b/packages/shared_preferences/pubspec.yaml
@@ -2,7 +2,7 @@ name: shared_preferences_tizen
 description: Tizen implementation of the shared_preferences plugin
 homepage: https://github.com/flutter-tizen/plugins
 repository: https://github.com/flutter-tizen/plugins/tree/master/packages/shared_preferences
-version: 2.0.2
+version: 2.0.3
 
 flutter:
   plugin:
@@ -11,7 +11,7 @@ flutter:
         dartPluginClass: SharedPreferencesPlugin
 
 dependencies:
-  ffi: ^1.1.2
+  ffi: ">=1.1.2 <3.0.0"
   flutter:
     sdk: flutter
   shared_preferences_platform_interface: ^2.0.0

--- a/packages/tizen_app_control/CHANGELOG.md
+++ b/packages/tizen_app_control/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.2.1
+
+* Bump ffi dependency.
+
 ## 0.2.0
 
 * Remove the deprecated API `AppManager`.

--- a/packages/tizen_app_control/README.md
+++ b/packages/tizen_app_control/README.md
@@ -10,7 +10,7 @@ To use this package, add `tizen_app_control` as a dependency in your `pubspec.ya
 
 ```yaml
 dependencies:
-  tizen_app_control: ^0.2.0
+  tizen_app_control: ^0.2.1
 ```
 
 ### Sending a launch request

--- a/packages/tizen_app_control/pubspec.yaml
+++ b/packages/tizen_app_control/pubspec.yaml
@@ -3,10 +3,10 @@ description: Tizen application control APIs. Used for launching and terminating
   applications on a Tizen device.
 homepage: https://github.com/flutter-tizen/plugins
 repository: https://github.com/flutter-tizen/plugins/tree/master/packages/tizen_app_control
-version: 0.2.0
+version: 0.2.1
 
 dependencies:
-  ffi: ^1.1.2
+  ffi: ">=1.1.2 <3.0.0"
   flutter:
     sdk: flutter
 

--- a/packages/tizen_app_manager/CHANGELOG.md
+++ b/packages/tizen_app_manager/CHANGELOG.md
@@ -1,6 +1,10 @@
+## 0.1.5
+
+* Bump ffi dependency.
+
 ## 0.1.4
 
-* Fix arm64 build error
+* Fix arm64 build error.
 
 ## 0.1.3
 

--- a/packages/tizen_app_manager/README.md
+++ b/packages/tizen_app_manager/README.md
@@ -10,7 +10,7 @@ To use this package, add `tizen_app_manager` as a dependency in your `pubspec.ya
 
 ```yaml
 dependencies:
-  tizen_app_manager: ^0.1.4
+  tizen_app_manager: ^0.1.5
 ```
 
 ### Retrieving current app info

--- a/packages/tizen_app_manager/pubspec.yaml
+++ b/packages/tizen_app_manager/pubspec.yaml
@@ -2,14 +2,14 @@ name: tizen_app_manager
 description: Tizen application manager APIs. Used for getting app info and getting app running context on a Tizen device.
 homepage: https://github.com/flutter-tizen/plugins
 repository: https://github.com/flutter-tizen/plugins/tree/master/packages/tizen_app_manager
-version: 0.1.4
+version: 0.1.5
 
 environment:
   sdk: ">=2.15.1 <3.0.0"
   flutter: ">=2.5.0"
 
 dependencies:
-  ffi: ^1.1.2
+  ffi: ">=1.1.2 <3.0.0"
   flutter:
     sdk: flutter
 

--- a/packages/tizen_log/CHANGELOG.md
+++ b/packages/tizen_log/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.1.2
+
+* Bump ffi dependency.
+
 ## 0.1.1
 
 * Remove Flutter dependency.

--- a/packages/tizen_log/README.md
+++ b/packages/tizen_log/README.md
@@ -10,7 +10,7 @@ To use this package, add `tizen_log` as a dependency in your `pubspec.yaml` file
 
 ```yaml
 dependencies:
-  tizen_log: ^0.1.1
+  tizen_log: ^0.1.2
 ```
 
 ### Simple logging

--- a/packages/tizen_log/pubspec.yaml
+++ b/packages/tizen_log/pubspec.yaml
@@ -2,10 +2,10 @@ name: tizen_log
 description: A Flutter plugin which provides the ability to use Tizen dlog logging service.
 homepage: https://github.com/flutter-tizen/plugins
 repository: https://github.com/flutter-tizen/plugins/tree/master/packages/tizen_log
-version: 0.1.1
+version: 0.1.2
 
 environment:
   sdk: ">=2.15.1 <3.0.0"
 
 dependencies:
-  ffi: ^1.1.2
+  ffi: ">=1.1.2 <3.0.0"


### PR DESCRIPTION
This helps resolving dependencies of apps that have ffi ^2.0.0 as a dependency. We may drop support for ffi ^1.1.2 and only support ^2.0.0 in the future.