### PR TITLE
Reallow CI build of geolocator and permission_handler

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -53,13 +53,8 @@ jobs:
           path: flutter-tizen
       - name: Build examples of changed packages
         if: ${{ env.HAS_CHANGED_PACKAGES == 'true' }}
-        # Example app of geolocator and permission_handler are temporary excluded 
-        # due to unmigrated depedency "baseflow_plugin_template". 
-        # Reallow the builds by removing the "--exclude=geolocator,permission_handler" line
-        # after https://github.com/Baseflow/baseflow_plugin_template/pull/4 is resolved.
         run: |
           export PATH=`pwd`/flutter-tizen/bin:$PATH
           ./tools/tools_runner.sh build-examples \
             --run-on-changed-packages \
-            --exclude=geolocator,permission_handler \
             --base-sha=$(git rev-parse HEAD^)

--- a/packages/geolocator/CHANGELOG.md
+++ b/packages/geolocator/CHANGELOG.md
@@ -1,6 +1,7 @@
-## NEXT
+## 1.0.4
 
 * Resolve linter warnings.
+* Bump up baseflow_plugin_template in example app.
 
 ## 1.0.3
 

--- a/packages/geolocator/README.md
+++ b/packages/geolocator/README.md
@@ -11,7 +11,7 @@ The Tizen implementation of [`geolocator`](https://github.com/Baseflow/flutter-g
  ```yaml
 dependencies:
   geolocator: ^8.0.0
-  geolocator_tizen: ^1.0.2
+  geolocator_tizen: ^1.0.4
 ```
 
 Then you can import `geolocator` in your Dart code:

--- a/packages/geolocator/example/pubspec.yaml
+++ b/packages/geolocator/example/pubspec.yaml
@@ -6,10 +6,7 @@ environment:
   sdk: ">=2.12.0 <3.0.0"
 
 dependencies:
-  baseflow_plugin_template:
-    git:
-      url: https://github.com/Baseflow/baseflow_plugin_template.git
-      ref: v2.1.0
+  baseflow_plugin_template: ^2.1.1
   cupertino_icons: ^1.0.1+1
   flutter:
     sdk: flutter

--- a/packages/geolocator/pubspec.yaml
+++ b/packages/geolocator/pubspec.yaml
@@ -2,7 +2,7 @@ name: geolocator_tizen
 description: Geolocation plugin for Flutter. This plugin provides the Tizen implementation for the geolocator.
 homepage: https://github.com/flutter-tizen/plugins
 repository: https://github.com/flutter-tizen/plugins/tree/master/packages/geolocator
-version: 1.0.3
+version: 1.0.4
 
 flutter:
   plugin:

--- a/packages/permission_handler/CHANGELOG.md
+++ b/packages/permission_handler/CHANGELOG.md
@@ -1,7 +1,8 @@
-## NEXT
+## 1.2.1
 
 * Code refactoring.
 * Resolve linter warnings.
+* Bump up baseflow_plugin_template in example app.
 
 ## 1.2.0
 

--- a/packages/permission_handler/README.md
+++ b/packages/permission_handler/README.md
@@ -21,7 +21,7 @@ You can use this plugin to ask the user for runtime permissions if your app perf
    ```yaml
    dependencies:
      permission_handler: ^8.3.0
-     permission_handler_tizen: ^1.2.0
+     permission_handler_tizen: ^1.2.1
    ```
 
    Then you can import `permission_handler` in your Dart code:

--- a/packages/permission_handler/example/pubspec.yaml
+++ b/packages/permission_handler/example/pubspec.yaml
@@ -3,10 +3,7 @@ description: Demonstrates how to use the permission_handler_tizen plugin.
 publish_to: "none"
 
 dependencies:
-  baseflow_plugin_template:
-    git:
-      url: https://github.com/Baseflow/baseflow_plugin_template.git
-      ref: v2.0.0-nullsafety
+  baseflow_plugin_template: ^2.1.1
   flutter:
     sdk: flutter
   permission_handler: ^8.3.0

--- a/packages/permission_handler/pubspec.yaml
+++ b/packages/permission_handler/pubspec.yaml
@@ -2,7 +2,7 @@ name: permission_handler_tizen
 description: Tizen implementation of the permission_handler plugin
 homepage: https://github.com/flutter-tizen/plugins
 repository: https://github.com/flutter-tizen/plugins/tree/master/packages/permission_handler
-version: 1.2.0
+version: 1.2.1
 
 flutter:
   plugin:


### PR DESCRIPTION
New versions of `geolocator` and `permission_handler` must be released as `baseflow_plugin_template` dependency was fixed to a specific version.