### PR TITLE
Sync analysis_options.yaml

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -62,7 +62,7 @@ linter:
     # - avoid_positional_boolean_parameters # would have been nice to enable this but by now there's too many places that break it
     # - avoid_print # LOCAL CHANGE - Needs to be enabled and violations fixed.
     # - avoid_private_typedef_functions # we prefer having typedef (discussion in https://github.com/flutter/flutter/pull/16356)
-    # - avoid_redundant_argument_values # LOCAL CHANGE - Needs to be enabled and violations fixed.
+    - avoid_redundant_argument_values
     - avoid_relative_lib_imports
     - avoid_renaming_method_parameters
     - avoid_return_types_on_setters
@@ -227,7 +227,7 @@ linter:
     - use_is_even_rather_than_modulo
     - use_key_in_widget_constructors
     - use_late_for_private_fields_and_variables
-    # - use_named_constants # LOCAL CHANGE - Needs to be enabled and violations fixed.
+    - use_named_constants
     - use_raw_strings
     - use_rethrow_when_possible
     - use_setters_to_change_properties

--- a/packages/camera/example/lib/main.dart
+++ b/packages/camera/example/lib/main.dart
@@ -159,7 +159,6 @@ class _CameraExampleHomeState extends State<CameraExampleHome>
           Padding(
             padding: const EdgeInsets.all(5.0),
             child: Row(
-              mainAxisAlignment: MainAxisAlignment.start,
               children: <Widget>[
                 _cameraTogglesRowWidget(),
                 _thumbnailWidget(),
@@ -271,7 +270,6 @@ class _CameraExampleHomeState extends State<CameraExampleHome>
       children: <Widget>[
         Row(
           mainAxisAlignment: MainAxisAlignment.spaceEvenly,
-          mainAxisSize: MainAxisSize.max,
           children: <Widget>[
             IconButton(
               icon: const Icon(Icons.flash_on),
@@ -325,7 +323,6 @@ class _CameraExampleHomeState extends State<CameraExampleHome>
       child: ClipRect(
         child: Row(
           mainAxisAlignment: MainAxisAlignment.spaceEvenly,
-          mainAxisSize: MainAxisSize.max,
           children: <Widget>[
             IconButton(
               icon: const Icon(Icons.flash_off),
@@ -393,7 +390,6 @@ class _CameraExampleHomeState extends State<CameraExampleHome>
               ),
               Row(
                 mainAxisAlignment: MainAxisAlignment.spaceEvenly,
-                mainAxisSize: MainAxisSize.max,
                 children: <Widget>[
                   TextButton(
                     style: styleAuto,
@@ -431,7 +427,6 @@ class _CameraExampleHomeState extends State<CameraExampleHome>
               ),
               Row(
                 mainAxisAlignment: MainAxisAlignment.spaceEvenly,
-                mainAxisSize: MainAxisSize.max,
                 children: <Widget>[
                   Text(_minAvailableExposureOffset.toString()),
                   Slider(
@@ -478,7 +473,6 @@ class _CameraExampleHomeState extends State<CameraExampleHome>
               ),
               Row(
                 mainAxisAlignment: MainAxisAlignment.spaceEvenly,
-                mainAxisSize: MainAxisSize.max,
                 children: <Widget>[
                   TextButton(
                     style: styleAuto,
@@ -515,7 +509,6 @@ class _CameraExampleHomeState extends State<CameraExampleHome>
 
     return Row(
       mainAxisAlignment: MainAxisAlignment.spaceEvenly,
-      mainAxisSize: MainAxisSize.max,
       children: <Widget>[
         IconButton(
           icon: const Icon(Icons.camera_alt),

--- a/packages/google_maps_flutter/example/integration_test/google_maps_test.dart
+++ b/packages/google_maps_flutter/example/integration_test/google_maps_test.dart
@@ -97,7 +97,6 @@ void main() {
       child: GoogleMap(
         key: key,
         initialCameraPosition: _kInitialCameraPosition,
-        zoomGesturesEnabled: true,
         onMapCreated: (GoogleMapController controller) {
           fail('OnMapCreated should get called only once.');
         },
@@ -182,7 +181,6 @@ void main() {
       child: GoogleMap(
         key: key,
         initialCameraPosition: _kInitialCameraPosition,
-        scrollGesturesEnabled: true,
         onMapCreated: (GoogleMapController controller) {
           fail('OnMapCreated should get called only once.');
         },
@@ -333,7 +331,6 @@ void main() {
       child: GoogleMap(
         key: key,
         initialCameraPosition: _kInitialCameraPosition,
-        trafficEnabled: false,
         onMapCreated: (GoogleMapController controller) {
           fail('OnMapCreated should get called only once.');
         },

--- a/packages/google_maps_flutter/example/lib/map_click.dart
+++ b/packages/google_maps_flutter/example/lib/map_click.dart
@@ -86,7 +86,6 @@ class _MapClickBodyState extends State<_MapClickBody> {
     }
 
     return Column(
-      mainAxisAlignment: MainAxisAlignment.start,
       crossAxisAlignment: CrossAxisAlignment.stretch,
       children: columnChildren,
     );

--- a/packages/google_maps_flutter/example/lib/map_coordinates.dart
+++ b/packages/google_maps_flutter/example/lib/map_coordinates.dart
@@ -66,7 +66,6 @@ class _MapCoordinatesBodyState extends State<_MapCoordinatesBody> {
     }
 
     return Column(
-      mainAxisAlignment: MainAxisAlignment.start,
       crossAxisAlignment: CrossAxisAlignment.stretch,
       children: columnChildren,
     );

--- a/packages/google_maps_flutter/example/lib/map_ui.dart
+++ b/packages/google_maps_flutter/example/lib/map_ui.dart
@@ -250,7 +250,6 @@ class MapUiBodyState extends State<MapUiBody> {
       );
     }
     return Column(
-      mainAxisAlignment: MainAxisAlignment.start,
       crossAxisAlignment: CrossAxisAlignment.stretch,
       children: columnChildren,
     );

--- a/packages/google_maps_flutter/example/lib/padding.dart
+++ b/packages/google_maps_flutter/example/lib/padding.dart
@@ -30,7 +30,7 @@ const LatLng _kMapCenter = LatLng(52.4478, -3.5402);
 class MarkerIconsBodyState extends State<MarkerIconsBody> {
   GoogleMapController? controller;
 
-  EdgeInsets _padding = const EdgeInsets.all(0);
+  EdgeInsets _padding = EdgeInsets.zero;
 
   @override
   Widget build(BuildContext context) {
@@ -68,7 +68,6 @@ class MarkerIconsBodyState extends State<MarkerIconsBody> {
     columnChildren.addAll(<Widget>[_paddingInput(), _buttons()]);
 
     return Column(
-      mainAxisAlignment: MainAxisAlignment.start,
       crossAxisAlignment: CrossAxisAlignment.stretch,
       children: columnChildren,
     );
@@ -168,7 +167,7 @@ class MarkerIconsBodyState extends State<MarkerIconsBody> {
                 _bottomController.clear();
                 _leftController.clear();
                 _rightController.clear();
-                _padding = const EdgeInsets.all(0);
+                _padding = EdgeInsets.zero;
               });
             },
           )

--- a/packages/google_maps_flutter/example/lib/place_marker.dart
+++ b/packages/google_maps_flutter/example/lib/place_marker.dart
@@ -312,7 +312,6 @@ class PlaceMarkerBodyState extends State<PlaceMarkerBody> {
           padding: const EdgeInsets.only(left: 12, right: 12),
           child: Row(
             mainAxisAlignment: MainAxisAlignment.spaceAround,
-            mainAxisSize: MainAxisSize.max,
             children: <Widget>[
               if (markerPosition == null)
                 Container()

--- a/packages/google_maps_flutter/example/lib/tile_overlay.dart
+++ b/packages/google_maps_flutter/example/lib/tile_overlay.dart
@@ -137,11 +137,9 @@ class _DebugTileProvider implements TileProvider {
       textDirection: TextDirection.ltr,
     );
     textPainter.layout(
-      minWidth: 0.0,
       maxWidth: width.toDouble(),
     );
-    const Offset offset = Offset(0, 0);
-    textPainter.paint(canvas, offset);
+    textPainter.paint(canvas, Offset.zero);
     canvas.drawRect(
         Rect.fromLTRB(0, 0, width.toDouble(), width.toDouble()), boxPaint);
     final ui.Picture picture = recorder.endRecording();

--- a/packages/messageport/example/lib/main.dart
+++ b/packages/messageport/example/lib/main.dart
@@ -151,7 +151,6 @@ class _MyAppState extends State<MyApp> {
     return Column(
       children: <Widget>[
         Row(
-          mainAxisAlignment: MainAxisAlignment.start,
           children: <Widget>[
             Checkbox(
                 value: _attachLocalPort,
@@ -164,7 +163,6 @@ class _MyAppState extends State<MyApp> {
           ],
         ),
         GridView.builder(
-          scrollDirection: Axis.vertical,
           shrinkWrap: true,
           gridDelegate: const SliverGridDelegateWithMaxCrossAxisExtent(
             maxCrossAxisExtent: 100,
@@ -218,7 +216,7 @@ class _MyAppState extends State<MyApp> {
     return Expanded(
       child: Container(
         decoration: BoxDecoration(
-          border: Border.all(width: 1),
+          border: Border.all(),
           borderRadius: const BorderRadius.all(Radius.circular(3)),
         ),
         margin: const EdgeInsets.all(5),

--- a/packages/path_provider/example/integration_test/path_provider_test.dart
+++ b/packages/path_provider/example/integration_test/path_provider_test.dart
@@ -71,8 +71,7 @@ void main() {
   for (final StorageDirectory? type in _allDirs) {
     test('getExternalStorageDirectories (type: $type)', () async {
       if (Platform.isIOS) {
-        final Future<List<Directory>?> result =
-            getExternalStorageDirectories(type: null);
+        final Future<List<Directory>?> result = getExternalStorageDirectories();
         expect(result, throwsA(isInstanceOf<UnsupportedError>()));
       } else {
         final List<Directory>? directories =

--- a/packages/tizen_app_manager/example/lib/main.dart
+++ b/packages/tizen_app_manager/example/lib/main.dart
@@ -294,11 +294,10 @@ class _AppsEventScreenState extends State<_AppsEventScreen> {
 
   @override
   Widget build(BuildContext context) {
-    final PageController controller = PageController(initialPage: 0);
+    final PageController controller = PageController();
     return Scaffold(
       appBar: AppBar(title: const Text('application context events')),
       body: PageView(
-        scrollDirection: Axis.horizontal,
         controller: controller,
         children: <Widget>[
           Center(

--- a/packages/tizen_audio_manager/example/lib/main.dart
+++ b/packages/tizen_audio_manager/example/lib/main.dart
@@ -126,7 +126,6 @@ class _VolumeControlScreenState extends State<VolumeControlScreen> {
             width: 250,
             child: Slider(
               value: _currentVolume.toDouble(),
-              min: 0,
               max: _maxVolume.toDouble(),
               divisions: _maxVolume,
               onChanged: _onVolumeSliderChanged,

--- a/packages/video_player/example/integration_test/video_player_test.dart
+++ b/packages/video_player/example/integration_test/video_player_test.dart
@@ -46,7 +46,7 @@ void main() {
       await _controller.initialize();
 
       expect(_controller.value.isInitialized, true);
-      expect(_controller.value.position, const Duration(seconds: 0));
+      expect(_controller.value.position, Duration.zero);
       expect(_controller.value.isPlaying, false);
       // The WebM version has a slightly different duration than the MP4.
       expect(_controller.value.duration,
@@ -84,7 +84,7 @@ void main() {
 
         expect(_controller.value.isPlaying, true);
         expect(_controller.value.position,
-            (Duration position) => position > const Duration(seconds: 0));
+            (Duration position) => position > Duration.zero);
       },
     );
 
@@ -174,7 +174,6 @@ void main() {
       }
 
       await tester.pumpWidget(Material(
-        elevation: 0,
         child: Directionality(
           textDirection: TextDirection.ltr,
           child: Center(
@@ -262,7 +261,7 @@ void main() {
 
         expect(_controller.value.isPlaying, false);
         expect(_controller.value.position,
-            (Duration position) => position > const Duration(seconds: 0));
+            (Duration position) => position > Duration.zero);
 
         await expectLater(started.future, completes);
         await expectLater(ended.future, completes);
@@ -282,7 +281,7 @@ void main() {
       await _controller.initialize();
 
       expect(_controller.value.isInitialized, true);
-      expect(_controller.value.position, const Duration(seconds: 0));
+      expect(_controller.value.position, Duration.zero);
       expect(_controller.value.isPlaying, false);
       // Due to the duration calculation accurancy between platforms,
       // the milliseconds on Web will be a slightly different from natives.
@@ -305,7 +304,7 @@ void main() {
       expect(_controller.value.isPlaying, true);
       expect(
         _controller.value.position,
-        (Duration position) => position > const Duration(milliseconds: 0),
+        (Duration position) => position > Duration.zero,
       );
     });
 

--- a/packages/video_player/example/lib/main.dart
+++ b/packages/video_player/example/lib/main.dart
@@ -272,7 +272,7 @@ class _ControlsOverlay extends StatelessWidget {
     Duration(seconds: -3),
     Duration(seconds: -1, milliseconds: -500),
     Duration(milliseconds: -250),
-    Duration(milliseconds: 0),
+    Duration.zero,
     Duration(milliseconds: 250),
     Duration(seconds: 1, milliseconds: 500),
     Duration(seconds: 3),
@@ -418,7 +418,6 @@ class _PlayerVideoAndPopPageState extends State<_PlayerVideoAndPopPage> {
   @override
   Widget build(BuildContext context) {
     return Material(
-      elevation: 0,
       child: Center(
         child: FutureBuilder<bool>(
           future: started(),

--- a/packages/wearable_rotary/example/lib/custom_page_view.dart
+++ b/packages/wearable_rotary/example/lib/custom_page_view.dart
@@ -16,7 +16,7 @@ class CustomPageView extends StatefulWidget {
 
 class _CustomPageViewState extends State<CustomPageView> {
   StreamSubscription<RotaryEvent>? _rotarySubscription;
-  final PageController _pager = PageController(initialPage: 0);
+  final PageController _pager = PageController();
   int _currentPageIdx = 0;
 
   @override

--- a/tools/lib/src/main.dart
+++ b/tools/lib/src/main.dart
@@ -8,6 +8,7 @@ import 'dart:io' as io;
 import 'package:args/command_runner.dart';
 import 'package:file/file.dart';
 import 'package:file/local.dart';
+import 'package:flutter_plugin_tools/src/analyze_command.dart';
 import 'package:flutter_plugin_tools/src/common/core.dart';
 import 'package:flutter_plugin_tools/src/format_command.dart';
 import 'package:flutter_plugin_tools/src/list_command.dart';
@@ -34,6 +35,7 @@ void main(List<String> args) {
   final CommandRunner<void> commandRunner = CommandRunner<void>(
       './tools/tools_runner.sh',
       'Productivity utils for hosting multiple plugins within one repository.')
+    ..addCommand(AnalyzeCommand(packagesDir))
     ..addCommand(BuildExamplesCommand(packagesDir))
     ..addCommand(FormatCommand(packagesDir))
     ..addCommand(IntegrationTestCommand(packagesDir))


### PR DESCRIPTION
- Sync the latest flutter/plugins [analysis_options.yaml](https://github.com/flutter/plugins/blob/main/analysis_options.yaml). The following two options were added:
  - `avoid_redundant_argument_values` (https://github.com/flutter/plugins/commit/cda37d5640f9fe1d4b1bac9a6e610d5ca4e867ee)
  - `use_named_constants` (https://github.com/flutter/plugins/commit/b77f6fcfbf8d02cdf43326a7f9b042bf8916bd36)
- Add the `analyze` command to the tools. To run `flutter analyze` for all packages, run:<p>
  ```sh
  ../tools/tools_runner.sh analyze --custom-analysis audioplayers,battery_plus,connectivity_plus,device_info_plus,flutter_tts,geolocator,network_info_plus,package_info_plus,permission_handler,sensors_plus,sqflite,wakelock
  ```