### PR TITLE
Clean up the tool code

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,7 +39,7 @@ jobs:
         env:
           PUB_CREDENTIALS: ${{ secrets.PUB_CREDENTIALS }}
         run: |
-          ./tools/tools_runner.sh publish-plugin \
+          ./tools/tools_runner.sh publish \
             --all-changed \
             --base-sha=HEAD~ \
             --skip-confirmation

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Dry run on pull request
         if: ${{ github.event_name == 'pull_request' }}
         run: |
-          ./tools/tools_runner.sh publish-plugin \
+          ./tools/tools_runner.sh publish \
             --all-changed \
             --pub-publish-flags=--dry-run \
             --base-sha=HEAD~
@@ -34,7 +34,7 @@ jobs:
           wait-interval: 180 # seconds
           allowed-conclusions: success
           verbose: false
-      - name: Publish plugins
+      - name: Publish packages
         if: ${{ github.event_name == 'push' }}
         env:
           PUB_CREDENTIALS: ${{ secrets.PUB_CREDENTIALS }}

--- a/tools/LICENSE
+++ b/tools/LICENSE
@@ -1,5 +1,5 @@
-Copyright 2021 Samsung Electronics Co., Ltd. All rights reserved.
-Copyright 2013 The Flutter Authors. All rights reserved.
+Copyright (c) 2022 Samsung Electronics Co., Ltd. All rights reserved.
+Copyright (c) 2013 The Flutter Authors. All rights reserved.
 
 Redistribution and use in source and binary forms, with or without modification,
 are permitted provided that the following conditions are met:
@@ -10,7 +10,7 @@ are permitted provided that the following conditions are met:
       copyright notice, this list of conditions and the following
       disclaimer in the documentation and/or other materials provided
       with the distribution.
-    * Neither the name of Google Inc. nor the names of its
+    * Neither the names of the copyright holders nor the names of the
       contributors may be used to endorse or promote products derived
       from this software without specific prior written permission.
 

--- a/tools/lib/src/device.dart
+++ b/tools/lib/src/device.dart
@@ -127,9 +127,8 @@ class Device {
   /// nor [PackageResult.exclude].
   Future<PackageResult> runIntegrationTest(
     Directory workingDir,
-    Duration timeout, {
-    bool debug = false,
-  }) async {
+    Duration timeout,
+  ) async {
     if (!isConnected) {
       return PackageResult.fail(
           <String>['Device $name ($profile) is not connected.']);
@@ -137,13 +136,7 @@ class Device {
 
     final io.Process process = await _processRunner.start(
       'flutter-tizen',
-      <String>[
-        if (debug) '-v',
-        '-d',
-        serial!,
-        'test',
-        'integration_test',
-      ],
+      <String>['-d', serial!, 'test', 'integration_test'],
       workingDirectory: workingDir,
     );
 
@@ -319,11 +312,10 @@ class EmulatorDevice extends Device {
   }
 
   /// Deletes this emulator.
-  Future<void> delete() async => await _processRunner.runAndStream(
-        _tizenSdk.emCli.path,
-        <String>['delete', '-n', name],
-        exitOnError: true,
-      );
+  Future<void> delete() async {
+    await _processRunner
+        .runAndStream(_tizenSdk.emCli.path, <String>['delete', '-n', name]);
+  }
 
   /// Launches this emualtor.
   Future<void> launch() async {
@@ -400,9 +392,8 @@ class EmulatorDevice extends Device {
   @override
   Future<PackageResult> runIntegrationTest(
     Directory workingDir,
-    Duration timeout, {
-    bool debug = false,
-  }) async {
+    Duration timeout,
+  ) async {
     bool autoLaunched = false;
     bool autoCreated = false;
     try {
@@ -415,7 +406,7 @@ class EmulatorDevice extends Device {
         await launch();
       }
       _disablePermissionPopups();
-      return await super.runIntegrationTest(workingDir, timeout, debug: debug);
+      return await super.runIntegrationTest(workingDir, timeout);
     } finally {
       if (autoLaunched) {
         await close();

--- a/tools/lib/src/integration_test_command.dart
+++ b/tools/lib/src/integration_test_command.dart
@@ -8,8 +8,8 @@ import 'package:args/args.dart';
 import 'package:file/file.dart';
 import 'package:file/local.dart';
 import 'package:flutter_plugin_tools/src/common/core.dart';
+import 'package:flutter_plugin_tools/src/common/package_command.dart';
 import 'package:flutter_plugin_tools/src/common/package_looping_command.dart';
-import 'package:flutter_plugin_tools/src/common/plugin_command.dart';
 import 'package:flutter_plugin_tools/src/common/repository_package.dart';
 import 'package:yaml/yaml.dart';
 
@@ -58,16 +58,16 @@ class IntegrationTestCommand extends PackageLoopingCommand {
     );
     argParser.addOption(
       _timeoutArg,
-      help: 'Timeout limit of each integration test in seconds.',
+      help: 'Time in seconds to wait for each test to finish.',
       valueHelp: 'seconds',
       defaultsTo: _timeout.inSeconds.toString(),
     );
   }
 
-  /// Copied from [PluginCommand].
+  /// Copied from [PackageCommand].
   static const String _excludeArg = 'exclude';
 
-  /// Copied from [PluginCommand].
+  /// Copied from [PackageCommand].
   static const String _packagesArg = 'packages';
 
   static const String _generateEmulatorsArg = 'generate-emulators';
@@ -142,7 +142,7 @@ class IntegrationTestCommand extends PackageLoopingCommand {
     }
   }
 
-  /// See: [PluginCommand.getTargetPackages].
+  /// See: [PackageCommand.getTargetPackages].
   @override
   Stream<PackageEnumerationEntry> getTargetPackages({
     bool filterExcluded = true,

--- a/tools/lib/src/integration_test_command.dart
+++ b/tools/lib/src/integration_test_command.dart
@@ -224,15 +224,14 @@ class IntegrationTestCommand extends PackageLoopingCommand {
       }
 
       for (final Device device in devices) {
-        PackageResult packageResult =
+        String? error =
             await device.runIntegrationTest(example.directory, _timeout);
-        if (packageResult.state == RunState.failed) {
+        if (error != null) {
           // Tests may fail unexpectedly on a self-hosted runner. Try again.
-          packageResult =
-              await device.runIntegrationTest(example.directory, _timeout);
+          error = await device.runIntegrationTest(example.directory, _timeout);
         }
-        if (packageResult.state == RunState.failed) {
-          errors.addAll(packageResult.details);
+        if (error != null) {
+          errors.add(error);
         }
       }
     }

--- a/tools/lib/src/integration_test_command.dart
+++ b/tools/lib/src/integration_test_command.dart
@@ -228,8 +228,8 @@ class IntegrationTestCommand extends PackageLoopingCommand {
             await device.runIntegrationTest(example.directory, _timeout);
         if (packageResult.state == RunState.failed) {
           // Tests may fail unexpectedly on a self-hosted runner. Try again.
-          packageResult = await device
-              .runIntegrationTest(example.directory, _timeout, debug: true);
+          packageResult =
+              await device.runIntegrationTest(example.directory, _timeout);
         }
         if (packageResult.state == RunState.failed) {
           errors.addAll(packageResult.details);

--- a/tools/lib/src/integration_test_command.dart
+++ b/tools/lib/src/integration_test_command.dart
@@ -151,19 +151,19 @@ class IntegrationTestCommand extends PackageLoopingCommand {
       yield* super.getTargetPackages(filterExcluded: filterExcluded);
     } else {
       final Recipe recipe = _recipe!;
-      final List<PackageEnumerationEntry> plugins = await super
+      final List<PackageEnumerationEntry> packages = await super
           .getTargetPackages(filterExcluded: filterExcluded)
           .toList();
 
-      for (final PackageEnumerationEntry plugin in plugins) {
-        final String pluginName = plugin.package.displayName;
-        if (!recipe.contains(pluginName)) {
+      for (final PackageEnumerationEntry package in packages) {
+        final String packageName = package.package.displayName;
+        if (!recipe.contains(packageName)) {
           continue;
         }
-        if (!(filterExcluded && plugin.excluded)) {
-          yield recipe.isExcluded(pluginName)
-              ? PackageEnumerationEntry(plugin.package, excluded: true)
-              : plugin;
+        if (!(filterExcluded && package.excluded)) {
+          yield recipe.isExcluded(packageName)
+              ? PackageEnumerationEntry(package.package, excluded: true)
+              : package;
         }
       }
     }

--- a/tools/lib/src/main.dart
+++ b/tools/lib/src/main.dart
@@ -15,7 +15,7 @@ import 'package:flutter_plugin_tools/src/list_command.dart';
 
 import 'build_examples_command.dart';
 import 'integration_test_command.dart';
-import 'publish_plugin_command.dart';
+import 'publish_command.dart';
 
 void main(List<String> args) {
   const FileSystem fileSystem = LocalFileSystem();
@@ -40,7 +40,7 @@ void main(List<String> args) {
     ..addCommand(FormatCommand(packagesDir))
     ..addCommand(IntegrationTestCommand(packagesDir))
     ..addCommand(ListCommand(packagesDir))
-    ..addCommand(PublishPluginCommand(packagesDir));
+    ..addCommand(PublishCommand(packagesDir));
 
   commandRunner.run(args).catchError((Object e) {
     final ToolExit toolExit = e as ToolExit;

--- a/tools/lib/src/process_runner_apis.dart
+++ b/tools/lib/src/process_runner_apis.dart
@@ -7,7 +7,6 @@ import 'dart:io' as io;
 
 import 'package:file/file.dart';
 import 'package:flutter_plugin_tools/src/common/core.dart';
-
 import 'package:flutter_plugin_tools/src/common/process_runner.dart';
 
 /// An extension method of [ProcessRunner] to supports synchronous operations.

--- a/tools/lib/src/publish_command.dart
+++ b/tools/lib/src/publish_command.dart
@@ -11,23 +11,25 @@ import 'package:file/file.dart';
 import 'package:flutter_plugin_tools/src/common/core.dart';
 import 'package:flutter_plugin_tools/src/common/file_utils.dart';
 import 'package:flutter_plugin_tools/src/common/git_version_finder.dart';
+import 'package:flutter_plugin_tools/src/common/package_command.dart';
 import 'package:flutter_plugin_tools/src/common/package_looping_command.dart';
-import 'package:flutter_plugin_tools/src/common/plugin_command.dart';
 import 'package:flutter_plugin_tools/src/common/process_runner.dart';
 import 'package:flutter_plugin_tools/src/common/pub_version_finder.dart';
 import 'package:flutter_plugin_tools/src/common/repository_package.dart';
+import 'package:flutter_plugin_tools/src/publish_command.dart'
+    as flutter_plugin_tools;
 import 'package:http/http.dart' as http;
 import 'package:path/path.dart' as p;
 import 'package:platform/platform.dart';
 import 'package:pub_semver/pub_semver.dart';
 
 /// Wraps pub publish with a few niceties used by the flutter-tizen team.
-// The code is mostly copied from `PublishPluginCommand` in
-// `flutter_plugin_tools`, parts regarding git tagging are removed as we don't
-// tag our releases.
-class PublishPluginCommand extends PackageLoopingCommand {
+///
+/// The code is a copy of [flutter_plugin_tools.PublishCommand] with parts
+/// related to git tagging removed as we don't tag our releases.
+class PublishCommand extends PackageLoopingCommand {
   /// Creates an instance of the publish command.
-  PublishPluginCommand(
+  PublishCommand(
     super.packagesDir, {
     super.processRunner = const ProcessRunner(),
     super.platform = const LocalPlatform(),
@@ -48,7 +50,6 @@ class PublishPluginCommand extends PackageLoopingCommand {
       help:
           'Release all packages that contains pubspec changes at the current commit compares to the base-sha.\n'
           'The --packages option is ignored if this is on.',
-      defaultsTo: false,
     );
     argParser.addFlag(
       _dryRunFlag,
@@ -56,15 +57,11 @@ class PublishPluginCommand extends PackageLoopingCommand {
           'Skips the real `pub publish` command and assumes the command is successful.\n'
           'This does not run `pub publish --dry-run`.\n'
           'If you want to run the command with `pub publish --dry-run`, use `--pub-publish-flags=--dry-run`',
-      defaultsTo: false,
-      negatable: true,
     );
     argParser.addFlag(
       _skipConfirmationFlag,
       help: 'Run the command without asking for Y/N inputs.\n'
           'This command will add a `--force` flag to the `pub publish` command if it is not added with $_pubFlagsOption\n',
-      defaultsTo: false,
-      negatable: true,
     );
   }
 
@@ -76,7 +73,7 @@ class PublishPluginCommand extends PackageLoopingCommand {
   static const String _pubCredentialName = 'PUB_CREDENTIALS';
 
   @override
-  String get name => 'publish-plugin';
+  String get name => 'publish';
 
   @override
   String get description => 'Attempts to publish the given packages to pub.\n'

--- a/tools/lib/src/recipe.dart
+++ b/tools/lib/src/recipe.dart
@@ -13,12 +13,12 @@ class Recipe {
 
   /// Creates a [Recipe] instance by parsing [yamlMap].
   factory Recipe.fromYaml(YamlMap yamlMap) {
-    final Map<String, YamlList> plugins =
+    final Map<String, YamlList> packages =
         (yamlMap['plugins'] as YamlMap).cast<String, YamlList>();
     final Map<String, List<Profile>> profilesPerPackage =
         <String, List<Profile>>{};
-    for (final MapEntry<String, YamlList> plugin in plugins.entries) {
-      profilesPerPackage[plugin.key] = plugin.value
+    for (final MapEntry<String, YamlList> package in packages.entries) {
+      profilesPerPackage[package.key] = package.value
           .map((dynamic profile) => Profile.fromString(profile as String))
           .toList();
     }
@@ -27,19 +27,19 @@ class Recipe {
 
   final Map<String, List<Profile>> _profilesPerPackage;
 
-  /// Returns `true` if [plugin] was specified in the recipe file but
+  /// Returns `true` if [package] was specified in the recipe file but
   /// with an empty profile list.
-  bool isExcluded(String plugin) =>
-      contains(plugin) && _profilesPerPackage[plugin]!.isEmpty;
+  bool isExcluded(String package) =>
+      contains(package) && _profilesPerPackage[package]!.isEmpty;
 
-  /// Returns `true` if [plugin] was specified in the recipe file.
-  bool contains(String plugin) => _profilesPerPackage.containsKey(plugin);
+  /// Returns `true` if [package] was specified in the recipe file.
+  bool contains(String package) => _profilesPerPackage.containsKey(package);
 
-  /// Returns a list of profiles to test on for [plugin].
-  List<Profile> getProfiles(String plugin) {
-    if (!contains(plugin)) {
-      throw ArgumentError('Package $plugin is not included in recipe.');
+  /// Returns a list of profiles to test on for [package].
+  List<Profile> getProfiles(String package) {
+    if (!contains(package)) {
+      throw ArgumentError('Package $package not found in the recipe.');
     }
-    return _profilesPerPackage[plugin]!;
+    return _profilesPerPackage[package]!;
   }
 }

--- a/tools/lib/src/tizen_sdk.dart
+++ b/tools/lib/src/tizen_sdk.dart
@@ -178,7 +178,7 @@ class TizenSdk {
     if (tizenHomeDir == null || !tizenHomeDir.existsSync()) {
       print(
         'Error: Unable to locate Tizen SDK.\n'
-        'If the Tizen SDK has been installed to a custom location, set TIZEN_SDK to that location.',
+        'If the Tizen SDK has been installed to a custom location, set $_kTizenSdk to that location.',
       );
       throw ToolExit(exitCommandFoundErrors);
     }
@@ -271,7 +271,7 @@ String? findEmulatorPid(String name) {
   final io.ProcessResult result = processRunner.runSync('ps', <String>['aux']);
 
   if (result.exitCode != 0) {
-    print('Error: running the command `ps aux` failed.');
+    print('Error: Unable to list running processes.');
     throw ToolExit(result.exitCode);
   }
 

--- a/tools/lib/src/tizen_sdk.dart
+++ b/tools/lib/src/tizen_sdk.dart
@@ -89,7 +89,6 @@ class Profile {
   /// Profile.fromString('wearable')
   /// // Wearable device with Tizen 5.5.
   /// Profile.fromString('wearable-5.5')
-  ///
   /// ```
   ///
   /// To see all supported device types, see [DeviceType].
@@ -111,8 +110,9 @@ class Profile {
     }
     if (matchingDeviceType == null) {
       throw ArgumentError(
-          'Profile string must start with one of ${DeviceType.values}.',
-          'value');
+        'Profile string must start with one of ${DeviceType.values}.',
+        'value',
+      );
     }
     Version? version;
     if (versionString != null && versionString.isNotEmpty) {
@@ -124,8 +124,9 @@ class Profile {
         version = Version.parse(segments.join('.'));
       } on FormatException {
         throw ArgumentError(
-            'Platform version cannot be parsed from profile string $value.',
-            'value');
+          'Platform version cannot be parsed from profile string $value.',
+          'value',
+        );
       }
     }
     return Profile(matchingDeviceType, version);
@@ -176,8 +177,9 @@ class TizenSdk {
     }
     if (tizenHomeDir == null || !tizenHomeDir.existsSync()) {
       print(
-          'Error: Cannot find tizen sdk, make sure to set the path of tizen sdk '
-          'to the environment variable $_kTizenSdk.');
+        'Error: Unable to locate Tizen SDK.\n'
+        'If the Tizen SDK has been installed to a custom location, set TIZEN_SDK to that location.',
+      );
       throw ToolExit(exitCommandFoundErrors);
     }
     return TizenSdk._(
@@ -269,7 +271,8 @@ String? findEmulatorPid(String name) {
   final io.ProcessResult result = processRunner.runSync('ps', <String>['aux']);
 
   if (result.exitCode != 0) {
-    throw ToolExit(1);
+    print('Error: running the command `ps aux` failed.');
+    throw ToolExit(result.exitCode);
   }
 
   final List<String> lines = LineSplitter.split(result.stdout as String)

--- a/tools/pubspec.yaml
+++ b/tools/pubspec.yaml
@@ -4,17 +4,15 @@ repository: https://github.com/flutter-tizen/plugins/tree/master/tools
 publish_to: none
 
 environment:
-  sdk: '>=2.17.0 <3.0.0'
+  sdk: ">=2.17.0 <3.0.0"
 
 dependencies:
   args: ^2.1.0
   file: ^6.1.0
-  flutter_plugin_tools: ^0.9.2
-  git: ^2.0.0
+  flutter_plugin_tools: ^0.13.0
   http: ^0.13.3
   platform: ^3.0.0
   pub_semver: ^2.1.0
-  pubspec_parse: ^1.0.0
   yaml: ^3.1.0
 
 dev_dependencies:

--- a/tools/test/device_test.dart
+++ b/tools/test/device_test.dart
@@ -66,12 +66,12 @@ void main() {
       Future<void>.delayed(Duration(seconds: timeoutLimit.inSeconds + 1), () {
         controller.close();
       });
-      final PackageResult result = await device.runIntegrationTest(
+      final String? error = await device.runIntegrationTest(
         fileSystem.systemTempDirectory,
         timeoutLimit,
       );
-      expect(result.state, RunState.failed);
-      expect(result.details.first.contains('Timeout expired'), true);
+      expect(error, isNotNull);
+      expect(error!.contains('Timeout expired'), true);
     });
 
     test('correctly parses log "No tests ran"', () async {
@@ -83,12 +83,12 @@ void main() {
           controller.close();
         },
       );
-      final PackageResult result = await device.runIntegrationTest(
+      final String? error = await device.runIntegrationTest(
         fileSystem.systemTempDirectory,
         timeoutLimit,
       );
-      expect(result.state, RunState.failed);
-      expect(result.details.first.contains('Missing integration tests'), true);
+      expect(error, isNotNull);
+      expect(error!.contains('Missing integration tests'), true);
     });
 
     test('correctly parses log "No devices found"', () async {
@@ -100,14 +100,12 @@ void main() {
           controller.close();
         },
       );
-      final PackageResult result = await device.runIntegrationTest(
+      final String? error = await device.runIntegrationTest(
         fileSystem.systemTempDirectory,
         timeoutLimit,
       );
-      expect(result.state, RunState.failed);
-      expect(
-          result.details.first.contains('Device was disconnected during test'),
-          true);
+      expect(error, isNotNull);
+      expect(error!.contains('Device was disconnected during test'), true);
     });
 
     test('correctly parses log "All tests passed!"', () async {
@@ -119,11 +117,11 @@ void main() {
           controller.close();
         },
       );
-      final PackageResult result = await device.runIntegrationTest(
+      final String? error = await device.runIntegrationTest(
         fileSystem.systemTempDirectory,
         timeoutLimit,
       );
-      expect(result.state, RunState.succeeded);
+      expect(error, isNull);
     });
 
     test('correctly parses log "Some tests failed"', () async {
@@ -135,14 +133,13 @@ void main() {
           controller.close();
         },
       );
-      final PackageResult result = await device.runIntegrationTest(
+      final String? error = await device.runIntegrationTest(
         fileSystem.systemTempDirectory,
         timeoutLimit,
       );
-      expect(result.state, RunState.failed);
+      expect(error, isNotNull);
       expect(
-        result.details.first
-            .contains('flutter-tizen test integration_test failed'),
+        error!.contains('flutter-tizen test integration_test failed'),
         true,
       );
     });

--- a/tools/test/integration/device_test.dart
+++ b/tools/test/integration/device_test.dart
@@ -34,9 +34,10 @@ Future<void> _checkSystemRequirements(String emulatorName) async {
       .map((String token) => token.trim())
       .toList();
   if (names.contains(emulatorName)) {
-    throw Exception('Emulator name used for test already exists: $emulatorName. '
-        'Emulator name is randomly generated each test, rerun test to '
-        'choose a different name.');
+    throw Exception(
+        'Emulator name used for test already exists: $emulatorName. '
+        'Emulator name is randomly generated for each test. '
+        'Rerun the test to choose a different name.');
   }
 
   result = await io.Process.run('flutter-tizen', <String>['-v']);
@@ -95,12 +96,12 @@ void main() {
     await io.Process.run('flutter-tizen', <String>['pub', 'get'],
         workingDirectory: testDataDir.parent.absolute.path);
 
-    final PackageResult result = await device.runIntegrationTest(
+    final String? error = await device.runIntegrationTest(
         testDataDir, const Duration(seconds: 60));
 
     await io.Process.run('flutter-tizen', <String>['clean'],
         workingDirectory: testDataDir.parent.absolute.path);
-    expect(result.state, RunState.succeeded);
+    expect(error, isNull);
   });
 
   tearDown(() async {


### PR DESCRIPTION
- Remove the `debug` parameter from `Device.runIntegrationTest` which has recently been added by https://github.com/flutter-tizen/plugins/pull/497.
- Remove `Device`'s dependency on `package_looping_command.dart` by changing the return type of `Device.runIntegrationTest`.
- Rename `publish_plugin_command.dart` to `publish_command.dart` and replace some occurrences of `plugin` with `package` (see https://github.com/flutter/plugins/pull/6503).
- Update flutter_plugin_tools to 0.13.0 and remove unused dependencies.
- Minor cleanups, including typo fix and etc.
