### PR TITLE
[webview_flutter] Set runtime path to $ORIGIN

### DIFF
--- a/packages/webview_flutter/CHANGELOG.md
+++ b/packages/webview_flutter/CHANGELOG.md
@@ -1,6 +1,7 @@
-## NEXT
+## 0.5.5
 
 * Update README.
+* Add `-Wl,-rpath=$ORIGIN` linker option.
 
 ## 0.5.4
 

--- a/packages/webview_flutter/README.md
+++ b/packages/webview_flutter/README.md
@@ -21,7 +21,7 @@ This package is not an _endorsed_ implementation of `webview_flutter`. Therefore
 ```yaml
 dependencies:
   webview_flutter: ^3.0.4
-  webview_flutter_tizen: ^0.5.4
+  webview_flutter_tizen: ^0.5.5
 ```
 
 ## Example

--- a/packages/webview_flutter/pubspec.yaml
+++ b/packages/webview_flutter/pubspec.yaml
@@ -2,7 +2,7 @@ name: webview_flutter_tizen
 description: Tizen implementation of the webview plugin
 homepage: https://github.com/flutter-tizen/plugins
 repository: https://github.com/flutter-tizen/plugins/tree/master/packages/webview_flutter
-version: 0.5.4
+version: 0.5.5
 
 environment:
   sdk: ">=2.17.0 <3.0.0"

--- a/packages/webview_flutter/tizen/project_def.prop
+++ b/packages/webview_flutter/tizen/project_def.prop
@@ -26,4 +26,4 @@ USER_CPP_INC_FILES =
 # Linker options
 USER_LIBS = pthread lightweight-web-engine.flutter tuv
 USER_LIB_DIRS = lib/${BUILD_ARCH}
-USER_LFLAGS =
+USER_LFLAGS = -Wl,-rpath='$$ORIGIN'


### PR DESCRIPTION
Fixes runtime errors of plugins that depend on the webview_flutter plugin (such as google_maps_flutter).