### PR TITLE
[wearable_rotary] Refactor the C++ code

### DIFF
--- a/packages/wearable_rotary/CHANGELOG.md
+++ b/packages/wearable_rotary/CHANGELOG.md
@@ -1,3 +1,7 @@
+## NEXT
+
+* Refactor the C++ code.
+
 ## 1.0.2
 
 * Typo fix and minor cleanups.

--- a/packages/wearable_rotary/tizen/src/wearable_rotary_plugin.cc
+++ b/packages/wearable_rotary/tizen/src/wearable_rotary_plugin.cc
@@ -8,15 +8,72 @@
 #include <flutter/encodable_value.h>
 #include <flutter/event_channel.h>
 #include <flutter/event_sink.h>
-#include <flutter/event_stream_handler_functions.h>
+#include <flutter/event_stream_handler.h>
 #include <flutter/plugin_registrar.h>
 #include <flutter/standard_method_codec.h>
 
 #include <memory>
+#include <string>
 
 #include "log.h"
 
-static constexpr char kChannelName[] = "flutter.wearable_rotary.channel";
+namespace {
+
+typedef flutter::EventChannel<flutter::EncodableValue> FlEventChannel;
+typedef flutter::EventSink<flutter::EncodableValue> FlEventSink;
+typedef flutter::StreamHandler<flutter::EncodableValue> FlStreamHandler;
+typedef flutter::StreamHandlerError<flutter::EncodableValue>
+    FlStreamHandlerError;
+
+class WearableRotaryStreamHandlerError : public FlStreamHandlerError {
+ public:
+  WearableRotaryStreamHandlerError(const std::string &error_code,
+                                   const std::string &error_message,
+                                   const flutter::EncodableValue *error_details)
+      : error_code_(error_code),
+        error_message_(error_message),
+        FlStreamHandlerError(error_code_, error_message_, error_details) {}
+
+ private:
+  std::string error_code_;
+  std::string error_message_;
+};
+
+class WearableRotaryStreamHandler : public FlStreamHandler {
+ public:
+  WearableRotaryStreamHandler() {}
+
+ protected:
+  std::unique_ptr<FlStreamHandlerError> OnListenInternal(
+      const flutter::EncodableValue *arguments,
+      std::unique_ptr<FlEventSink> &&events) override {
+    events_ = std::move(events);
+    Eina_Bool ret = eext_rotary_event_handler_add(RotaryEventCallBack, this);
+    if (ret == EINA_FALSE) {
+      return std::make_unique<WearableRotaryStreamHandlerError>(
+          "Operation failed", "Failed to add rotary event handler", nullptr);
+    }
+    return nullptr;
+  }
+
+  std::unique_ptr<FlStreamHandlerError> OnCancelInternal(
+      const flutter::EncodableValue *arguments) override {
+    eext_rotary_event_handler_del(RotaryEventCallBack);
+    events_.reset();
+    return nullptr;
+  }
+
+ private:
+  static Eina_Bool RotaryEventCallBack(void *data,
+                                       Eext_Rotary_Event_Info *info) {
+    auto *self = reinterpret_cast<WearableRotaryStreamHandler *>(data);
+    bool clockwise = (info->direction == EEXT_ROTARY_DIRECTION_CLOCKWISE);
+    self->events_->Success(flutter::EncodableValue(clockwise));
+    return EINA_TRUE;
+  }
+
+  std::unique_ptr<FlEventSink> events_;
+};
 
 class WearableRotaryPlugin : public flutter::Plugin {
  public:
@@ -32,49 +89,18 @@ class WearableRotaryPlugin : public flutter::Plugin {
 
  private:
   void SetupEventChannel(flutter::PluginRegistrar *registrar) {
-    event_channel_ =
-        std::make_unique<flutter::EventChannel<flutter::EncodableValue>>(
-            registrar->messenger(), kChannelName,
-            &flutter::StandardMethodCodec::GetInstance());
-    auto wearable_rotary_channel_handler =
-        std::make_unique<flutter::StreamHandlerFunctions<>>(
-            [this](const flutter::EncodableValue *arguments,
-                   std::unique_ptr<flutter::EventSink<>> &&events)
-                -> std::unique_ptr<flutter::StreamHandlerError<>> {
-              LOG_DEBUG("OnListen");
-              Eina_Bool ret =
-                  eext_rotary_event_handler_add(RotaryEventCallBack, this);
-              if (ret == EINA_FALSE) {
-                events->Error("failed to add callback");
-                return nullptr;
-              }
-              events_ = std::move(events);
-              return nullptr;
-            },
-            [this](const flutter::EncodableValue *arguments)
-                -> std::unique_ptr<flutter::StreamHandlerError<>> {
-              LOG_DEBUG("OnCancel");
-              eext_rotary_event_handler_del(RotaryEventCallBack);
-              events_ = nullptr;
-              return nullptr;
-            });
+    event_channel_ = std::make_unique<FlEventChannel>(
+        registrar->messenger(), "flutter.wearable_rotary.channel",
+        &flutter::StandardMethodCodec::GetInstance());
     event_channel_->SetStreamHandler(
-        std::move(wearable_rotary_channel_handler));
-  }
-
-  static Eina_Bool RotaryEventCallBack(void *data,
-                                       Eext_Rotary_Event_Info *info) {
-    auto *self = reinterpret_cast<WearableRotaryPlugin *>(data);
-    bool clockwise = info->direction == EEXT_ROTARY_DIRECTION_CLOCKWISE;
-    self->events_->Success(flutter::EncodableValue(clockwise));
-    return EINA_TRUE;
+        std::make_unique<WearableRotaryStreamHandler>());
   }
 
  private:
-  std::unique_ptr<flutter::EventChannel<flutter::EncodableValue>>
-      event_channel_;
-  std::unique_ptr<flutter::EventSink<flutter::EncodableValue>> events_;
+  std::unique_ptr<FlEventChannel> event_channel_;
 };
+
+}  // namespace
 
 void WearableRotaryPluginRegisterWithRegistrar(
     FlutterDesktopPluginRegistrarRef registrar) {


### PR DESCRIPTION
This patch includes:
* Simplify WearableRotaryPlugin Implementation.
* Use derived class from flutter::StreamHandler to set stream handlers.
* Use derived class from flutter::StreamHandlerError to hold references safely.

This change contribute #354

Signed-off-by: Boram Bae <boram21.bae@samsung.com>