### PR TITLE
[camera] Treat permission request as a success on TV

### DIFF
--- a/packages/camera/tizen/src/permission_manager.cc
+++ b/packages/camera/tizen/src/permission_manager.cc
@@ -6,11 +6,9 @@
 
 #ifndef TV_PROFILE
 #include <privacy_privilege_manager.h>
-#endif
 
 #include "log.h"
 
-#ifndef TV_PROFILE
 const char* PermissionToString(Permission permission) {
   switch (permission) {
     case Permission::kCamera:
@@ -37,7 +35,6 @@ void PermissionManager::RequestPermission(Permission permission,
                                           const OnFailure& on_failure) {
 #ifdef TV_PROFILE
   on_success();
-  return;
 #else
   ppm_check_result_e result;
   const char* permission_string = PermissionToString(permission);
@@ -83,6 +80,5 @@ void PermissionManager::RequestPermission(Permission permission,
         break;
     }
   }
-  return;
 #endif  // TV_PROFILE
 }

--- a/packages/camera/tizen/src/permission_manager.cc
+++ b/packages/camera/tizen/src/permission_manager.cc
@@ -4,10 +4,13 @@
 
 #include "permission_manager.h"
 
+#ifndef TV_PROFILE
 #include <privacy_privilege_manager.h>
+#endif
 
 #include "log.h"
 
+#ifndef TV_PROFILE
 const char* PermissionToString(Permission permission) {
   switch (permission) {
     case Permission::kCamera:
@@ -27,12 +30,15 @@ const char* PermissionToString(Permission permission) {
       return nullptr;
   }
 }
+#endif
 
 void PermissionManager::RequestPermission(Permission permission,
                                           const OnSuccess& on_success,
                                           const OnFailure& on_failure) {
-  LOG_DEBUG("enter");
-
+#ifdef TV_PROFILE
+  on_success();
+  return;
+#else
   ppm_check_result_e result;
   const char* permission_string = PermissionToString(permission);
   int error = ppm_check_permission(permission_string, &result);
@@ -78,4 +84,5 @@ void PermissionManager::RequestPermission(Permission permission,
     }
   }
   return;
+#endif  // TV_PROFILE
 }


### PR DESCRIPTION
* TV does not support the privilege API, which causes a crash.
* This patch resolves this crash. but it still doesn't support TV.

Signed-off-by: Boram Bae <boram21.bae@samsung.com>