### PR TITLE
Hold memory of StreamHandlerError's member

### DIFF
--- a/packages/battery_plus/CHANGELOG.md
+++ b/packages/battery_plus/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.1.1
+
+* Hold memory of StreamHandlerError's member to prevent crash.
+
 ## 1.1.0
 
 * Update battery_plus to 2.1.3.

--- a/packages/battery_plus/README.md
+++ b/packages/battery_plus/README.md
@@ -11,7 +11,7 @@ This package is not an _endorsed_ implementation of `battery_plus`. Therefore, y
 ```yaml
 dependencies:
   battery_plus: ^2.1.3
-  battery_plus_tizen: ^1.1.0
+  battery_plus_tizen: ^1.1.1
 ```
 
 Then you can import `battery_plus` in your Dart code:

--- a/packages/battery_plus/pubspec.yaml
+++ b/packages/battery_plus/pubspec.yaml
@@ -2,7 +2,7 @@ name: battery_plus_tizen
 description: Tizen implementation of the battery_plus plugin
 homepage: https://github.com/flutter-tizen/plugins
 repository: https://github.com/flutter-tizen/plugins/tree/master/packages/battery_plus
-version: 1.1.0
+version: 1.1.1
 
 flutter:
   plugin:

--- a/packages/battery_plus/tizen/src/battery_plus_tizen_plugin.cc
+++ b/packages/battery_plus/tizen/src/battery_plus_tizen_plugin.cc
@@ -41,6 +41,20 @@ std::string BatteryStatusToString(BatteryStatus status) {
   }
 }
 
+class BatteryStatusStreamHandlerError : public FlStreamHandlerError {
+ public:
+  BatteryStatusStreamHandlerError(const std::string &error_code,
+                                  const std::string &error_message,
+                                  const flutter::EncodableValue *error_details)
+      : error_code_(error_code),
+        error_message_(error_message),
+        FlStreamHandlerError(error_code_, error_message_, error_details) {}
+
+ private:
+  std::string error_code_;
+  std::string error_message_;
+};
+
 class BatteryStatusStreamHandler : public FlStreamHandler {
  protected:
   std::unique_ptr<FlStreamHandlerError> OnListenInternal(
@@ -58,7 +72,7 @@ class BatteryStatusStreamHandler : public FlStreamHandler {
       }
     };
     if (!battery_.StartListen(callback)) {
-      return std::make_unique<FlStreamHandlerError>(
+      return std::make_unique<BatteryStatusStreamHandlerError>(
           std::to_string(battery_.GetLastError()),
           battery_.GetLastErrorString(), nullptr);
     }

--- a/packages/connectivity_plus/CHANGELOG.md
+++ b/packages/connectivity_plus/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.1.2
+
+* Hold memory of StreamHandlerError's member to prevent crash.
+
 ## 1.1.1
 
 * Update connectivity_plus to 2.3.0.

--- a/packages/connectivity_plus/README.md
+++ b/packages/connectivity_plus/README.md
@@ -11,7 +11,7 @@ This package is not an _endorsed_ implementation of `connectivity_plus`. Therefo
 ```yaml
 dependencies:
   connectivity_plus: ^2.3.0
-  connectivity_plus_tizen: ^1.1.1
+  connectivity_plus_tizen: ^1.1.2
 ```
 
 Then you can import `connectivity_plus` in your Dart code:

--- a/packages/connectivity_plus/pubspec.yaml
+++ b/packages/connectivity_plus/pubspec.yaml
@@ -2,7 +2,7 @@ name: connectivity_plus_tizen
 description: Tizen implementation of the connectivity_plus plugin.
 homepage: https://github.com/flutter-tizen/plugins
 repository: https://github.com/flutter-tizen/plugins/tree/master/packages/connectivity_plus
-version: 1.1.1
+version: 1.1.2
 
 flutter:
   plugin:

--- a/packages/connectivity_plus/tizen/src/connectivity_plus_tizen_plugin.cc
+++ b/packages/connectivity_plus/tizen/src/connectivity_plus_tizen_plugin.cc
@@ -43,6 +43,20 @@ std::string ConnectionTypeToString(ConnectionType type) {
   }
 }
 
+class ConnectivityStreamHandlerError : public FlStreamHandlerError {
+ public:
+  ConnectivityStreamHandlerError(const std::string &error_code,
+                                 const std::string &error_message,
+                                 const flutter::EncodableValue *error_details)
+      : error_code_(error_code),
+        error_message_(error_message),
+        FlStreamHandlerError(error_code_, error_message_, error_details) {}
+
+ private:
+  std::string error_code_;
+  std::string error_message_;
+};
+
 class ConnectivityStreamHandler : public FlStreamHandler {
  protected:
   std::unique_ptr<FlStreamHandlerError> OnListenInternal(
@@ -59,7 +73,7 @@ class ConnectivityStreamHandler : public FlStreamHandler {
       }
     };
     if (!connection_.StartListen(callback)) {
-      return std::make_unique<FlStreamHandlerError>(
+      return std::make_unique<ConnectivityStreamHandlerError>(
           std::to_string(connection_.GetLastError()),
           connection_.GetLastErrorString(), nullptr);
     }

--- a/packages/geolocator/CHANGELOG.md
+++ b/packages/geolocator/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.0.5
+
+* Hold memory of StreamHandlerError's member to prevent crash
+
 ## 1.0.4
 
 * Resolve linter warnings.

--- a/packages/geolocator/README.md
+++ b/packages/geolocator/README.md
@@ -11,7 +11,7 @@ The Tizen implementation of [`geolocator`](https://github.com/Baseflow/flutter-g
  ```yaml
 dependencies:
   geolocator: ^8.0.0
-  geolocator_tizen: ^1.0.4
+  geolocator_tizen: ^1.0.5
 ```
 
 Then you can import `geolocator` in your Dart code:

--- a/packages/geolocator/pubspec.yaml
+++ b/packages/geolocator/pubspec.yaml
@@ -2,7 +2,7 @@ name: geolocator_tizen
 description: Geolocation plugin for Flutter. This plugin provides the Tizen implementation for the geolocator.
 homepage: https://github.com/flutter-tizen/plugins
 repository: https://github.com/flutter-tizen/plugins/tree/master/packages/geolocator
-version: 1.0.4
+version: 1.0.5
 
 flutter:
   plugin:

--- a/packages/geolocator/tizen/src/geolocator_tizen_plugin.cc
+++ b/packages/geolocator/tizen/src/geolocator_tizen_plugin.cc
@@ -31,6 +31,20 @@ typedef flutter::StreamHandlerError<flutter::EncodableValue>
 
 constexpr char kPrivilegeLocation[] = "http://tizen.org/privilege/location";
 
+class LocationStreamHandlerError : public FlStreamHandlerError {
+ public:
+  LocationStreamHandlerError(const std::string &error_code,
+                             const std::string &error_message,
+                             const flutter::EncodableValue *error_details)
+      : error_code_(error_code),
+        error_message_(error_message),
+        FlStreamHandlerError(error_code_, error_message_, error_details) {}
+
+ private:
+  std::string error_code_;
+  std::string error_message_;
+};
+
 class LocationStreamHandler : public FlStreamHandler {
  protected:
   std::unique_ptr<FlStreamHandlerError> OnListenInternal(
@@ -43,11 +57,9 @@ class LocationStreamHandler : public FlStreamHandler {
     try {
       location_manager_.StartListenLocationUpdate(callback);
     } catch (const LocationManagerError &error) {
-      // Issue: https://github.com/flutter/flutter/issues/101682
-      error_code_ = std::to_string(error.GetErrorCode());
-      error_message_ = error.GetErrorString();
-      return std::make_unique<FlStreamHandlerError>(error_code_, error_message_,
-                                                    nullptr);
+      return std::make_unique<LocationStreamHandlerError>(
+          std::to_string(error.GetErrorCode()), error.GetErrorString(),
+          nullptr);
     }
     return nullptr;
   }
@@ -57,10 +69,9 @@ class LocationStreamHandler : public FlStreamHandler {
     try {
       location_manager_.StopListenLocationUpdate();
     } catch (const LocationManagerError &error) {
-      error_code_ = std::to_string(error.GetErrorCode());
-      error_message_ = error.GetErrorString();
-      return std::make_unique<FlStreamHandlerError>(error_code_, error_message_,
-                                                    nullptr);
+      return std::make_unique<LocationStreamHandlerError>(
+          std::to_string(error.GetErrorCode()), error.GetErrorString(),
+          nullptr);
     }
     events_.reset();
     return nullptr;
@@ -69,9 +80,6 @@ class LocationStreamHandler : public FlStreamHandler {
  private:
   LocationManager location_manager_;
   std::unique_ptr<FlEventSink> events_;
-
-  std::string error_code_;
-  std::string error_message_;
 };
 
 class ServiceStatusStreamHandler : public FlStreamHandler {
@@ -86,11 +94,9 @@ class ServiceStatusStreamHandler : public FlStreamHandler {
     try {
       location_manager_.StartListenServiceStatusUpdate(callback);
     } catch (const LocationManagerError &error) {
-      // Issue: https://github.com/flutter/flutter/issues/101682
-      error_code_ = std::to_string(error.GetErrorCode());
-      error_message_ = error.GetErrorString();
-      return std::make_unique<FlStreamHandlerError>(error_code_, error_message_,
-                                                    nullptr);
+      return std::make_unique<LocationStreamHandlerError>(
+          std::to_string(error.GetErrorCode()), error.GetErrorString(),
+          nullptr);
     }
     return nullptr;
   }
@@ -100,10 +106,9 @@ class ServiceStatusStreamHandler : public FlStreamHandler {
     try {
       location_manager_.StopListenServiceStatusUpdate();
     } catch (const LocationManagerError &error) {
-      error_code_ = std::to_string(error.GetErrorCode());
-      error_message_ = error.GetErrorString();
-      return std::make_unique<FlStreamHandlerError>(error_code_, error_message_,
-                                                    nullptr);
+      return std::make_unique<LocationStreamHandlerError>(
+          std::to_string(error.GetErrorCode()), error.GetErrorString(),
+          nullptr);
     }
     events_.reset();
     return nullptr;
@@ -112,9 +117,6 @@ class ServiceStatusStreamHandler : public FlStreamHandler {
  private:
   LocationManager location_manager_;
   std::unique_ptr<FlEventSink> events_;
-
-  std::string error_code_;
-  std::string error_message_;
 };
 
 class GeolocatorTizenPlugin : public flutter::Plugin {

--- a/packages/sensors_plus/CHANGELOG.md
+++ b/packages/sensors_plus/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.1.1
+
+* Hold memory of StreamHandlerError's member to prevent crash.
+
 ## 1.1.0
 
 * Update sensors_plus to 1.2.1.

--- a/packages/sensors_plus/README.md
+++ b/packages/sensors_plus/README.md
@@ -11,7 +11,7 @@ This package is not an _endorsed_ implementation of 'sensors_plus'. Therefore, y
 ```yaml
 dependencies:
   sensors_plus: ^1.2.1
-  sensors_plus_tizen: ^1.1.0
+  sensors_plus_tizen: ^1.1.1
 ```
 
 Then you can import `sensors_plus` in your Dart code:

--- a/packages/sensors_plus/pubspec.yaml
+++ b/packages/sensors_plus/pubspec.yaml
@@ -2,7 +2,7 @@ name: sensors_plus_tizen
 description: Tizen implementation of the sensors plugin
 homepage: https://github.com/flutter-tizen/plugins
 repository: https://github.com/flutter-tizen/plugins/tree/master/packages/sensors_plus
-version: 1.1.0
+version: 1.1.1
 
 flutter:
   plugin:

--- a/packages/sensors_plus/tizen/src/sensors_plus_plugin.cc
+++ b/packages/sensors_plus/tizen/src/sensors_plus_plugin.cc
@@ -18,6 +18,20 @@ typedef flutter::StreamHandler<flutter::EncodableValue> FlStreamHandler;
 typedef flutter::StreamHandlerError<flutter::EncodableValue>
     FlStreamHandlerError;
 
+class DeviceSensorStreamHandlerError : public FlStreamHandlerError {
+ public:
+  DeviceSensorStreamHandlerError(const std::string &error_code,
+                                 const std::string &error_message,
+                                 const flutter::EncodableValue *error_details)
+      : error_code_(error_code),
+        error_message_(error_message),
+        FlStreamHandlerError(error_code_, error_message_, error_details) {}
+
+ private:
+  std::string error_code_;
+  std::string error_message_;
+};
+
 class DeviceSensorStreamHandler : public FlStreamHandler {
  public:
   DeviceSensorStreamHandler(SensorType type) : sensor_(type) {}
@@ -32,7 +46,7 @@ class DeviceSensorStreamHandler : public FlStreamHandler {
       events_->Success(flutter::EncodableValue(sensor_event));
     };
     if (!sensor_.StartListen(callback)) {
-      return std::make_unique<FlStreamHandlerError>(
+      return std::make_unique<DeviceSensorStreamHandlerError>(
           std::to_string(sensor_.GetLastError()), sensor_.GetLastErrorString(),
           nullptr);
     }


### PR DESCRIPTION
* Use a derived class to hold memory not guaranteed by StreamHandlerError.
* This patch prevents crashes caused by dereferences to invalid memory.
* Update version.

Signed-off-by: Boram Bae <boram21.bae@samsung.com>