### PR TITLE
Update tizen-manifest.xml files

### DIFF
--- a/packages/audioplayers/example/tizen/tizen-manifest.xml
+++ b/packages/audioplayers/example/tizen/tizen-manifest.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest package="org.tizen.audioplayers_tizen_example" version="1.0.0" api-version="4.0" xmlns="http://tizen.org/ns/packages">
     <profile name="common"/>
-    <ui-application appid="org.tizen.audioplayers_tizen_example" exec="Runner.dll" type="dotnet" multiple="false" taskmanage="true" nodisplay="false" api-version="4">
+    <ui-application appid="org.tizen.audioplayers_tizen_example" exec="Runner.dll" type="dotnet" multiple="false" taskmanage="true" nodisplay="false">
         <label>audioplayers_tizen_example</label>
         <icon>ic_launcher.png</icon>
         <metadata key="http://tizen.org/metadata/prefer_dotnet_aot" value="true"/>

--- a/packages/battery_plus/example/tizen/tizen-manifest.xml
+++ b/packages/battery_plus/example/tizen/tizen-manifest.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest package="org.tizen.battery_plus_example" version="1.0.0" api-version="4.0" xmlns="http://tizen.org/ns/packages">
     <profile name="wearable"/>
-    <ui-application appid="org.tizen.battery_plus_example" exec="Runner.dll" type="dotnet" multiple="false" taskmanage="true" nodisplay="false" api-version="4">
+    <ui-application appid="org.tizen.battery_plus_example" exec="Runner.dll" type="dotnet" multiple="false" taskmanage="true" nodisplay="false">
         <label>battery_plus_tizen_example</label>
         <icon>ic_launcher.png</icon>
         <metadata key="http://tizen.org/metadata/prefer_dotnet_aot" value="true"/>

--- a/packages/camera/example/tizen/tizen-manifest.xml
+++ b/packages/camera/example/tizen/tizen-manifest.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest package="com.example.camera_plugin_example" version="1.0.0" api-version="4.0" xmlns="http://tizen.org/ns/packages">
+<manifest package="org.tizen.camera_plugin_example" version="1.0.0" api-version="4.0" xmlns="http://tizen.org/ns/packages">
     <profile name="common"/>
-    <ui-application appid="com.example.camera_plugin_example" exec="Runner.dll" type="dotnet" multiple="false" taskmanage="true" nodisplay="false" api-version="4">
+    <ui-application appid="org.tizen.camera_plugin_example" exec="Runner.dll" type="dotnet" multiple="false" taskmanage="true" nodisplay="false">
         <label>camera_plugin_example</label>
         <icon>ic_launcher.png</icon>
         <metadata key="http://tizen.org/metadata/prefer_dotnet_aot" value="true"/>

--- a/packages/connectivity_plus/example/tizen/tizen-manifest.xml
+++ b/packages/connectivity_plus/example/tizen/tizen-manifest.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest package="org.tizen.connectivity_plus_tizen_example" version="1.0.0" api-version="4.0" xmlns="http://tizen.org/ns/packages">
     <profile name="common"/>
-    <ui-application appid="org.tizen.connectivity_plus_tizen_example" exec="Runner.dll" type="dotnet" multiple="false" taskmanage="true" nodisplay="false" api-version="4">
+    <ui-application appid="org.tizen.connectivity_plus_tizen_example" exec="Runner.dll" type="dotnet" multiple="false" taskmanage="true" nodisplay="false">
         <label>connectivity_plus_tizen_example</label>
         <icon>ic_launcher.png</icon>
         <metadata key="http://tizen.org/metadata/prefer_dotnet_aot" value="true"/>

--- a/packages/device_info_plus/example/tizen/tizen-manifest.xml
+++ b/packages/device_info_plus/example/tizen/tizen-manifest.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest package="org.tizen.device_info_plus_tizen_example" version="1.0.0" api-version="4.0" xmlns="http://tizen.org/ns/packages">
     <profile name="common"/>
-    <ui-application appid="org.tizen.device_info_plus_tizen_example" exec="Runner.dll" type="dotnet" multiple="false" taskmanage="true" nodisplay="false" api-version="4">
+    <ui-application appid="org.tizen.device_info_plus_tizen_example" exec="Runner.dll" type="dotnet" multiple="false" taskmanage="true" nodisplay="false">
         <label>device_info_plus_tizen_example</label>
         <icon>ic_launcher.png</icon>
         <metadata key="http://tizen.org/metadata/prefer_dotnet_aot" value="true"/>

--- a/packages/flutter_tts/example/tizen/tizen-manifest.xml
+++ b/packages/flutter_tts/example/tizen/tizen-manifest.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest package="org.tizen.flutter_tts_tizen_example" version="1.0.0" api-version="4.0" xmlns="http://tizen.org/ns/packages">
     <profile name="common"/>
-    <ui-application appid="org.tizen.flutter_tts_tizen_example" exec="Runner.dll" type="dotnet" multiple="false" taskmanage="true" nodisplay="false" api-version="4">
+    <ui-application appid="org.tizen.flutter_tts_tizen_example" exec="Runner.dll" type="dotnet" multiple="false" taskmanage="true" nodisplay="false">
         <label>flutter_tts_tizen_example</label>
         <icon>ic_launcher.png</icon>
         <metadata key="http://tizen.org/metadata/prefer_dotnet_aot" value="true"/>

--- a/packages/geolocator/example/tizen/tizen-manifest.xml
+++ b/packages/geolocator/example/tizen/tizen-manifest.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest package="org.tizen.geolocator_example" version="1.0.0" api-version="4.0" xmlns="http://tizen.org/ns/packages">
     <profile name="wearable"/>
-    <ui-application appid="org.tizen.geolocator_example" exec="Runner.dll" type="dotnet" multiple="false" nodisplay="false" taskmanage="true" api-version="4">
+    <ui-application appid="org.tizen.geolocator_example" exec="Runner.dll" type="dotnet" multiple="false" nodisplay="false" taskmanage="true">
         <label>geolocator_example</label>
         <icon>ic_launcher.png</icon>
         <metadata key="http://tizen.org/metadata/prefer_dotnet_aot" value="true"/>

--- a/packages/google_maps_flutter/example/tizen/tizen-manifest.xml
+++ b/packages/google_maps_flutter/example/tizen/tizen-manifest.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest package="org.tizen.google_maps_flutter_tizen_example" version="1.0.0" api-version="5.5" xmlns="http://tizen.org/ns/packages">
     <profile name="mobile"/>
-    <ui-application appid="org.tizen.google_maps_flutter_tizen_example" exec="Runner.dll" type="dotnet" multiple="false" taskmanage="true" nodisplay="false" api-version="4" launch_mode="single">
+    <ui-application appid="org.tizen.google_maps_flutter_tizen_example" exec="Runner.dll" type="dotnet" multiple="false" taskmanage="true" nodisplay="false" launch_mode="single">
         <label>google_maps_flutter_tizen_example</label>
         <icon>ic_launcher.png</icon>
         <metadata key="http://tizen.org/metadata/prefer_dotnet_aot" value="true"/>

--- a/packages/google_sign_in/example/tizen/tizen-manifest.xml
+++ b/packages/google_sign_in/example/tizen/tizen-manifest.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest package="com.example.google_sign_in_tizen_example" version="1.0.0" api-version="4.0" xmlns="http://tizen.org/ns/packages">
+<manifest package="org.tizen.google_sign_in_tizen_example" version="1.0.0" api-version="4.0" xmlns="http://tizen.org/ns/packages">
     <profile name="common"/>
-    <ui-application appid="com.example.google_sign_in_tizen_example" exec="Runner.dll" type="dotnet" multiple="false" nodisplay="false" taskmanage="true" api-version="4">
+    <ui-application appid="org.tizen.google_sign_in_tizen_example" exec="Runner.dll" type="dotnet" multiple="false" nodisplay="false" taskmanage="true">
         <label>google_sign_in_tizen_example</label>
         <icon>ic_launcher.png</icon>
         <metadata key="http://tizen.org/metadata/prefer_dotnet_aot" value="true"/>

--- a/packages/image_picker/example/tizen/tizen-manifest.xml
+++ b/packages/image_picker/example/tizen/tizen-manifest.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest package="org.tizen.image_picker_tizen_example" version="1.0.0" api-version="5.5" xmlns="http://tizen.org/ns/packages">
     <profile name="wearable"/>
-    <ui-application appid="org.tizen.image_picker_tizen_example" exec="Runner.dll" type="dotnet" multiple="false" taskmanage="true" nodisplay="false" api-version="4">
+    <ui-application appid="org.tizen.image_picker_tizen_example" exec="Runner.dll" type="dotnet" multiple="false" taskmanage="true" nodisplay="false">
         <label>image_picker_tizen_example</label>
         <icon>ic_launcher.png</icon>
         <metadata key="http://tizen.org/metadata/prefer_dotnet_aot" value="true"/>

--- a/packages/integration_test/example/tizen/tizen-manifest.xml
+++ b/packages/integration_test/example/tizen/tizen-manifest.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest package="org.tizen.integration_test_example" version="1.0.0" api-version="4.0" xmlns="http://tizen.org/ns/packages">
     <profile name="common"/>
-    <ui-application appid="org.tizen.integration_test_example" exec="Runner.dll" type="dotnet" multiple="false" taskmanage="true" nodisplay="false" api-version="4">
+    <ui-application appid="org.tizen.integration_test_example" exec="Runner.dll" type="dotnet" multiple="false" taskmanage="true" nodisplay="false">
         <label>integration_test_example</label>
         <icon>ic_launcher.png</icon>
         <metadata key="http://tizen.org/metadata/prefer_dotnet_aot" value="true"/>

--- a/packages/messageport/example/tizen/tizen-manifest.xml
+++ b/packages/messageport/example/tizen/tizen-manifest.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest package="org.tizen.messageport_tizen_example" version="1.0.0" api-version="4.0" xmlns="http://tizen.org/ns/packages">
     <profile name="common"/>
-    <ui-application appid="org.tizen.messageport_tizen_example" exec="Runner.dll" type="dotnet" multiple="false" taskmanage="true" nodisplay="false" api-version="4">
+    <ui-application appid="org.tizen.messageport_tizen_example" exec="Runner.dll" type="dotnet" multiple="false" taskmanage="true" nodisplay="false">
         <label>MessagePort Tizen Example</label>
         <icon>ic_launcher.png</icon>
         <metadata key="http://tizen.org/metadata/prefer_dotnet_aot" value="true"/>

--- a/packages/network_info_plus/example/tizen/tizen-manifest.xml
+++ b/packages/network_info_plus/example/tizen/tizen-manifest.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest package="org.tizen.network_info_plus_tizen_example" version="1.0.0" api-version="4.0" xmlns="http://tizen.org/ns/packages">
     <profile name="common"/>
-    <ui-application appid="org.tizen.network_info_plus_tizen_example" exec="Runner.dll" type="dotnet" multiple="false" taskmanage="true" nodisplay="false" api-version="4">
+    <ui-application appid="org.tizen.network_info_plus_tizen_example" exec="Runner.dll" type="dotnet" multiple="false" taskmanage="true" nodisplay="false">
         <label>network_info_plus_tizen_example</label>
         <icon>ic_launcher.png</icon>
         <metadata key="http://tizen.org/metadata/prefer_dotnet_aot" value="true"/>

--- a/packages/package_info_plus/example/tizen/tizen-manifest.xml
+++ b/packages/package_info_plus/example/tizen/tizen-manifest.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest package="org.tizen.package_info_plus_tizen_example" version="1.2.3" api-version="4.0" xmlns="http://tizen.org/ns/packages">
     <profile name="common"/>
-    <ui-application appid="org.tizen.package_info_plus_tizen_example" exec="Runner.dll" type="dotnet" multiple="false" taskmanage="true" nodisplay="false" api-version="4">
+    <ui-application appid="org.tizen.package_info_plus_tizen_example" exec="Runner.dll" type="dotnet" multiple="false" taskmanage="true" nodisplay="false">
         <label>package_info_plus_tizen_example</label>
         <icon>ic_launcher.png</icon>
         <metadata key="http://tizen.org/metadata/prefer_dotnet_aot" value="true"/>

--- a/packages/path_provider/example/tizen/tizen-manifest.xml
+++ b/packages/path_provider/example/tizen/tizen-manifest.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest package="org.tizen.path_provider_tizen_example" version="1.0.0" api-version="4.0" xmlns="http://tizen.org/ns/packages">
     <profile name="common"/>
-    <ui-application appid="org.tizen.path_provider_tizen_example" exec="Runner.dll" type="dotnet" multiple="false" taskmanage="true" nodisplay="false" api-version="4">
+    <ui-application appid="org.tizen.path_provider_tizen_example" exec="Runner.dll" type="dotnet" multiple="false" taskmanage="true" nodisplay="false">
         <label>path_provider_tizen_example</label>
         <icon>ic_launcher.png</icon>
         <metadata key="http://tizen.org/metadata/prefer_dotnet_aot" value="true"/>

--- a/packages/permission_handler/example/tizen/tizen-manifest.xml
+++ b/packages/permission_handler/example/tizen/tizen-manifest.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest package="org.tizen.permission_handler_tizen_example" version="1.0.0" api-version="4.0" xmlns="http://tizen.org/ns/packages">
     <profile name="wearable"/>
-    <ui-application appid="org.tizen.permission_handler_tizen_example" exec="Runner.dll" type="dotnet" multiple="false" taskmanage="true" nodisplay="false" api-version="4">
+    <ui-application appid="org.tizen.permission_handler_tizen_example" exec="Runner.dll" type="dotnet" multiple="false" taskmanage="true" nodisplay="false">
         <label>permission_handler_tizen_example</label>
         <icon>ic_launcher.png</icon>
         <metadata key="http://tizen.org/metadata/prefer_dotnet_aot" value="true"/>

--- a/packages/sensors_plus/example/tizen/tizen-manifest.xml
+++ b/packages/sensors_plus/example/tizen/tizen-manifest.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest package="org.tizen.sensors_plus_example" version="1.0.0" api-version="4.0" xmlns="http://tizen.org/ns/packages">
     <profile name="wearable"/>
-    <ui-application appid="org.tizen.sensors_plus_example" exec="Runner.dll" type="dotnet" multiple="false" taskmanage="true" nodisplay="false" api-version="4">
+    <ui-application appid="org.tizen.sensors_plus_example" exec="Runner.dll" type="dotnet" multiple="false" taskmanage="true" nodisplay="false">
         <label>sensors_plus_example</label>
         <icon>ic_launcher.png</icon>
         <metadata key="http://tizen.org/metadata/prefer_dotnet_aot" value="true"/>

--- a/packages/shared_preferences/example/tizen/tizen-manifest.xml
+++ b/packages/shared_preferences/example/tizen/tizen-manifest.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest package="org.tizen.shared_preferences_tizen_example" version="1.0.0" api-version="4.0" xmlns="http://tizen.org/ns/packages">
     <profile name="common"/>
-    <ui-application appid="org.tizen.shared_preferences_tizen_example" exec="Runner.dll" type="dotnet" multiple="false" taskmanage="true" nodisplay="false" api-version="4">
+    <ui-application appid="org.tizen.shared_preferences_tizen_example" exec="Runner.dll" type="dotnet" multiple="false" taskmanage="true" nodisplay="false">
         <label>shared_preferences_tizen_example</label>
         <icon>ic_launcher.png</icon>
         <metadata key="http://tizen.org/metadata/prefer_dotnet_aot" value="true"/>

--- a/packages/sqflite/example/tizen/tizen-manifest.xml
+++ b/packages/sqflite/example/tizen/tizen-manifest.xml
@@ -1,13 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest package="org.tizen.sqflite_example" version="1.0.0" api-version="4.0" xmlns="http://tizen.org/ns/packages">
     <profile name="wearable"/>
-    <ui-application appid="org.tizen.sqflite_example" exec="Runner.dll" type="dotnet" multiple="false" nodisplay="false" taskmanage="true" api-version="4">
+    <ui-application appid="org.tizen.sqflite_example" exec="Runner.dll" type="dotnet" multiple="false" nodisplay="false" taskmanage="true">
         <label>sqflite_example</label>
         <icon>ic_launcher.png</icon>
         <metadata key="http://tizen.org/metadata/prefer_dotnet_aot" value="true"/>
     </ui-application>
-    <tv-info api-version="8.8.0">
-        <infolink>T-INFOLINK2021-1000</infolink>
-    </tv-info>
     <feature name="http://tizen.org/feature/screen.size.all"/>
 </manifest>

--- a/packages/tizen_app_manager/example/integration_test/tizen_app_manager_test.dart
+++ b/packages/tizen_app_manager/example/integration_test/tizen_app_manager_test.dart
@@ -13,9 +13,9 @@ void main() {
   testWidgets('Can get current app info', (WidgetTester tester) async {
     // These test are based on the example app.
     final String appId = await AppManager.currentAppId;
-    expect(appId, 'com.example.tizen_app_manager_example');
+    expect(appId, 'org.tizen.tizen_app_manager_example');
     final AppInfo appInfo = await AppManager.getAppInfo(appId);
-    expect(appInfo.packageId, 'com.example.tizen_app_manager_example');
+    expect(appInfo.packageId, 'org.tizen.tizen_app_manager_example');
     expect(appInfo.label, 'tizen_app_manager_example');
     expect(appInfo.appType, 'dotnet');
   });

--- a/packages/tizen_app_manager/example/lib/main.dart
+++ b/packages/tizen_app_manager/example/lib/main.dart
@@ -119,7 +119,7 @@ class _CurrentAppScreenState extends State<_CurrentAppScreen> {
   );
 
   late AppRunningContext _currentAppContext =
-      AppRunningContext(appId: 'com.example.tizen_app_manager_example');
+      AppRunningContext(appId: 'org.tizen.tizen_app_manager_example');
 
   @override
   void initState() {

--- a/packages/tizen_app_manager/example/tizen/tizen-manifest.xml
+++ b/packages/tizen_app_manager/example/tizen/tizen-manifest.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest package="com.example.tizen_app_manager_example" version="1.0.0" api-version="4.0" xmlns="http://tizen.org/ns/packages">
+<manifest package="org.tizen.tizen_app_manager_example" version="1.0.0" api-version="4.0" xmlns="http://tizen.org/ns/packages">
     <profile name="common"/>
-    <ui-application appid="com.example.tizen_app_manager_example" exec="Runner.dll" type="dotnet" multiple="false" nodisplay="false" taskmanage="true" api-version="4">
+    <ui-application appid="org.tizen.tizen_app_manager_example" exec="Runner.dll" type="dotnet" multiple="false" nodisplay="false" taskmanage="true">
         <label>tizen_app_manager_example</label>
         <icon>ic_launcher.png</icon>
         <metadata key="http://tizen.org/metadata/prefer_dotnet_aot" value="true"/>

--- a/packages/tizen_audio_manager/example/tizen/tizen-manifest.xml
+++ b/packages/tizen_audio_manager/example/tizen/tizen-manifest.xml
@@ -1,14 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest package="org.tizen.tizen_audio_manager_example" version="1.0.0" api-version="4.0" xmlns="http://tizen.org/ns/packages">
     <profile name="common"/>
-    <ui-application appid="org.tizen.tizen_audio_manager_example" exec="Runner.dll" type="dotnet" multiple="false" nodisplay="false" taskmanage="true" api-version="4">
+    <ui-application appid="org.tizen.tizen_audio_manager_example" exec="Runner.dll" type="dotnet" multiple="false" nodisplay="false" taskmanage="true">
         <label>tizen_audio_manager_example</label>
         <icon>ic_launcher.png</icon>
         <metadata key="http://tizen.org/metadata/prefer_dotnet_aot" value="true"/>
     </ui-application>
-    <tv-info api-version="8.8.0">
-        <infolink>T-INFOLINK2021-1000</infolink>
-    </tv-info>
     <feature name="http://tizen.org/feature/screen.size.all"/>
     <privileges>
         <privilege>http://tizen.org/privilege/volume.set</privilege>

--- a/packages/tizen_bundle/example/tizen/tizen-manifest.xml
+++ b/packages/tizen_bundle/example/tizen/tizen-manifest.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest package="com.example.tizen_bundle_example" version="1.0.0" api-version="4.0" xmlns="http://tizen.org/ns/packages">
+<manifest package="org.tizen.tizen_bundle_example" version="1.0.0" api-version="4.0" xmlns="http://tizen.org/ns/packages">
     <profile name="common"/>
     <ui-application appid="org.tizen.tizen_bundle_example" exec="Runner.dll" type="dotnet" multiple="false" nodisplay="false" taskmanage="true">
         <label>tizen_bundle_example</label>

--- a/packages/tizen_log/example/tizen/tizen-manifest.xml
+++ b/packages/tizen_log/example/tizen/tizen-manifest.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest package="org.tizen.tizen_log_example" version="1.0.0" api-version="4.0" xmlns="http://tizen.org/ns/packages">
     <profile name="common"/>
-    <ui-application appid="org.tizen.tizen_log_example" exec="Runner.dll" type="dotnet" multiple="false" nodisplay="false" taskmanage="true" api-version="4">
+    <ui-application appid="org.tizen.tizen_log_example" exec="Runner.dll" type="dotnet" multiple="false" nodisplay="false" taskmanage="true">
         <label>tizen_log_example</label>
         <icon>ic_launcher.png</icon>
         <metadata key="http://tizen.org/metadata/prefer_dotnet_aot" value="true"/>

--- a/packages/tizen_notification/example/tizen/tizen-manifest.xml
+++ b/packages/tizen_notification/example/tizen/tizen-manifest.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest package="org.tizen.tizen_notification_example" version="1.0.0" api-version="4.0" xmlns="http://tizen.org/ns/packages">
     <profile name="common"/>
-    <ui-application appid="org.tizen.tizen_notification_example" exec="Runner.dll" type="dotnet" multiple="false" nodisplay="false" taskmanage="true" api-version="4">
+    <ui-application appid="org.tizen.tizen_notification_example" exec="Runner.dll" type="dotnet" multiple="false" nodisplay="false" taskmanage="true">
         <label>tizen_notification_example</label>
         <icon>ic_launcher.png</icon>
         <metadata key="http://tizen.org/metadata/prefer_dotnet_aot" value="true"/>

--- a/packages/tizen_package_manager/example/integration_test/tizen_package_manager_test.dart
+++ b/packages/tizen_package_manager/example/integration_test/tizen_package_manager_test.dart
@@ -15,7 +15,7 @@ void main() {
     // These test are based on the example app.
     final PackageInfo info =
         await PackageManager.getPackageInfo(currentPackageId);
-    expect(info.packageId, 'com.example.tizen_package_manager_example');
+    expect(info.packageId, 'org.tizen.tizen_package_manager_example');
     expect(info.label, 'tizen_package_manager_example');
     expect(info.packageType, PackageType.tpk);
     expect(info.version, '1.0.0');

--- a/packages/tizen_package_manager/example/lib/main.dart
+++ b/packages/tizen_package_manager/example/lib/main.dart
@@ -8,7 +8,7 @@ import 'package:flutter/material.dart';
 import 'package:tizen_package_manager/package_manager.dart';
 
 /// The example app package ID.
-const String currentPackageId = 'com.example.tizen_package_manager_example';
+const String currentPackageId = 'org.tizen.tizen_package_manager_example';
 
 void main() {
   runApp(const MyApp());

--- a/packages/tizen_package_manager/example/tizen/tizen-manifest.xml
+++ b/packages/tizen_package_manager/example/tizen/tizen-manifest.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest package="com.example.tizen_package_manager_example" version="1.0.0" api-version="4.0" xmlns="http://tizen.org/ns/packages">
+<manifest package="org.tizen.tizen_package_manager_example" version="1.0.0" api-version="4.0" xmlns="http://tizen.org/ns/packages">
     <profile name="common"/>
-    <ui-application appid="com.example.tizen_package_manager_example" exec="Runner.dll" type="dotnet" multiple="false" nodisplay="false" taskmanage="true" api-version="4">
+    <ui-application appid="org.tizen.tizen_package_manager_example" exec="Runner.dll" type="dotnet" multiple="false" nodisplay="false" taskmanage="true">
         <label>tizen_package_manager_example</label>
         <icon>ic_launcher.png</icon>
         <metadata key="http://tizen.org/metadata/prefer_dotnet_aot" value="true"/>

--- a/packages/url_launcher/example/tizen/tizen-manifest.xml
+++ b/packages/url_launcher/example/tizen/tizen-manifest.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest package="org.tizen.url_launcher_example" version="1.0.0" api-version="4.0" xmlns="http://tizen.org/ns/packages">
     <profile name="common"/>
-    <ui-application appid="org.tizen.url_launcher_example" exec="Runner.dll" type="dotnet" multiple="false" taskmanage="true" nodisplay="false" api-version="4">
+    <ui-application appid="org.tizen.url_launcher_example" exec="Runner.dll" type="dotnet" multiple="false" taskmanage="true" nodisplay="false">
         <label>url_launcher_example</label>
         <icon>ic_launcher.png</icon>
         <metadata key="http://tizen.org/metadata/prefer_dotnet_aot" value="true"/>

--- a/packages/video_player/example/tizen/tizen-manifest.xml
+++ b/packages/video_player/example/tizen/tizen-manifest.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest package="org.tizen.video_player_tizen_example" version="1.0.0" api-version="4.0" xmlns="http://tizen.org/ns/packages">
     <profile name="common"/>
-    <ui-application appid="org.tizen.video_player_tizen_example" exec="Runner.dll" type="dotnet" multiple="false" taskmanage="true" nodisplay="false" api-version="4">
+    <ui-application appid="org.tizen.video_player_tizen_example" exec="Runner.dll" type="dotnet" multiple="false" taskmanage="true" nodisplay="false">
         <label>video_player_tizen_example</label>
         <icon>ic_launcher.png</icon>
         <metadata key="http://tizen.org/metadata/prefer_dotnet_aot" value="true"/>

--- a/packages/wakelock/example/tizen/tizen-manifest.xml
+++ b/packages/wakelock/example/tizen/tizen-manifest.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest package="com.example.wakelock_tizen_example" version="1.0.0" api-version="4.0" xmlns="http://tizen.org/ns/packages">
+<manifest package="org.tizen.wakelock_tizen_example" version="1.0.0" api-version="4.0" xmlns="http://tizen.org/ns/packages">
     <profile name="wearable"/>
-    <ui-application appid="com.example.wakelock_tizen_example" exec="Runner.dll" type="dotnet" multiple="false" taskmanage="true" nodisplay="false" api-version="4">
+    <ui-application appid="org.tizen.wakelock_tizen_example" exec="Runner.dll" type="dotnet" multiple="false" taskmanage="true" nodisplay="false">
         <label>wakelock_tizen_example</label>
         <icon>ic_launcher.png</icon>
         <metadata key="http://tizen.org/metadata/prefer_dotnet_aot" value="true"/>

--- a/packages/wearable_rotary/example/tizen/tizen-manifest.xml
+++ b/packages/wearable_rotary/example/tizen/tizen-manifest.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest package="com.example.wearable_rotary_example" version="1.0.0" api-version="4.0" xmlns="http://tizen.org/ns/packages">
+<manifest package="org.tizen.wearable_rotary_example" version="1.0.0" api-version="4.0" xmlns="http://tizen.org/ns/packages">
     <profile name="wearable"/>
-    <ui-application appid="com.example.wearable_rotary_example" exec="Runner.dll" type="dotnet" multiple="false" taskmanage="true" nodisplay="false" api-version="4">
+    <ui-application appid="org.tizen.wearable_rotary_example" exec="Runner.dll" type="dotnet" multiple="false" taskmanage="true" nodisplay="false">
         <label>wearable_rotary_example</label>
         <icon>ic_launcher.png</icon>
         <metadata key="http://tizen.org/metadata/prefer_dotnet_aot" value="true"/>

--- a/packages/webview_flutter/example/tizen/tizen-manifest.xml
+++ b/packages/webview_flutter/example/tizen/tizen-manifest.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest package="org.tizen.webview_flutter_tizen_example" version="1.0.0" api-version="5.5" xmlns="http://tizen.org/ns/packages">
     <profile name="common"/>
-    <ui-application appid="org.tizen.webview_flutter_tizen_example" exec="Runner.dll" type="dotnet" multiple="false" taskmanage="true" nodisplay="false" api-version="4" launch_mode="single">
+    <ui-application appid="org.tizen.webview_flutter_tizen_example" exec="Runner.dll" type="dotnet" multiple="false" taskmanage="true" nodisplay="false" launch_mode="single">
         <label>webview_flutter_tizen_example</label>
         <icon>ic_launcher.png</icon>
         <metadata key="http://tizen.org/metadata/prefer_dotnet_aot" value="true"/>

--- a/tools/test_data/foo/example/tizen/tizen-manifest.xml
+++ b/tools/test_data/foo/example/tizen/tizen-manifest.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest package="com.example.foo_example" version="1.0.0" api-version="4.0" xmlns="http://tizen.org/ns/packages">
     <profile name="wearable"/>
-    <ui-application appid="com.example.foo_example" exec="Runner.dll" type="dotnet" multiple="false" nodisplay="false" taskmanage="true" api-version="4">
+    <ui-application appid="com.example.foo_example" exec="Runner.dll" type="dotnet" multiple="false" nodisplay="false" taskmanage="true">
         <label>foo_example</label>
         <icon>ic_launcher.png</icon>
         <metadata key="http://tizen.org/metadata/prefer_dotnet_aot" value="true"/>


### PR DESCRIPTION
- Change the organization prefix in package and application IDs (`com.example` → `org.tizen`).
- Remove unnecessary `api-version` attributes from `ui-application` elements.
- Remove unnecessary `tv-info` elements.