### PR TITLE
[video_player] Add a queue for storing decoded media packets

### DIFF
--- a/packages/video_player/CHANGELOG.md
+++ b/packages/video_player/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.4.1
+
+* Implement a new message loop for storing media packet.
+
 ## 2.4.0
 
 * Update video_player to 2.4.2.

--- a/packages/video_player/CHANGELOG.md
+++ b/packages/video_player/CHANGELOG.md
@@ -1,6 +1,9 @@
-## 2.4.1
+## 2.4.2
 
 * Implement a new message loop for storing media packet.
+
+## 2.4.1
+
 * Apply new texture APIs.
 
 ## 2.4.0

--- a/packages/video_player/CHANGELOG.md
+++ b/packages/video_player/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 2.4.2
 
-* Implement a new message loop for storing media packet.
+* Add a queue for storing decoded media packet.
 
 ## 2.4.1
 

--- a/packages/video_player/README.md
+++ b/packages/video_player/README.md
@@ -29,7 +29,7 @@ This package is not an _endorsed_ implementation of `video_player`. Therefore, y
 ```yaml
 dependencies:
   video_player: ^2.4.2
-  video_player_tizen: ^2.4.0
+  video_player_tizen: ^2.4.1
 ```
 
 Then you can import `video_player` in your Dart code:

--- a/packages/video_player/README.md
+++ b/packages/video_player/README.md
@@ -29,7 +29,7 @@ This package is not an _endorsed_ implementation of `video_player`. Therefore, y
 ```yaml
 dependencies:
   video_player: ^2.4.2
-  video_player_tizen: ^2.4.1
+  video_player_tizen: ^2.4.2
 ```
 
 Then you can import `video_player` in your Dart code:

--- a/packages/video_player/pubspec.yaml
+++ b/packages/video_player/pubspec.yaml
@@ -3,7 +3,7 @@ description: Flutter plugin for displaying inline video with other Flutter
   widgets on Tizen.
 homepage: https://github.com/flutter-tizen/plugins
 repository: https://github.com/flutter-tizen/plugins/tree/master/packages/video_player
-version: 2.4.1
+version: 2.4.2
 
 flutter:
   plugin:

--- a/packages/video_player/pubspec.yaml
+++ b/packages/video_player/pubspec.yaml
@@ -3,7 +3,7 @@ description: Flutter plugin for displaying inline video with other Flutter
   widgets on Tizen.
 homepage: https://github.com/flutter-tizen/plugins
 repository: https://github.com/flutter-tizen/plugins/tree/master/packages/video_player
-version: 2.4.0
+version: 2.4.1
 
 flutter:
   plugin:

--- a/packages/video_player/tizen/src/video_player.cc
+++ b/packages/video_player/tizen/src/video_player.cc
@@ -12,12 +12,6 @@
 #include "log.h"
 #include "video_player_error.h"
 
-struct Message {
-  Eina_Thread_Queue_Msg head;
-  MessageEvent event;
-  media_packet_h media_packet;
-};
-
 static std::string RotationToString(player_display_rotation_e rotation) {
   switch (rotation) {
     case PLAYER_DISPLAY_ROTATION_NONE:
@@ -263,17 +257,6 @@ void VideoPlayer::Dispose() {
   event_sink_ = nullptr;
   event_channel_->SetStreamHandler(nullptr);
 
-  if (player_) {
-    player_unprepare(player_);
-    player_unset_media_packet_video_frame_decoded_cb(player_);
-    player_unset_buffering_cb(player_);
-    player_unset_completed_cb(player_);
-    player_unset_interrupted_cb(player_);
-    player_unset_error_cb(player_);
-    player_destroy(player_);
-    player_ = 0;
-  }
-
   while (!packet_queue_.empty()) {
     media_packet_destroy(packet_queue_.front());
     packet_queue_.pop();
@@ -287,6 +270,16 @@ void VideoPlayer::Dispose() {
   if (previous_media_packet_) {
     media_packet_destroy(previous_media_packet_);
     previous_media_packet_ = nullptr;
+  }
+  if (player_) {
+    player_unprepare(player_);
+    player_unset_media_packet_video_frame_decoded_cb(player_);
+    player_unset_buffering_cb(player_);
+    player_unset_completed_cb(player_);
+    player_unset_interrupted_cb(player_);
+    player_unset_error_cb(player_);
+    player_destroy(player_);
+    player_ = 0;
   }
 
   if (texture_registrar_) {

--- a/packages/video_player/tizen/src/video_player.cc
+++ b/packages/video_player/tizen/src/video_player.cc
@@ -446,7 +446,7 @@ void VideoPlayer::OnError(int code, void *data) {
 void VideoPlayer::OnVideoFrameDecoded(media_packet_h packet, void *data) {
   auto *player = reinterpret_cast<VideoPlayer *>(data);
   std::lock_guard<std::mutex> lock(player->mutex_);
-  player->SendMessage(kMessageOnFrameDecoded, packet);
+  player->SendMessage(kMessageFrameDecoded, packet);
 }
 
 void VideoPlayer::RunMediaPacketLoop(void *data, Ecore_Thread *thread) {
@@ -470,7 +470,7 @@ void VideoPlayer::RunMediaPacketLoop(void *data, Ecore_Thread *thread) {
       break;
     }
 
-    if (message->event == kMessageOnFrameDecoded) {
+    if (message->event == kMessageFrameDecoded) {
       if (message->media_packet != nullptr) {
         packet_queue.push(message->media_packet);
       }
@@ -524,5 +524,5 @@ void VideoPlayer::SendRenderFinishedMessage() {
     media_packet_destroy(previous_media_packet_);
     previous_media_packet_ = nullptr;
   }
-  SendMessage(kMessageOnRenderFinished, nullptr);
+  SendMessage(kMessageRenderFinished, nullptr);
 }

--- a/packages/video_player/tizen/src/video_player.cc
+++ b/packages/video_player/tizen/src/video_player.cc
@@ -8,6 +8,7 @@
 #include <flutter/standard_method_codec.h>
 
 #include <algorithm>
+#include <queue>
 
 #include "log.h"
 #include "video_player_error.h"
@@ -92,7 +93,6 @@ VideoPlayer::VideoPlayer(flutter::PluginRegistrar *plugin_registrar,
                          flutter::TextureRegistrar *texture_registrar,
                          const std::string &uri, VideoPlayerOptions &options) {
   is_initialized_ = false;
-  is_rendering_ = false;
   texture_registrar_ = texture_registrar;
 
   texture_variant_ =
@@ -470,7 +470,6 @@ void VideoPlayer::RunMediaPacketLoop(void *data, Ecore_Thread *thread) {
     Message *message = static_cast<Message *>(
         eina_thread_queue_wait(packet_thread_queue, &ref));
     if (message->event == kMessageQuit) {
-      LOG_ERROR("Message quit.");
       eina_thread_queue_wait_done(packet_thread_queue, ref);
       break;
     }

--- a/packages/video_player/tizen/src/video_player.cc
+++ b/packages/video_player/tizen/src/video_player.cc
@@ -488,6 +488,10 @@ void VideoPlayer::RunMediaPacketLoop(void *data, Ecore_Thread *thread) {
       self->previous_media_packet_ = self->current_media_packet_;
       self->current_media_packet_ = packet_queue.front();
       packet_queue.pop();
+      while (!packet_queue.empty()) {
+        media_packet_destroy(packet_queue.front());
+        packet_queue.pop();
+      }
     }
   }
 

--- a/packages/video_player/tizen/src/video_player.h
+++ b/packages/video_player/tizen/src/video_player.h
@@ -5,7 +5,6 @@
 #ifndef FLUTTER_PLUGIN_VIDEO_PLAYER_H_
 #define FLUTTER_PLUGIN_VIDEO_PLAYER_H_
 
-#include <Ecore.h>
 #include <flutter/encodable_value.h>
 #include <flutter/event_channel.h>
 #include <flutter/plugin_registrar.h>
@@ -18,12 +17,6 @@
 #include <string>
 
 #include "video_player_options.h"
-
-typedef enum {
-  kMessageQuit = 0,
-  kMessageFrameDecoded,
-  kMessageRenderFinished,
-} MessageEvent;
 
 class VideoPlayer {
  public:

--- a/packages/video_player/tizen/src/video_player.h
+++ b/packages/video_player/tizen/src/video_player.h
@@ -18,6 +18,12 @@
 
 #include "video_player_options.h"
 
+typedef enum {
+  kMessageQuit = 0,
+  kMessageOnFrameDecoded,
+  kMessageOnRenderFinished,
+} MessageEvent;
+
 class VideoPlayer {
  public:
   using SeekCompletedCallback = std::function<void()>;
@@ -43,7 +49,7 @@ class VideoPlayer {
   void Initialize();
   void SetUpEventChannel(flutter::BinaryMessenger *messenger);
   void SendInitialized();
-  void SendMessage(int event, media_packet_h media_packet);
+  void SendMessage(MessageEvent event, media_packet_h media_packet);
   void SendRenderFinishedMessage();
   FlutterDesktopGpuBuffer *ObtainGpuBuffer(size_t width, size_t height);
   static void ReleaseMediaPacket(void *packet);
@@ -61,7 +67,7 @@ class VideoPlayer {
   Eina_Thread_Queue *packet_thread_queue_ = nullptr;
   media_packet_h current_media_packet_ = nullptr;
   media_packet_h previous_media_packet_ = nullptr;
-  bool is_initialized_;
+  bool is_initialized_ = false;
   bool is_rendering_ = false;
   player_h player_;
   std::unique_ptr<flutter::EventChannel<flutter::EncodableValue>>

--- a/packages/video_player/tizen/src/video_player.h
+++ b/packages/video_player/tizen/src/video_player.h
@@ -20,8 +20,8 @@
 
 typedef enum {
   kMessageQuit = 0,
-  kMessageOnFrameDecoded,
-  kMessageOnRenderFinished,
+  kMessageFrameDecoded,
+  kMessageRenderFinished,
 } MessageEvent;
 
 class VideoPlayer {

--- a/packages/video_player/tizen/src/video_player.h
+++ b/packages/video_player/tizen/src/video_player.h
@@ -14,7 +14,6 @@
 #include <functional>
 #include <memory>
 #include <mutex>
-#include <queue>
 #include <string>
 
 #include "video_player_options.h"
@@ -63,7 +62,7 @@ class VideoPlayer {
   media_packet_h current_media_packet_ = nullptr;
   media_packet_h previous_media_packet_ = nullptr;
   bool is_initialized_;
-  bool is_rendering_;
+  bool is_rendering_ = false;
   player_h player_;
   std::unique_ptr<flutter::EventChannel<flutter::EncodableValue>>
       event_channel_;


### PR DESCRIPTION
For fixing frame tearing issue on RB5:
1.Should destory media packet in sequence.
2.Should not destory current rendering packet when rendering finished.