### PR TITLE
Disable permission popups during testing

### DIFF
--- a/.github/recipe.yaml
+++ b/.github/recipe.yaml
@@ -6,10 +6,12 @@ plugins:
   flutter_app_badger: ["wearable-5.5"]
   flutter_secure_storage: ["wearable-5.5", "tv-6.5"]
   flutter_tts: ["wearable-5.5", "tv-6.5"]
+  google_maps_flutter: ["wearable-5.5", "tv-6.5"]
   integration_test: ["wearable-5.5", "tv-6.5"]
   messageport: ["wearable-5.5", "tv-6.5"]
   package_info_plus: ["wearable-5.5", "tv-6.5"]
-  path_provider: ["tv-6.5"]
+  path_provider: ["wearable-5.5", "tv-6.5"]
+  permission_handler: ["wearable-5.5"]
   sensors_plus: ["wearable-5.5"]
   shared_preferences: ["wearable-5.5", "tv-6.5"]
   sqflite: ["wearable-5.5", "tv-6.5"]
@@ -21,13 +23,6 @@ plugins:
   url_launcher: ["wearable-5.5", "tv-6.5"]
   wakelock: ["wearable-5.5"]
 
-  # Not supported by emulators.
-  camera: []
-  google_maps_flutter: []
-  network_info_plus: []
-  webview_flutter: []
-  webview_flutter_lwe: []
-
   # No tests.
   google_sign_in: []
   image_picker: []
@@ -35,12 +30,18 @@ plugins:
   tizen_notification: []
   wearable_rotary: []
 
-  # Permission cannot be granted without manual interaction.
+  # Functionality not available on emulator.
+  camera: []
   geolocator: []
-  permission_handler: []
+  network_info_plus: []
 
   # Only testable with the drive command: https://github.com/flutter-tizen/plugins/issues/272
   tizen_app_control: []
 
   # Test frequently breaks due to memory issue: https://github.com/flutter-tizen/plugins/issues/135
   video_player: []
+
+  # Temporarily disabled due to test_api error. Testable with the drive command.
+  # https://github.com/flutter-tizen/plugins/pull/397#issuecomment-1139299838
+  webview_flutter: []
+  webview_flutter_lwe: []

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,8 +24,8 @@ jobs:
       - name: Install Tizen Studio
         if: ${{ env.HAS_CHANGED_PACKAGES == 'true' }}
         run: |
-          sudo apt install -y pciutils zip libncurses5 python libpython2.7 make gettext
-          curl http://download.tizen.org/sdk/Installer/tizen-studio_4.6/web-cli_Tizen_Studio_4.6_ubuntu-64.bin -o install.bin
+          sudo apt install -y libncurses5 python2.7 libpython2.7 gettext
+          curl http://download.tizen.org/sdk/Installer/tizen-studio_5.0/web-cli_Tizen_Studio_5.0_ubuntu-64.bin -o install.bin
           chmod a+x install.bin
           ./install.bin --accept-license $HOME/tizen-studio
           rm install.bin

--- a/packages/permission_handler/example/integration_test/permission_handler_test.dart
+++ b/packages/permission_handler/example/integration_test/permission_handler_test.dart
@@ -6,7 +6,7 @@ void main() {
   IntegrationTestWidgetsFlutterBinding.ensureInitialized();
 
   testWidgets('get permission status', (tester) async {
-    expect(await Permission.camera.status.isDenied, true);
+    expect(await Permission.camera.status.isGranted, true);
   });
 
   testWidgets('get location service status', (tester) async {

--- a/tools/lib/src/integration_test_command.dart
+++ b/tools/lib/src/integration_test_command.dart
@@ -81,7 +81,7 @@ class IntegrationTestCommand extends PackageLoopingCommand {
   // Tizen SDK installed on the system.
   late final TizenSdk _tizenSdk = TizenSdk.locateTizenSdk();
 
-  Duration _timeout = const Duration(seconds: 120);
+  Duration _timeout = const Duration(seconds: 300);
 
   Recipe? _recipe;
 


### PR DESCRIPTION
Disable permission popups when testing on a wearable emulator, by creating the `askuser_disable` file. This enables testing of `path_provider_tizen` and `permission_handler_tizen`, but not `geolocator_tizen` because the location service is not available on emulator.