### PR TITLE
[webview_flutter] Fix canGoBack/Forward error

### DIFF
--- a/packages/webview_flutter/CHANGELOG.md
+++ b/packages/webview_flutter/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.6.1
+
+*  Fix canGoBack/Forward error
+
 ## 0.6.0
 
 *  Change the backing web engine from LWE to EFL WebKit (EWK).

--- a/packages/webview_flutter/README.md
+++ b/packages/webview_flutter/README.md
@@ -22,7 +22,7 @@ This package is not an _endorsed_ implementation of `webview_flutter`. Therefore
 ```yaml
 dependencies:
   webview_flutter: ^3.0.4
-  webview_flutter_tizen: ^0.6.0
+  webview_flutter_tizen: ^0.6.1
 ```
 
 ## Example

--- a/packages/webview_flutter/pubspec.yaml
+++ b/packages/webview_flutter/pubspec.yaml
@@ -2,7 +2,7 @@ name: webview_flutter_tizen
 description: Tizen implementation of the webview plugin
 homepage: https://github.com/flutter-tizen/plugins
 repository: https://github.com/flutter-tizen/plugins/tree/master/packages/webview_flutter
-version: 0.6.0
+version: 0.6.1
 
 environment:
   sdk: ">=2.17.0 <3.0.0"

--- a/packages/webview_flutter/tizen/src/webview.cc
+++ b/packages/webview_flutter/tizen/src/webview.cc
@@ -402,11 +402,11 @@ void WebView::HandleMethodCall(const FlMethodCall& method_call,
     }
     result->Success();
   } else if (method_name == "canGoBack") {
-    result->Success(
-        flutter::EncodableValue(ewk_view_back_possible(webview_instance_)));
+    result->Success(flutter::EncodableValue(
+        static_cast<bool>(ewk_view_back_possible(webview_instance_))));
   } else if (method_name == "canGoForward") {
-    result->Success(
-        flutter::EncodableValue(ewk_view_forward_possible(webview_instance_)));
+    result->Success(flutter::EncodableValue(
+        static_cast<bool>(ewk_view_forward_possible(webview_instance_))));
   } else if (method_name == "goBack") {
     ewk_view_back(webview_instance_);
     result->Success();


### PR DESCRIPTION
For EncodableValue(), the result of Eina_bool type must be explicitly changed to bool type.

[Log]
```
E/ConsoleMessage(24058): [ERROR:flutter/runtime/dart_vm_initializer.cc(41)] Unhandled Exception: type 'int' is not a subtype of type 'bool?' in type cast
E/ConsoleMessage(24058): #0      MethodChannel._invokeMethod (package:flutter/src/services/platform_channel.dart:296:41)
E/ConsoleMessage(24058): <asynchronous suspension>
E/ConsoleMessage(24058): #1      NavigationControls.build.<anonymous closure>.<anonymous closure> (package:webview_flutter_tizen_example/main.dart:462:27)
E/ConsoleMessage(24058): <asynchronous suspension>
```

Eina_Bool documents
`https://docs.tizen.org/application/native/api/wearable/5.5/group__Eina__Types__Group.html#ga3fe0caf72e93b1bab1ca8ee3ccf3f226`