### PR TITLE
Use the tools analyze command for code analysis

### DIFF
--- a/.github/workflows/analyze.yml
+++ b/.github/workflows/analyze.yml
@@ -10,14 +10,8 @@ jobs:
       - uses: subosito/flutter-action@v2
         with:
           channel: stable
-      - name: Install pub dependencies
-        run: |
-          for d in `pwd`/packages/*/; do
-            cd $d
-            flutter pub get
-          done
       - name: Analyze source code
-        run: dart analyze --fatal-infos packages
+        run: ./tools/tools_runner.sh analyze --custom-analysis=$(ls packages | tr '\n' ',')
 
   format:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Use the `tools_runner.sh analyze` command instead of `dart analyze` for analyzing Dart source code, to ensure that `dart pub get` is run for all example apps before the analysis.

c.f. This change is for the "analyze" workflow. f065d1f6658cb35ad824c1160b52cec24787b72c is for the "build" workflow.

Resolves the analyze error of https://github.com/flutter-tizen/plugins/pull/438.