### PR TITLE
[webview_flutter] Use only error types known to Dart

### DIFF
--- a/packages/webview_flutter/CHANGELOG.md
+++ b/packages/webview_flutter/CHANGELOG.md
@@ -1,3 +1,8 @@
+## NEXT
+
+* Use only error type names defined in `web_resource_error.dart`.
+* Remove unused dependencies.
+
 ## 0.6.2
 
 * Remove the use of internal API `ewk_settings_viewport_meta_tag_set`.

--- a/packages/webview_flutter/example/pubspec.yaml
+++ b/packages/webview_flutter/example/pubspec.yaml
@@ -17,7 +17,6 @@ dependencies:
     path: ../
 
 dev_dependencies:
-  espresso: ^0.1.0+2
   flutter_driver:
     sdk: flutter
   flutter_test:
@@ -26,7 +25,6 @@ dev_dependencies:
     sdk: flutter
   integration_test_tizen:
     path: ../../integration_test/
-  pedantic: ^1.10.0
 
 flutter:
   uses-material-design: true

--- a/packages/webview_flutter/tizen/src/webview.cc
+++ b/packages/webview_flutter/tizen/src/webview.cc
@@ -62,12 +62,16 @@ std::string ErrorCodeToString(int error_code) {
       return "authentication";
     case EWK_ERROR_CODE_BAD_URL:
       return "badUrl";
+    case EWK_ERROR_CODE_CANT_CONNECT:
+      return "connect";
     case EWK_ERROR_CODE_FAILED_TLS_HANDSHAKE:
       return "failedSslHandshake";
     case EWK_ERROR_CODE_FAILED_FILE_IO:
       return "file";
     case EWK_ERROR_CODE_CANT_LOOKUP_HOST:
       return "hostLookup";
+    case EWK_ERROR_CODE_TOO_MANY_REDIRECTS:
+      return "redirectLoop";
     case EWK_ERROR_CODE_REQUEST_TIMEOUT:
       return "timeout";
     case EWK_ERROR_CODE_TOO_MANY_REQUESTS:
@@ -78,7 +82,7 @@ std::string ErrorCodeToString(int error_code) {
       return "unsupportedScheme";
     default:
       LOG_ERROR("Unknown error type: %d", error_code);
-      return std::to_string(error_code);
+      return "unknown";
   }
 }
 

--- a/packages/webview_flutter_lwe/CHANGELOG.md
+++ b/packages/webview_flutter_lwe/CHANGELOG.md
@@ -1,4 +1,9 @@
+## NEXT
+
+* Use only error type names defined in `web_resource_error.dart`.
+* Remove unused dependencies.
+
 ## 0.1.0
 
 * Initial release.
-* Rename from webview_flutter_tizen to webview_flutter_lwe.
+* Rename the package from webview_flutter_tizen to webview_flutter_lwe.

--- a/packages/webview_flutter_lwe/example/pubspec.yaml
+++ b/packages/webview_flutter_lwe/example/pubspec.yaml
@@ -17,7 +17,6 @@ dependencies:
     path: ../
 
 dev_dependencies:
-  espresso: ^0.1.0+2
   flutter_driver:
     sdk: flutter
   flutter_test:
@@ -26,7 +25,6 @@ dev_dependencies:
     sdk: flutter
   integration_test_tizen:
     path: ../../integration_test/
-  pedantic: ^1.10.0
 
 flutter:
   uses-material-design: true

--- a/packages/webview_flutter_lwe/tizen/src/webview.cc
+++ b/packages/webview_flutter_lwe/tizen/src/webview.cc
@@ -118,7 +118,7 @@ static std::string ErrorCodeToString(int error_code) {
       return "unsupportedScheme";
     default:
       LOG_ERROR("Unknown error type: %d", error_code);
-      return std::to_string(error_code);
+      return "unknown";
   }
 }
 


### PR DESCRIPTION
`std::to_string(error_code)` shouldn't be used because the error type string is converted back to a Dart enum in [this way](https://github.com/flutter/plugins/blob/webview_flutter_platform_interface-v1.9.5/packages/webview_flutter/webview_flutter_platform_interface/lib/src/method_channel/webview_method_channel.dart#L67-L70). Otherwise a `StateError` occurs.
