### PR TITLE
[tizen_rpc_port] Support explicitly stopping a server

### DIFF
--- a/packages/tizen_rpc_port/CHANGELOG.md
+++ b/packages/tizen_rpc_port/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## 0.1.2
 
+* Update the TIDLC version to 1.10.6.
 * Support explicitly stopping a server by adding `StubBase.close`.
 
 ## 0.1.1

--- a/packages/tizen_rpc_port/CHANGELOG.md
+++ b/packages/tizen_rpc_port/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.1.2
+
+* Support explicitly stopping a server by adding `StubBase.close`.
+
 ## 0.1.1
 
 * Clean up the API documentation.

--- a/packages/tizen_rpc_port/README.md
+++ b/packages/tizen_rpc_port/README.md
@@ -21,7 +21,7 @@ The generated source files (`message_client.dart` and `message_server.dart`) dep
 
 ```yaml
 depenedencies:
-  tizen_rpc_port: ^0.1.1
+  tizen_rpc_port: ^0.1.2
 ```
 
 Assuming that the name of the interface defined in your interface file is `Message`, the client must first call its `connect` method to connect to the server before making any remote invocation.

--- a/packages/tizen_rpc_port/example/client/lib/main.dart
+++ b/packages/tizen_rpc_port/example/client/lib/main.dart
@@ -28,25 +28,35 @@ class _MyAppState extends State<MyApp> {
   String _input = '';
 
   Future<void> _connect() async {
-    await _client.connect(
-      onError: (Object error) {
-        setState(() {
-          _message = 'Error: $error';
-        });
-      },
-      onDisconnected: () async {
-        setState(() {
-          _isConnected = false;
-          _message = 'Disconnected';
-        });
-      },
-    );
-    _client.register('ClientApp', onMessage);
-
     setState(() {
-      _isConnected = true;
-      _message = 'Connected';
+      _message = 'Connecting...';
     });
+
+    try {
+      await _client.connect(
+        onError: (Object error) {
+          setState(() {
+            _message = 'Error: $error';
+          });
+        },
+        onDisconnected: () async {
+          setState(() {
+            _isConnected = false;
+            _message = 'Disconnected';
+          });
+        },
+      );
+      _client.register('ClientApp', onMessage);
+
+      setState(() {
+        _isConnected = true;
+        _message = 'Connected';
+      });
+    } catch (error) {
+      setState(() {
+        _message = 'Error: $error';
+      });
+    }
   }
 
   void onMessage(String sender, String message) {
@@ -62,9 +72,10 @@ class _MyAppState extends State<MyApp> {
   }
 
   @override
-  Future<void> dispose() async {
+  void dispose() {
     if (_isConnected) {
       _client.unregister();
+      _client.disconnect();
     }
     super.dispose();
   }

--- a/packages/tizen_rpc_port/example/server/lib/main.dart
+++ b/packages/tizen_rpc_port/example/server/lib/main.dart
@@ -63,17 +63,21 @@ class MyApp extends StatefulWidget {
 }
 
 class _MyAppState extends State<MyApp> {
-  late final Message _server;
+  final Message _server = Message(
+    serviceBuilder: (String sender, String instance) =>
+        EchoService(sender, instance),
+  );
 
   @override
   void initState() {
     super.initState();
-
-    _server = Message(
-      serviceBuilder: (String sender, String instance) =>
-          EchoService(sender, instance),
-    );
     _server.listen();
+  }
+
+  @override
+  void dispose() {
+    _server.close();
+    super.dispose();
   }
 
   @override

--- a/packages/tizen_rpc_port/lib/src/stub_base.dart
+++ b/packages/tizen_rpc_port/lib/src/stub_base.dart
@@ -19,23 +19,10 @@ export 'package:meta/meta.dart' show nonVirtual, visibleForOverriding;
 abstract class StubBase {
   /// Creates a [StubBase] instance with the specified port name.
   StubBase(this.portName) {
-    _handle = using((Arena arena) {
-      final Pointer<rpc_port_stub_h> pStub = arena();
-      final Pointer<Char> pPortName = portName.toNativeChar(allocator: arena);
-      final int ret = tizen.rpc_port_stub_create(pStub, pPortName);
-      if (ret != 0) {
-        throw PlatformException(
-          code: ret.toString(),
-          message: tizen.get_error_message(ret).toDartString(),
-        );
-      }
-      return pStub.value;
-    });
-
     _finalizer.attach(this, this);
   }
 
-  late final rpc_port_stub_h _handle;
+  rpc_port_stub_h _handle = nullptr;
 
   final Finalizer<StubBase> _finalizer = Finalizer<StubBase>((StubBase stub) {
     stub.close();
@@ -78,9 +65,21 @@ abstract class StubBase {
 
   /// Starts listening to connection requests from clients.
   Future<void> listen({OnError? onError}) async {
-    if (_streamSubscription != null) {
+    if (_handle != nullptr) {
       throw StateError('Cannot listen again');
     }
+    _handle = using((Arena arena) {
+      final Pointer<rpc_port_stub_h> pStub = arena();
+      final Pointer<Char> pPortName = portName.toNativeChar(allocator: arena);
+      final int ret = tizen.rpc_port_stub_create(pStub, pPortName);
+      if (ret != 0) {
+        throw PlatformException(
+          code: ret.toString(),
+          message: tizen.get_error_message(ret).toDartString(),
+        );
+      }
+      return pStub.value;
+    });
 
     final Stream<dynamic> stream = _eventChannel
         .receiveBroadcastStream(<String, Object>{'handle': _handle.address});
@@ -125,11 +124,12 @@ abstract class StubBase {
 
   /// Shuts down this stub.
   ///
-  /// All active connections will be closed immediately. No operation can be
-  /// made to this stub after this call.
+  /// All active connections will be closed immediately.
   Future<void> close() async {
     _streamSubscription?.cancel();
+    _streamSubscription = null;
     tizen.rpc_port_stub_destroy(_handle);
+    _handle = nullptr;
   }
 
   /// Called when a connection is established by a client.

--- a/packages/tizen_rpc_port/pubspec.yaml
+++ b/packages/tizen_rpc_port/pubspec.yaml
@@ -2,7 +2,7 @@ name: tizen_rpc_port
 description: Tizen RPC Port APIs. Used to make remote procedure calls between Tizen apps.
 homepage: https://github.com/flutter-tizen/plugins
 repository: https://github.com/flutter-tizen/plugins/tree/master/packages/tizen_rpc_port
-version: 0.1.1
+version: 0.1.2
 
 environment:
   sdk: ">=2.17.0 <3.0.0"


### PR DESCRIPTION
Part of https://github.com/flutter-tizen/plugins/issues/504.

Calling `StubBase.close` will destroy the underlying native handle so no additional operation can be made to the stub afterwards.