### PR TITLE
[network_info_plus] Do not use deprecated APIs

### DIFF
--- a/packages/network_info_plus/CHANGELOG.md
+++ b/packages/network_info_plus/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 1.1.3
+
+* Update network_info_plus to 2.3.2.
+* Update network_info_plus_platform_interface to 1.1.2.
+* Update the example app to not use deprecated iOS-specific APIs.
+
 ## 1.1.2
 
 * Update network_info_plus to 2.1.2

--- a/packages/network_info_plus/README.md
+++ b/packages/network_info_plus/README.md
@@ -10,8 +10,8 @@ This package is not an _endorsed_ implementation of `network_info_plus`. Therefo
 
 ```yaml
 dependencies:
-  network_info_plus: ^2.1.2
-  network_info_plus_tizen: ^1.1.2
+  network_info_plus: ^2.3.2
+  network_info_plus_tizen: ^1.1.3
 ```
 
 Then you can import `network_info_plus` in your Dart code:

--- a/packages/network_info_plus/example/integration_test/network_info_plus_test.dart
+++ b/packages/network_info_plus/example/integration_test/network_info_plus_test.dart
@@ -4,9 +4,8 @@
 
 // @dart=2.9
 
-import 'dart:io';
-import 'package:integration_test/integration_test.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:integration_test/integration_test.dart';
 import 'package:network_info_plus/network_info_plus.dart';
 
 void main() {
@@ -19,11 +18,14 @@ void main() {
       _networkInfo = NetworkInfo();
     });
 
-    testWidgets('test location methods, iOS only', (WidgetTester tester) async {
-      if (Platform.isIOS) {
-        expect(await _networkInfo.getLocationServiceAuthorization(),
-            LocationAuthorizationStatus.notDetermined);
-      }
+    testWidgets('test non-null network value', (WidgetTester tester) async {
+      expect(_networkInfo.getWifiName(), isNotNull);
+      expect(_networkInfo.getWifiBSSID(), isNotNull);
+      expect(_networkInfo.getWifiIP(), isNotNull);
+      expect(_networkInfo.getWifiIPv6(), isNotNull);
+      expect(_networkInfo.getWifiSubmask(), isNotNull);
+      expect(_networkInfo.getWifiGatewayIP(), isNotNull);
+      expect(_networkInfo.getWifiBroadcast(), isNotNull);
     });
   });
 }

--- a/packages/network_info_plus/example/lib/main.dart
+++ b/packages/network_info_plus/example/lib/main.dart
@@ -65,9 +65,23 @@ class _MyHomePageState extends State<MyHomePage> {
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(
-        title: const Text('NetworkInfo example app'),
+        title: const Text('NetworkInfoPlus example'),
       ),
-      body: Center(child: Text('Connection Status: $_connectionStatus')),
+      body: Center(
+          child: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          const Text(
+            'Network info',
+            style: TextStyle(
+              fontSize: 16,
+              fontWeight: FontWeight.bold,
+            ),
+          ),
+          const SizedBox(height: 16),
+          Text(_connectionStatus),
+        ],
+      )),
     );
   }
 
@@ -81,40 +95,14 @@ class _MyHomePageState extends State<MyHomePage> {
         wifiSubmask;
 
     try {
-      if (!kIsWeb && Platform.isIOS) {
-        var status = await _networkInfo.getLocationServiceAuthorization();
-        if (status == LocationAuthorizationStatus.notDetermined) {
-          status = await _networkInfo.requestLocationServiceAuthorization();
-        }
-        if (status == LocationAuthorizationStatus.authorizedAlways ||
-            status == LocationAuthorizationStatus.authorizedWhenInUse) {
-          wifiName = await _networkInfo.getWifiName();
-        } else {
-          wifiName = await _networkInfo.getWifiName();
-        }
-      } else {
-        wifiName = await _networkInfo.getWifiName();
-      }
+      wifiName = await _networkInfo.getWifiName();
     } on PlatformException catch (e) {
       developer.log('Failed to get Wifi Name', error: e);
       wifiName = 'Failed to get Wifi Name';
     }
 
     try {
-      if (!kIsWeb && Platform.isIOS) {
-        var status = await _networkInfo.getLocationServiceAuthorization();
-        if (status == LocationAuthorizationStatus.notDetermined) {
-          status = await _networkInfo.requestLocationServiceAuthorization();
-        }
-        if (status == LocationAuthorizationStatus.authorizedAlways ||
-            status == LocationAuthorizationStatus.authorizedWhenInUse) {
-          wifiBSSID = await _networkInfo.getWifiBSSID();
-        } else {
-          wifiBSSID = await _networkInfo.getWifiBSSID();
-        }
-      } else {
-        wifiBSSID = await _networkInfo.getWifiBSSID();
-      }
+      wifiBSSID = await _networkInfo.getWifiBSSID();
     } on PlatformException catch (e) {
       developer.log('Failed to get Wifi BSSID', error: e);
       wifiBSSID = 'Failed to get Wifi BSSID';

--- a/packages/network_info_plus/example/pubspec.yaml
+++ b/packages/network_info_plus/example/pubspec.yaml
@@ -5,7 +5,7 @@ publish_to: "none"
 dependencies:
   flutter:
     sdk: flutter
-  network_info_plus: ^2.1.2
+  network_info_plus: ^2.3.2
   network_info_plus_tizen:
     path: ../
 

--- a/packages/network_info_plus/pubspec.yaml
+++ b/packages/network_info_plus/pubspec.yaml
@@ -2,7 +2,7 @@ name: network_info_plus_tizen
 description: Tizen implementation of the network_info_plus plugin
 homepage: https://github.com/flutter-tizen/plugins
 repository: https://github.com/flutter-tizen/plugins/tree/master/packages/network_info_plus
-version: 1.1.2
+version: 1.1.3
 
 flutter:
   plugin:
@@ -14,7 +14,7 @@ flutter:
 dependencies:
   flutter:
     sdk: flutter
-  network_info_plus_platform_interface: ^1.1.1
+  network_info_plus_platform_interface: ^1.1.2
 
 dev_dependencies:
   flutter_lints: ^1.0.4


### PR DESCRIPTION
Update the example app and integration_test to not use iOS-specific permission methods (deprecated as of network_info_plus 2.3.2).

Fixes CI analyze failures.