### PR TITLE
[google_maps_flutter] Change dependency to webview_flutter_lwe

### DIFF
--- a/packages/google_maps_flutter/CHANGELOG.md
+++ b/packages/google_maps_flutter/CHANGELOG.md
@@ -1,5 +1,6 @@
-## NEXT
+## 0.1.4
 
+* Change dependency from webview_flutter_tizen to webview_flutter_lwe.
 * Fix integration test failures
 
 ## 0.1.3

--- a/packages/google_maps_flutter/pubspec.yaml
+++ b/packages/google_maps_flutter/pubspec.yaml
@@ -2,7 +2,7 @@ name: google_maps_flutter_tizen
 description: Tizen platform implementation of google_maps_flutter
 homepage: https://github.com/flutter-tizen/plugins
 repository: https://github.com/flutter-tizen/plugins/tree/master/packages/google_maps_flutter
-version: 0.1.3
+version: 0.1.4
 
 flutter:
   plugin:
@@ -19,7 +19,7 @@ dependencies:
   meta: ^1.3.0
   stream_transform: ^2.0.0
   webview_flutter: ^3.0.4
-  webview_flutter_tizen: ^0.5.3
+  webview_flutter_lwe: ^0.1.0
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
* This plugin still depends on a lightweight web engine.

Signed-off-by: Boram Bae <boram21.bae@samsung.com>