### PR TITLE
[image_picker] Resolve unnecessary_nullable_for_final_variable_declarations

### DIFF
--- a/packages/image_picker/CHANGELOG.md
+++ b/packages/image_picker/CHANGELOG.md
@@ -1,5 +1,7 @@
-## NEXT
+## 2.1.1
 
+* Update image_picker to 0.8.6.
+* Update image_picker_platform_interface to 2.6.2.
 * Update the example app.
 * Migrate to new analysis options.
 * Remove obsolete dependency on pedantic.

--- a/packages/image_picker/README.md
+++ b/packages/image_picker/README.md
@@ -10,8 +10,8 @@ To use this plugin, add `image_picker` and `image_picker_tizen` as [dependencies
 
 ```yaml
 dependencies:
-  image_picker: ^0.8.4
-  image_picker_tizen: ^2.1.0
+  image_picker: ^0.8.6
+  image_picker_tizen: ^2.1.1
 ```
 
 Then you can import `image_picker` in your Dart code.

--- a/packages/image_picker/example/lib/main.dart
+++ b/packages/image_picker/example/lib/main.dart
@@ -93,7 +93,7 @@ class _MyHomePageState extends State<MyHomePage> {
       await _displayPickImageDialog(context!,
           (double? maxWidth, double? maxHeight, int? quality) async {
         try {
-          final List<XFile>? pickedFileList = await _picker.pickMultiImage(
+          final List<XFile> pickedFileList = await _picker.pickMultiImage(
             maxWidth: maxWidth,
             maxHeight: maxHeight,
             imageQuality: quality,

--- a/packages/image_picker/example/pubspec.yaml
+++ b/packages/image_picker/example/pubspec.yaml
@@ -5,7 +5,7 @@ publish_to: "none"
 dependencies:
   flutter:
     sdk: flutter
-  image_picker: ^0.8.4
+  image_picker: ^0.8.6
   image_picker_tizen:
     path: ../
   video_player: ^2.1.4

--- a/packages/image_picker/pubspec.yaml
+++ b/packages/image_picker/pubspec.yaml
@@ -3,7 +3,7 @@ description: Flutter plugin for selecting images from the Tizen image
   library, and taking new pictures with the camera.
 homepage: https://github.com/flutter-tizen/plugins
 repository: https://github.com/flutter-tizen/plugins/tree/master/packages/image_picker
-version: 2.1.0
+version: 2.1.1
 
 flutter:
   plugin:
@@ -15,7 +15,7 @@ flutter:
 dependencies:
   flutter:
     sdk: flutter
-  image_picker_platform_interface: ^2.4.1
+  image_picker_platform_interface: ^2.6.2
 
 environment:
   sdk: ">=2.12.0 <3.0.0"


### PR DESCRIPTION
The return type of `pickMultiImage` is now non-nullable.

Fixes [this CI analysis failure](https://github.com/flutter-tizen/plugins/actions/runs/3203312940/jobs/5233258312).