### PR TITLE
[tizen_app_control] Remove unused code

### DIFF
--- a/packages/tizen_app_control/CHANGELOG.md
+++ b/packages/tizen_app_control/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## NEXT
 
 * Update README.
+* Remove unused code and clean up.
 
 ## 0.2.2
 

--- a/packages/tizen_app_control/example/tizen/.gitignore
+++ b/packages/tizen_app_control/example/tizen/.gitignore
@@ -1,1 +1,0 @@
-flutter/

--- a/packages/tizen_app_control/example/tizen/ui/.gitignore
+++ b/packages/tizen_app_control/example/tizen/ui/.gitignore
@@ -1,3 +1,4 @@
+flutter/
 lib/*.so
 res/flutter_assets/
 res/icudtl.dat

--- a/packages/tizen_app_control/lib/src/ffi.dart
+++ b/packages/tizen_app_control/lib/src/ffi.dart
@@ -10,10 +10,10 @@ import 'package:ffi/ffi.dart';
 
 typedef _InitializeDartApiNative = IntPtr Function(Pointer<Void>);
 typedef _InitializeDartApi = int Function(Pointer<Void>);
-typedef _CreateAppControlNative = Uint32 Function(Handle);
+typedef _CreateAppControlNative = Int32 Function(Handle);
 typedef CreateAppControl = int Function(Object);
-typedef _AttachAppControlNative = Int8 Function(Int32, Handle);
-typedef _AttachAppControl = int Function(int, Object);
+typedef _AttachAppControlNative = Bool Function(Int32, Handle);
+typedef AttachAppControl = bool Function(int, Object);
 
 final DynamicLibrary _processLib = () {
   final DynamicLibrary processLib = DynamicLibrary.process();
@@ -27,38 +27,11 @@ final DynamicLibrary _processLib = () {
 final CreateAppControl nativeCreateAppControl =
     _processLib.lookupFunction<_CreateAppControlNative, CreateAppControl>(
         'NativeCreateAppControl');
-final _AttachAppControl _nativeAttachAppControl =
-    _processLib.lookupFunction<_AttachAppControlNative, _AttachAppControl>(
+final AttachAppControl nativeAttachAppControl =
+    _processLib.lookupFunction<_AttachAppControlNative, AttachAppControl>(
         'NativeAttachAppControl');
 
-bool nativeAttachAppControl(int id, Object dartObject) {
-  return _nativeAttachAppControl(id, dartObject) > 0;
-}
-
-class _AppContext extends Opaque {}
-
-typedef AppContextHandle = Pointer<_AppContext>;
-
-typedef _AppContextDestroyNative = Int32 Function(AppContextHandle);
-typedef AppContextDestroy = int Function(AppContextHandle);
-
-typedef _AppManagerGetAppContextNative = Int32 Function(
-    Pointer<Utf8>, Pointer<AppContextHandle>);
-typedef AppManagerGetAppContext = int Function(
-    Pointer<Utf8>, Pointer<AppContextHandle>);
-
-final DynamicLibrary _libAppManager =
-    DynamicLibrary.open('libcapi-appfw-app-manager.so.0');
-
-final AppManagerGetAppContext appManagerGetAppContext = _libAppManager
-    .lookupFunction<_AppManagerGetAppContextNative, AppManagerGetAppContext>(
-        'app_manager_get_app_context');
-
-final AppContextDestroy appContextDestroy =
-    _libAppManager.lookupFunction<_AppContextDestroyNative, AppContextDestroy>(
-        'app_context_destroy');
-
-typedef _GetErrorMessageNative = Pointer<Utf8> Function(Int32);
+typedef _GetErrorMessageNative = Pointer<Utf8> Function(Int);
 typedef GetErrorMessage = Pointer<Utf8> Function(int);
 
 final DynamicLibrary _libBaseCommon =


### PR DESCRIPTION
- Remove unused `AppContext`-related typedefs and references, which are a leftover from https://github.com/flutter-tizen/plugins/pull/407.
- Simplify `AttachAppControl` based on Dart 2.15's new `Bool` type support.
- Update `.gitignore` files according to the latest multi-app template.