### PR TITLE
[tizen_bundle] General cleanups

### DIFF
--- a/packages/tizen_bundle/CHANGELOG.md
+++ b/packages/tizen_bundle/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.1.1
+
+* General cleanups.
+
 ## 0.1.0
 
 * Initial release.

--- a/packages/tizen_bundle/README.md
+++ b/packages/tizen_bundle/README.md
@@ -2,7 +2,7 @@
 
 [![pub package](https://img.shields.io/pub/v/tizen_bundle.svg)](https://pub.dev/packages/tizen_bundle)
 
-Tizen bundle APIs.
+Tizen [Data Bundle](https://docs.tizen.org/application/native/guides/app-management/data-bundles) APIs.
 
 ## Usage
 
@@ -10,106 +10,64 @@ To use this package, add `tizen_bundle` as a dependency in your `pubspec.yaml` f
 
 ```yaml
 depenedencies:
-  tizen_bundle: ^0.1.0
+  tizen_bundle: ^0.1.1
 ```
 
-### Adding Content to a Bundle
+### Adding content to a bundle
 
-The bundle content is in the from of key-value pairs. The key is always a string. The value can be of the following types:
+The bundle content is in the form of key-value pairs. The key is always a `String`. The value is either a `String`, a `List<String>`, or a `Uint8List`.
 
-**Table: Bundle value types**
-| Type enum                | Dart type         |
-|--------------------------|-------------------|
-| `BundleType.string`      | String            |
-| `BundleType.strings`     | List<String>      |
-| `BundleType.bytes`       | Uint8List         |
-
-To add content to a bundle, use following methods or `operator [](String key, Object value)` you want to add:
-
-- `Bundle.addAll()`
-- `Bundle.addEntries()`
+Bundles can be treated like a `Map`. You can use the `[]` operator or `Bundle.addAll()` to add data to a bundle.
 
 ```dart
+import 'dart:typed_data';
 import 'package:tizen_bundle/tizen_bundle.dart';
 
 var bundle = Bundle();
-bundle['string'] = 'stringValue';
-
-List<String> values = ['stringValue1', 'stringValue2', 'stringValue3'];
-bundle['strings'] = values;
-
-Uint8List bytes = Uint8List(3);
-bytes[0] = 0x01;
-bytes[1] = 0x02;
-bytes[2] = 0x03;
-bundle['bytes'] =  bytes;
+bundle['string'] = 'value';
+bundle['strings'] = <String>['value1', 'value2', 'value3'];
+bundle['bytes'] = Uint8List.fromList(<int>[0x01, 0x02, 0x03]);
 ```
 
-## Managing the Bundle Content
+### Accessing the bundle content
 
-To manage the bundle content:
-
-1. Gets values from the bundle object using `operator [](String key)` you want to get :
-   You can also get the number of the bundle items with the `Bundle.length` property, and check whether the value is the type or not with `is` keyword as below:
+To get data from a bundle (or update their values), use the `[]` operator.
 
 ```dart
-import 'package:tizen_log/tizen_log.dart';
-
-String logTag = 'BundleTest';
-Log.info(logTag, 'length: ${bundle.length}');
 var stringValue = bundle['string'];
 if (stringValue is String) {
-  Log.info(logTag, 'string: $stringValue');
+  print('string: $stringValue');
 }
 
 var stringsValue = bundle['strings'];
 if (stringsValue is List<String>) {
-  Log.info(logTag, 'strings: $stringsValue');
+  print('strings: $stringsValue');
 }
 
 var bytesValue = bundle['bytes'];
 if (bytesValue is Uint8List) {
-  Log.info(logTag, 'bytes: $bytesValue');
+  print('bytes: $bytesValue');
 }
 ```
 
-2. Deletes a key-value pair from the bundle content using the `Bundle.remove()` method:
+To remove a key-value pair from a bundle, use `Bundle.remove()`.
 
 ```dart
-if (bundle.containsKey('string'))
+if (bundle.containsKey('string')) {
   bundle.remove('string');
-
-if (bundle.containsKey('strings'))
-  bundle.remove('strings');
-
-if (bundle.containsKey('bytes'))
-  bundle.remove('bytes');
-```
-
-## Iterating the Bundle Content
-
-To iterate through the bundle records, use the 'Bundle.keys' property:
-
-```dart
-final keys = bundle.keys;
-keys.asMap().forEach((index, key) {
-  Log.info(logTag, 'key: ${keyInfo.name}');
 }
-
 ```
 
-## Encoding and Decoding the Bundle
+### Encoding and decoding a bundle
 
-To store or send a bundle over a connection, encode it to `String` with the `Bundle.toRaw()` method.
-
-To open the encoded bundle, use the `Bundle.fromRaw()` method.
+To store bundle data to a file or send over a connection, you can encode it to a string using `Bundle.encode()`. To decode the string back to a bundle, use `Bundle.decode()`.
 
 ```dart
 var bundle = Bundle();
-bundle.addString('key1', 'value1');
+bundle['key'] = 'value';
 
-var raw = bundle.toRaw();
+var encoded = bundle.encode();
+var newBundle = Bundle.decode(encoded);
 
-var newBundle = Bundle.fromRaw(raw);
-Log.info(logTag, 'value: ${newBundle.getString('key')}');
+print(newBundle['key']);
 ```

--- a/packages/tizen_bundle/README.md
+++ b/packages/tizen_bundle/README.md
@@ -15,12 +15,11 @@ depenedencies:
 
 ### Adding content to a bundle
 
-The bundle content is in the form of key-value pairs. The key is always a `String`. The value is either a `String`, a `List<String>`, or a `Uint8List`.
+The bundle content is in the form of key-value pairs. The key is always a `String`. The value must be either a `String`, a `List<String>`, or a `Uint8List`.
 
 Bundles can be treated like a `Map`. You can use the `[]` operator or `Bundle.addAll()` to add data to a bundle.
 
 ```dart
-import 'dart:typed_data';
 import 'package:tizen_bundle/tizen_bundle.dart';
 
 var bundle = Bundle();
@@ -31,7 +30,7 @@ bundle['bytes'] = Uint8List.fromList(<int>[0x01, 0x02, 0x03]);
 
 ### Accessing the bundle content
 
-To get data from a bundle (or update their values), use the `[]` operator.
+To get data from a bundle or update their values, use the `[]` operator.
 
 ```dart
 var stringValue = bundle['string'];
@@ -50,7 +49,7 @@ if (bytesValue is Uint8List) {
 }
 ```
 
-To remove a key-value pair from a bundle, use `Bundle.remove()`.
+You can also use other [methods and properties](https://api.flutter.dev/flutter/dart-collection/MapMixin-class.html) supported by a `Map`, such as `containsKey` and `remove`.
 
 ```dart
 if (bundle.containsKey('string')) {
@@ -60,7 +59,7 @@ if (bundle.containsKey('string')) {
 
 ### Encoding and decoding a bundle
 
-To store bundle data to a file or send over a connection, you can encode it to a string using `Bundle.encode()`. To decode the string back to a bundle, use `Bundle.decode()`.
+To save bundle data to a file or send over network, you can encode them to a raw string using `Bundle.encode()`. To restore the bundle from the encoded string, use `Bundle.decode()`.
 
 ```dart
 var bundle = Bundle();

--- a/packages/tizen_bundle/example/integration_test/bundle_test.dart
+++ b/packages/tizen_bundle/example/integration_test/bundle_test.dart
@@ -2,9 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'dart:typed_data';
-
-import 'package:flutter/foundation.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:integration_test/integration_test.dart';
 import 'package:tizen_bundle/tizen_bundle.dart';
@@ -12,96 +9,94 @@ import 'package:tizen_bundle/tizen_bundle.dart';
 void main() {
   IntegrationTestWidgetsFlutterBinding.ensureInitialized();
 
-  group('$Bundle', () {
-    testWidgets('can create a bundle', (WidgetTester _) async {
-      final Bundle bundle = Bundle();
-      bundle['stringKey'] = 'stringValue';
-      expect(bundle['stringKey'], 'stringValue');
+  testWidgets('can create a bundle', (WidgetTester _) async {
+    final Bundle bundle = Bundle();
+    bundle['stringKey'] = 'stringValue';
+    expect(bundle['stringKey'], 'stringValue');
+  });
+
+  testWidgets('can create a bundle from another bundle',
+      (WidgetTester _) async {
+    final Bundle bundle = Bundle();
+    bundle['stringKey'] = 'stringValue';
+
+    final Bundle newBundle = Bundle.fromBundle(bundle);
+    expect(newBundle['stringKey'], 'stringValue');
+  });
+
+  testWidgets('can create a bundle from a map', (WidgetTester _) async {
+    final Bundle bundle = Bundle.fromMap(<String, Object>{
+      'stringKey': 'stringValue',
+      'stringsKey': <String>['value1', 'value2'],
+      'bytesKey': Uint8List.fromList(<int>[0x03]),
     });
+    expect(bundle.length, 3);
+    expect(bundle['stringKey'], 'stringValue');
+    expect(bundle['stringsKey'], <String>['value1', 'value2']);
+    expect(bundle['bytesKey'], Uint8List.fromList(<int>[0x03]));
+  });
 
-    testWidgets('can create a bundle from another bundle',
-        (WidgetTester _) async {
-      final Bundle bundle = Bundle();
-      bundle['stringKey'] = 'stringValue';
-
-      final Bundle newBundle = Bundle.fromBundle(bundle);
-      expect(newBundle['stringKey'], 'stringValue');
+  testWidgets('returns all stored keys and values', (WidgetTester _) async {
+    final Bundle bundle = Bundle.fromMap(<String, String>{
+      'key1': 'value1',
+      'key2': 'value2',
+      'key3': 'value3',
     });
+    expect(bundle.keys, unorderedEquals(<String>['key1', 'key2', 'key3']));
+    expect(
+        bundle.values, unorderedEquals(<String>['value1', 'value2', 'value3']));
+  });
 
-    testWidgets('can create a bundle from a map', (WidgetTester _) async {
-      final Bundle bundle = Bundle.fromMap(<String, Object>{
-        'stringKey': 'stringValue',
-        'stringsKey': <String>['value1', 'value2'],
-        'bytesKey': Uint8List.fromList(<int>[0x03]),
-      });
-      expect(bundle.length, 3);
-      expect(bundle['stringKey'], 'stringValue');
-      expect(bundle['stringsKey'], <String>['value1', 'value2']);
-      expect(bundle['bytesKey'], Uint8List.fromList(<int>[0x03]));
-    });
+  testWidgets('checks whether the bundle is empty', (WidgetTester _) async {
+    final Bundle bundle = Bundle();
+    bundle['stringKey'] = 'stringValue';
+    expect(bundle.isNotEmpty, true);
 
-    testWidgets('returns all stored keys and values', (WidgetTester _) async {
-      final Bundle bundle = Bundle.fromMap(<String, String>{
-        'key1': 'value1',
-        'key2': 'value2',
-        'key3': 'value3',
-      });
-      expect(bundle.keys, unorderedEquals(<String>['key1', 'key2', 'key3']));
-      expect(bundle.values,
-          unorderedEquals(<String>['value1', 'value2', 'value3']));
-    });
+    bundle.remove('stringKey');
+    expect(bundle.isEmpty, true);
+  });
 
-    testWidgets('checks whether the bundle is empty', (WidgetTester _) async {
-      final Bundle bundle = Bundle();
-      bundle['stringKey'] = 'stringValue';
-      expect(bundle.isNotEmpty, true);
+  testWidgets('can add a Uint8List value', (WidgetTester _) async {
+    final Bundle bundle = Bundle();
+    bundle['bytesKey'] = Uint8List(10);
 
-      bundle.remove('stringKey');
-      expect(bundle.isEmpty, true);
-    });
+    final Uint8List bytes = bundle['bytesKey']! as Uint8List;
+    expect(bytes.length, 10);
+  });
 
-    testWidgets('can add a Uint8List value', (WidgetTester _) async {
-      final Bundle bundle = Bundle();
-      bundle['bytesKey'] = Uint8List(10);
+  testWidgets('can add a List<String> value', (WidgetTester _) async {
+    final Bundle bundle = Bundle();
+    bundle['stringsKey'] = <String>['value1', 'value2'];
 
-      final Uint8List bytes = bundle['bytesKey']! as Uint8List;
-      expect(bytes.length, 10);
-    });
+    final List<String> strings = bundle['stringsKey']! as List<String>;
+    expect(strings, <String>['value1', 'value2']);
+  });
 
-    testWidgets('can add a List<String> value', (WidgetTester _) async {
-      final Bundle bundle = Bundle();
-      bundle['stringsKey'] = <String>['value1', 'value2'];
+  testWidgets('can remove all entries', (WidgetTester _) async {
+    final Bundle bundle = Bundle();
+    bundle['stringKey1'] = 'stringValue1';
+    bundle['stringKey2'] = 'stringValue2';
+    expect(bundle.length, 2);
 
-      final List<String> strings = bundle['stringsKey']! as List<String>;
-      expect(strings, <String>['value1', 'value2']);
-    });
+    bundle.clear();
+    expect(bundle.length, 0);
+  });
 
-    testWidgets('can remove all entries', (WidgetTester _) async {
-      final Bundle bundle = Bundle();
-      bundle['stringKey1'] = 'stringValue1';
-      bundle['stringKey2'] = 'stringValue2';
-      expect(bundle.length, 2);
+  testWidgets('can remove key and its associated value',
+      (WidgetTester _) async {
+    final Bundle bundle = Bundle();
+    bundle['stringKey'] = 'stringValue';
+    expect(bundle.containsKey('stringKey'), true);
 
-      bundle.clear();
-      expect(bundle.length, 0);
-    });
+    bundle.remove('stringKey');
+    expect(bundle.containsKey('stringKey'), false);
+  });
 
-    testWidgets('can remove key and its associated value',
-        (WidgetTester _) async {
-      final Bundle bundle = Bundle();
-      bundle['stringKey'] = 'stringValue';
-      expect(bundle.containsKey('stringKey'), true);
-
-      bundle.remove('stringKey');
-      expect(bundle.containsKey('stringKey'), false);
-    });
-
-    testWidgets('can encode and decode raw data', (WidgetTester _) async {
-      final Bundle bundle = Bundle();
-      bundle['stringKey'] = 'stringValue';
-      final String encoded = bundle.encode();
-      final Bundle newBundle = Bundle.decode(encoded);
-      expect(newBundle['stringKey'], 'stringValue');
-    });
+  testWidgets('can encode and decode raw data', (WidgetTester _) async {
+    final Bundle bundle = Bundle();
+    bundle['stringKey'] = 'stringValue';
+    final String encoded = bundle.encode();
+    final Bundle newBundle = Bundle.decode(encoded);
+    expect(newBundle['stringKey'], 'stringValue');
   });
 }

--- a/packages/tizen_bundle/example/integration_test/bundle_test.dart
+++ b/packages/tizen_bundle/example/integration_test/bundle_test.dart
@@ -1,5 +1,10 @@
+// Copyright 2022 Samsung Electronics Co., Ltd. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
 import 'dart:typed_data';
 
+import 'package:flutter/foundation.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:integration_test/integration_test.dart';
 import 'package:tizen_bundle/tizen_bundle.dart';
@@ -10,363 +15,93 @@ void main() {
   group('$Bundle', () {
     testWidgets('can create a bundle', (WidgetTester _) async {
       final Bundle bundle = Bundle();
-      bundle['testName'] = 'bundleTest';
-      expect(bundle['testName'], 'bundleTest');
+      bundle['stringKey'] = 'stringValue';
+      expect(bundle['stringKey'], 'stringValue');
     });
 
     testWidgets('can create a bundle from another bundle',
         (WidgetTester _) async {
       final Bundle bundle = Bundle();
-      bundle['testName'] = 'bundleFromBundleTest';
+      bundle['stringKey'] = 'stringValue';
 
       final Bundle newBundle = Bundle.fromBundle(bundle);
-      expect(newBundle['testName'], 'bundleFromBundleTest');
+      expect(newBundle['stringKey'], 'stringValue');
     });
 
     testWidgets('can create a bundle from a map', (WidgetTester _) async {
-      const String string = 'String';
-      final List<String> strings = <String>['String 1', 'String 2'];
-      final Uint8List bytes = Uint8List(1);
-      bytes[0] = 0x03;
-      final Map<String, Object> map = <String, Object>{
-        'keyString': string,
-        'keyListString': strings,
-        'keyBytes': bytes
-      };
-
-      final Bundle bundle = Bundle.fromMap(map);
+      final Bundle bundle = Bundle.fromMap(<String, Object>{
+        'stringKey': 'stringValue',
+        'stringsKey': <String>['value1', 'value2'],
+        'bytesKey': Uint8List.fromList(<int>[0x03]),
+      });
       expect(bundle.length, 3);
-      expect(bundle['keyString'], string);
-      expect(bundle['keyListString'], strings);
-      expect(bundle['keyBytes'], bytes);
+      expect(bundle['stringKey'], 'stringValue');
+      expect(bundle['stringsKey'], <String>['value1', 'value2']);
+      expect(bundle['bytesKey'], Uint8List.fromList(<int>[0x03]));
     });
 
-    testWidgets('Bundle.entries returns entries of the Bundle',
-        (WidgetTester _) async {
-      final Bundle bundle = Bundle();
-      bundle['testName'] = 'entriesTest';
-      bundle['testName2'] = 'entriesTest2';
-
-      final Iterable<MapEntry<String, Object>> entries = bundle.entries;
-      for (final MapEntry<String, Object> entry in entries) {
-        bool matched = false;
-        if (entry.key == 'testName' && entry.value == 'entriesTest') {
-          matched = true;
-        } else if (entry.key == 'testName2' && entry.value == 'entriesTest2') {
-          matched = true;
-        }
-
-        expect(matched, true);
-      }
-
-      expect(entries.length, 2);
+    testWidgets('returns all stored keys and values', (WidgetTester _) async {
+      final Bundle bundle = Bundle.fromMap(<String, String>{
+        'key1': 'value1',
+        'key2': 'value2',
+        'key3': 'value3',
+      });
+      expect(bundle.keys, unorderedEquals(<String>['key1', 'key2', 'key3']));
+      expect(bundle.values,
+          unorderedEquals(<String>['value1', 'value2', 'value3']));
     });
 
-    testWidgets('Bundle.keys returns all stored keys', (WidgetTester _) async {
+    testWidgets('checks whether the bundle is empty', (WidgetTester _) async {
       final Bundle bundle = Bundle();
-      final List<String> keys = <String>['testKey', 'key1', 'key2', 'key3'];
-      final List<String> values = <String>[
-        'getKeyTest',
-        'value1',
-        'value2',
-        'value3'
-      ];
-      for (int index = 0; index < keys.length; ++index) {
-        bundle[keys[index]] = values[index];
-      }
+      bundle['stringKey'] = 'stringValue';
+      expect(bundle.isNotEmpty, true);
 
-      final Iterable<String> keysFromBundle = bundle.keys;
-      for (final String key in bundle.keys) {
-        expect(keys.contains(key), true);
-      }
-
-      expect(keysFromBundle.length, keys.length);
-    });
-
-    testWidgets('Bundle.values returns all stored values',
-        (WidgetTester _) async {
-      final Bundle bundle = Bundle();
-      final List<String> keys = <String>['testKey', 'key1', 'key2', 'key3'];
-      final List<String> values = <String>[
-        'getKeyTest',
-        'value1',
-        'value2',
-        'value3'
-      ];
-      for (int index = 0; index < keys.length; ++index) {
-        bundle[keys[index]] = values[index];
-      }
-
-      final Iterable<Object> valuesFromBundle = bundle.values;
-      for (final Object value in valuesFromBundle) {
-        expect(values.contains(value), true);
-      }
-
-      expect(valuesFromBundle.length, values.length);
-    });
-
-    testWidgets('Bundle.length returns the number of key/value pairs',
-        (WidgetTester _) async {
-      final Bundle bundle = Bundle();
-      expect(bundle.length, 0);
-      bundle['key1'] = 'value1';
-      expect(bundle.length, 1);
-      bundle['key2'] = 'value2';
-      expect(bundle.length, 2);
-      bundle['key3'] = 'value3';
-      expect(bundle.length, 3);
-      bundle['key4'] = 'value4';
-      bundle['testName'] = 'lengthTest';
-      expect(bundle.length, 5);
-    });
-
-    testWidgets('can check whether there is no key/value pair in the bundle',
-        (WidgetTester _) async {
-      final Bundle bundle = Bundle();
-      bundle['testName'] = 'isEmptyPropertyTest';
-      expect(bundle.isEmpty, false);
-      bundle.remove('testName');
+      bundle.remove('stringKey');
       expect(bundle.isEmpty, true);
     });
 
-    testWidgets(
-        'can check whether there is at least on key/value pair in the bundle',
-        (WidgetTester _) async {
+    testWidgets('can add a Uint8List value', (WidgetTester _) async {
       final Bundle bundle = Bundle();
-      bundle['testName'] = 'isNotEmptyPropertyTest';
-      expect(bundle.isNotEmpty, true);
-      bundle.remove('testName');
-      expect(bundle.isNotEmpty, false);
+      bundle['bytesKey'] = Uint8List(10);
+
+      final Uint8List bytes = bundle['bytesKey']! as Uint8List;
+      expect(bytes.length, 10);
     });
 
-    testWidgets('can set the key with the given String value to the bundle',
-        (WidgetTester _) async {
+    testWidgets('can add a List<String> value', (WidgetTester _) async {
       final Bundle bundle = Bundle();
-      bundle['testKey'] = 'testValue';
-      expect(bundle.length, 1);
-      expect(bundle['testKey'], 'testValue');
+      bundle['stringsKey'] = <String>['value1', 'value2'];
+
+      final List<String> strings = bundle['stringsKey']! as List<String>;
+      expect(strings, <String>['value1', 'value2']);
     });
 
-    testWidgets('can set the key with the given Uint8List value to the bundle',
-        (WidgetTester _) async {
+    testWidgets('can remove all entries', (WidgetTester _) async {
       final Bundle bundle = Bundle();
-      final Uint8List bytes = Uint8List(10);
-      bundle['testKey'] = bytes;
-      expect(bundle.length, 1);
-      final Uint8List resultBytes = bundle['testKey']! as Uint8List;
-      expect(bytes, resultBytes);
-      expect(bytes.length, resultBytes.length);
-    });
-
-    testWidgets(
-        'can set the key with the given List<String> value to the bundle',
-        (WidgetTester _) async {
-      final Bundle bundle = Bundle();
-      final List<String> strings = <String>['Hello', 'Tizen', 'Bundle'];
-      bundle['testKey'] = strings;
-      bundle['testName'] = 'operatorTestForStrings';
+      bundle['stringKey1'] = 'stringValue1';
+      bundle['stringKey2'] = 'stringValue2';
       expect(bundle.length, 2);
-      expect(bundle['testName'], 'operatorTestForStrings');
-      final List<String> resultStrings = bundle['testKey']! as List<String>;
-      expect(resultStrings.length, strings.length);
-      expect(resultStrings, strings);
-    });
 
-    testWidgets('can add all key/value pairs of other to this bundle',
-        (WidgetTester _) async {
-      const String string = 'String';
-      final List<String> strings = <String>['String 1', 'String 2'];
-      final Uint8List bytes = Uint8List(1);
-      bytes[0] = 0x02;
-      final Map<String, Object> map = <String, Object>{
-        'keyString': string,
-        'keyListString': strings,
-        'keyBytes': bytes
-      };
-
-      final Bundle bundle = Bundle();
-      bundle.addAll(map);
-      expect(bundle.length, 3);
-      expect(bundle['keyString'], string);
-      expect(bundle['keyListString'], strings);
-      expect(bundle['keyBytes'], bytes);
-    });
-
-    testWidgets('can add all key/value pairs of entries to this bundle',
-        (WidgetTester _) async {
-      const String string = 'String';
-      final List<String> strings = <String>['String 1', 'String 2'];
-      final Uint8List bytes = Uint8List(2);
-      bytes[0] = 0x01;
-      bytes[1] = 0x02;
-      final Map<String, Object> map = <String, Object>{
-        'keyString': string,
-        'keyListString': strings,
-        'keyBytes': bytes
-      };
-
-      final Bundle bundle = Bundle();
-      bundle.addEntries(map.entries);
-      expect(bundle.length, 3);
-      expect(bundle['keyString'], string);
-      expect(bundle['keyListString'], strings);
-      expect(bundle['keyBytes'], bytes);
-    });
-
-    testWidgets('can remove all entries from the bundle',
-        (WidgetTester _) async {
-      final Bundle bundle = Bundle();
-      bundle['testName'] = 'clearTest';
-      bundle['testName2'] = 'clearTest2';
-      expect(bundle.length, 2);
       bundle.clear();
       expect(bundle.length, 0);
-    });
-
-    testWidgets('can apply action to each key/value pair of the bundle',
-        (WidgetTester _) async {
-      final Bundle bundle = Bundle();
-      bundle['testName'] = 'forEachTest';
-      bundle['testName2'] = 'forEachTest2';
-      bundle['testName3'] = 'forEachTest3';
-      bundle.forEach((String key, Object value) {
-        bool matched = false;
-        if (key == 'testName' && value == 'forEachTest') {
-          matched = true;
-        } else if (key == 'testName2' && value == 'forEachTest2') {
-          matched = true;
-        } else if (key == 'testName3' && value == 'forEachTest3') {
-          matched = true;
-        }
-
-        expect(matched, true);
-      });
-    });
-
-    testWidgets('can check whether the bundle contains the given key or not',
-        (WidgetTester _) async {
-      final Bundle bundle = Bundle();
-      bundle['testName'] = 'containsKeyTest';
-      expect(bundle.containsKey('testName'), true);
-    });
-
-    testWidgets('can check whether the bundle contains the given value or not',
-        (WidgetTester _) async {
-      final Bundle bundle = Bundle();
-      bundle['testName'] = 'containsValueTest';
-      expect(bundle.containsValue('containsValueTest'), true);
-    });
-
-    testWidgets('Bundle.map returns a new map where all entries of the bundle',
-        (WidgetTester _) async {
-      final Bundle bundle = Bundle();
-      bundle['testName'] = 'mapTest';
-      bundle['testName2'] = 'mapTest';
-      bundle['testName3'] = 'mapTest';
-      bundle.map<String, String>((String key, Object value) {
-        return MapEntry<String, String>(key, value as String);
-      }).forEach((String key, String value) {
-        bool matched = false;
-        if (key == 'testName' && value == 'mapTest') {
-          matched = true;
-        } else if (key == 'testName2' && value == 'mapTest') {
-          matched = true;
-        } else if (key == 'testName3' && value == 'mapTest') {
-          matched = true;
-        }
-
-        expect(matched, true);
-      });
-    });
-
-    testWidgets('can add a new entry if it is not there',
-        (WidgetTester _) async {
-      final Bundle bundle = Bundle();
-      bundle['testName'] = 'putIfAbsentTest';
-      bundle.putIfAbsent('testName', () => 'putIfAbsentTest2');
-      expect(bundle.length, 1);
-      expect(bundle['testName'], 'putIfAbsentTest');
     });
 
     testWidgets('can remove key and its associated value',
         (WidgetTester _) async {
       final Bundle bundle = Bundle();
-      bundle['testName'] = 'removeTest';
-      expect(bundle.length, 1);
-      expect(bundle['testName'], 'removeTest');
-      bundle.remove('testName');
-      expect(bundle.length, 0);
+      bundle['stringKey'] = 'stringValue';
+      expect(bundle.containsKey('stringKey'), true);
+
+      bundle.remove('stringKey');
+      expect(bundle.containsKey('stringKey'), false);
     });
 
-    testWidgets(
-        'can remove all entries of the bundle that stisfy the given function',
-        (WidgetTester _) async {
+    testWidgets('can encode and decode raw data', (WidgetTester _) async {
       final Bundle bundle = Bundle();
-      bundle['testName'] = 'removeWhereTest';
-      bundle['testName2'] = 'removeWhereTest2';
-      expect(bundle.length, 2);
-      expect(bundle['testName'], 'removeWhereTest');
-      bundle.removeWhere((String key, Object value) {
-        return key == 'testName';
-      });
-      expect(bundle.length, 1);
-      expect(bundle['testName2'], 'removeWhereTest2');
-    });
-
-    testWidgets('can update the value for the provided key',
-        (WidgetTester _) async {
-      final Bundle bundle = Bundle();
-      bundle['testName'] = 'updateTest';
-      expect(bundle.length, 1);
-      expect(bundle['testName'], 'updateTest');
-
-      bundle.update('testName', (Object value) {
-        final String result = '${value as String}2';
-        return result;
-      });
-      expect(bundle.length, 1);
-      expect(bundle['testName'], 'updateTest2');
-    });
-
-    testWidgets('can update all values', (WidgetTester _) async {
-      final Bundle bundle = Bundle();
-      bundle['testName'] = 'updateAllTest';
-      bundle['testName2'] = 'updateAllTest';
-      bundle['testName3'] = 'updateAllTest';
-      expect(bundle.length, 3);
-      expect(bundle['testName'], 'updateAllTest');
-      expect(bundle['testName2'], 'updateAllTest');
-      expect(bundle['testName3'], 'updateAllTest');
-
-      bundle.updateAll((String key, Object value) {
-        final String result = '$key+${value as String}';
-        return result;
-      });
-      expect(bundle.length, 3);
-      expect(bundle['testName'], 'testName+updateAllTest');
-      expect(bundle['testName2'], 'testName2+updateAllTest');
-      expect(bundle['testName3'], 'testName3+updateAllTest');
-    });
-
-    testWidgets('can create a bundle from the encoded raw data',
-        (WidgetTester _) async {
-      final Bundle bundle = Bundle();
-      bundle['testName'] = 'bundleDecodeTest';
-      final String bundleRaw = bundle.encode();
-      final Bundle newBundle = Bundle.decode(bundleRaw);
-      expect(newBundle['testName'], 'bundleDecodeTest');
-    });
-
-    testWidgets('can encode the bundle to the String', (WidgetTester _) async {
-      final Bundle bundle = Bundle();
-      bundle['testName'] = 'encodeTest';
-      expect(bundle.length, 1);
-
-      final String bundleRaw = bundle.encode();
-      expect(bundleRaw.isNotEmpty, true);
-
-      final Bundle newBundle = Bundle.decode(bundleRaw);
-      expect(newBundle['testName'], 'encodeTest');
+      bundle['stringKey'] = 'stringValue';
+      final String encoded = bundle.encode();
+      final Bundle newBundle = Bundle.decode(encoded);
+      expect(newBundle['stringKey'], 'stringValue');
     });
   });
 }

--- a/packages/tizen_bundle/example/lib/main.dart
+++ b/packages/tizen_bundle/example/lib/main.dart
@@ -1,14 +1,17 @@
+// Copyright 2022 Samsung Electronics Co., Ltd. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// ignore_for_file: public_member_api_docs
+
 import 'package:flutter/material.dart';
 import 'package:tizen_bundle/tizen_bundle.dart';
 
-/// The main entry point.
 void main() {
   runApp(const MyApp());
 }
 
-/// The UI app widget.
 class MyApp extends StatefulWidget {
-  /// The UI app widget.
   const MyApp({super.key});
 
   @override
@@ -18,12 +21,6 @@ class MyApp extends StatefulWidget {
 class _MyAppState extends State<MyApp> {
   final Bundle _bundle = Bundle();
   int _count = 0;
-  String _msg = '';
-
-  @override
-  void initState() {
-    super.initState();
-  }
 
   @override
   Widget build(BuildContext context) {
@@ -36,74 +33,30 @@ class _MyAppState extends State<MyApp> {
           child: Column(
             mainAxisAlignment: MainAxisAlignment.center,
             children: <Widget>[
-              const Text(
-                'Bundle example',
-                style: TextStyle(fontWeight: FontWeight.bold),
-              ),
-              Padding(
-                padding: const EdgeInsets.fromLTRB(0.0, 50.0, 0.0, 50.0),
-                child: Text('Message: $_msg\n'),
-              ),
-              const SizedBox(height: 20),
-              TextButton(
+              Text('Current size: ${_bundle.length}'),
+              const SizedBox(height: 10),
+              ElevatedButton(
                 onPressed: () {
-                  try {
-                    _bundle['stringKey_${_count++}'] = 'stringValue_$_count';
-                    setState(() {
-                      _msg = 'addString done.';
-                    });
-                  } on Exception catch (_, e) {
-                    setState(() {
-                      _msg = 'Exception($e) occurs';
-                    });
-                  }
+                  _bundle['stringKey_${_count++}'] = 'stringValue_$_count';
+                  setState(() {});
                 },
                 child: const Text('Add String'),
               ),
-              TextButton(
+              const SizedBox(height: 10),
+              ElevatedButton(
                 onPressed: () {
-                  if (_count > 0) {
-                    final Object? value = _bundle['stringKey_${_count - 1}'];
-                    setState(() {
-                      _msg = 'getString done. value: $value';
-                    });
-                  } else {
-                    setState(() {
-                      _msg = 'Bundle is empty';
-                    });
-                  }
-                },
-                child: const Text('Get String'),
-              ),
-              TextButton(
-                onPressed: () {
-                  setState(() {
-                    _msg = 'length: ${_bundle.length}';
-                  });
-                },
-                child: const Text('Get length'),
-              ),
-              TextButton(
-                onPressed: () {
-                  if (_count > 0) {
-                    _bundle.remove('stringKey_${--_count}');
-                    setState(() {
-                      _msg = 'remove done.';
-                    });
-                  } else {
-                    setState(() {
-                      _msg = 'Bundle is empty';
-                    });
+                  if (_bundle.isNotEmpty) {
+                    _bundle.remove(_bundle.keys.last);
+                    setState(() {});
                   }
                 },
                 child: const Text('Remove String'),
               ),
-              TextButton(
+              const SizedBox(height: 10),
+              ElevatedButton(
                 onPressed: () {
                   _bundle.clear();
-                  setState(() {
-                    _msg = 'clear done.';
-                  });
+                  setState(() {});
                 },
                 child: const Text('Clear'),
               ),

--- a/packages/tizen_bundle/lib/tizen_bundle.dart
+++ b/packages/tizen_bundle/lib/tizen_bundle.dart
@@ -9,9 +9,11 @@ import 'package:ffi/ffi.dart';
 import 'package:flutter/services.dart' hide Size;
 import 'package:tizen_interop/4.0/tizen.dart';
 
+export 'dart:typed_data' show Uint8List;
+
 /// A string-based dictionary data type.
 ///
-/// A dictionary is a collection of key-value pairs from which you can locate
+/// A dictionary is a collection of key-value pairs, from which you can locate
 /// a value using its associated key. The key is always a [String]. The value
 /// must be either a [String], a list of [String]s, or a [Uint8List].
 class Bundle extends MapMixin<String, Object> {

--- a/packages/tizen_bundle/pubspec.yaml
+++ b/packages/tizen_bundle/pubspec.yaml
@@ -2,14 +2,14 @@ name: tizen_bundle
 description: Tizen bundle APIs.
 homepage: https://github.com/flutter-tizen/plugins
 repository: https://github.com/flutter-tizen/plugins/tree/master/packages/tizen_bundle
-version: 0.1.0
+version: 0.1.1
 
 environment:
   sdk: ">=2.17.0 <3.0.0"
   flutter: ">=2.5.0"
 
 dependencies:
-  ffi: ">=2.0.1 <3.0.0"
+  ffi: ^2.0.1
   flutter:
     sdk: flutter
   tizen_interop: ^0.2.0


### PR DESCRIPTION
- Update outdated information in README.
- Remove redundant test cases.
- Simplify the example app.
- Export the `Uint8List` type from `tizen_bundle.dart`.
- Compute `Bundle.length`, `Bundle.isEmpty`, and `Bundle.isNotEmpty` more efficiently.
- Code formatting and cleanups.