### PR TITLE
[tizen_package_manager] Add threading to prevent app freezing

### DIFF
--- a/packages/tizen_package_manager/CHANGELOG.md
+++ b/packages/tizen_package_manager/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.2.1
+
+* Add threading to `PackageManager.getPackagesInfo` to prevent app freezing.
+
 ## 0.2.0
 
 * Rename `package_manager.dart` to `tizen_package_manager.dart`.

--- a/packages/tizen_package_manager/README.md
+++ b/packages/tizen_package_manager/README.md
@@ -10,7 +10,7 @@ To use this package, add `tizen_package_manager` as a dependency in your `pubspe
 
 ```yaml
 dependencies:
-  tizen_package_manager: ^0.2.0
+  tizen_package_manager: ^0.2.1
 ```
 
 ### Retrieving specific package info

--- a/packages/tizen_package_manager/example/lib/main.dart
+++ b/packages/tizen_package_manager/example/lib/main.dart
@@ -44,11 +44,14 @@ class _MyHomePageState extends State<MyHomePage> {
       child: Scaffold(
         appBar: AppBar(
           title: const Text('Package Manager Demo'),
-          bottom: const TabBar(tabs: <Tab>[
-            Tab(text: 'This package'),
-            Tab(text: 'Package list'),
-            Tab(text: 'Package events'),
-          ]),
+          bottom: const TabBar(
+            isScrollable: true,
+            tabs: <Tab>[
+              Tab(text: 'This package'),
+              Tab(text: 'Package list'),
+              Tab(text: 'Package events'),
+            ],
+          ),
         ),
         body: const TabBarView(
           children: <Widget>[
@@ -110,9 +113,15 @@ class _PackageListScreen extends StatefulWidget {
   State<_PackageListScreen> createState() => _PackageListScreenState();
 }
 
-class _PackageListScreenState extends State<_PackageListScreen> {
+class _PackageListScreenState extends State<_PackageListScreen>
+    with AutomaticKeepAliveClientMixin {
+  @override
+  bool get wantKeepAlive => true;
+
   @override
   Widget build(BuildContext context) {
+    super.build(context);
+
     return FutureBuilder<List<PackageInfo>>(
       future: PackageManager.getPackagesInfo(),
       builder:

--- a/packages/tizen_package_manager/pubspec.yaml
+++ b/packages/tizen_package_manager/pubspec.yaml
@@ -2,7 +2,7 @@ name: tizen_package_manager
 description: Tizen package manager APIs. Used for getting installed package info.
 homepage: https://github.com/flutter-tizen/plugins
 repository: https://github.com/flutter-tizen/plugins/tree/master/packages/tizen_package_manager
-version: 0.2.0
+version: 0.2.1
 
 environment:
   sdk: ">=2.15.1 <3.0.0"

--- a/packages/tizen_package_manager/tizen/src/tizen_package_manager_plugin.cc
+++ b/packages/tizen_package_manager/tizen/src/tizen_package_manager_plugin.cc
@@ -4,6 +4,7 @@
 
 #include "tizen_package_manager_plugin.h"
 
+#include <Ecore.h>
 #include <flutter/encodable_value.h>
 #include <flutter/event_channel.h>
 #include <flutter/event_sink.h>
@@ -218,20 +219,31 @@ class TizenPackageManagerPlugin : public flutter::Plugin {
   }
 
   void GetAllPackagesInfo(std::unique_ptr<FlMethodResult> result) {
-    TizenPackageManager &package_manager = TizenPackageManager::GetInstance();
-    std::optional<std::vector<PackageInfo>> packages =
-        package_manager.GetAllPackagesInfo();
-    if (!packages.has_value()) {
-      result->Error(std::to_string(package_manager.GetLastError()),
-                    package_manager.GetLastErrorString());
-      return;
-    }
+    // TizenPackageManager::GetAllPackagesInfo() is an expensive operation and
+    // might cause unresponsiveness on low-end devices if run on the platform
+    // thread.
+    ecore_thread_run(
+        [](void *data, Ecore_Thread *thread) {
+          auto *result = static_cast<FlMethodResult *>(data);
 
-    flutter::EncodableList list;
-    for (const PackageInfo &package : packages.value()) {
-      list.push_back(flutter::EncodableValue(PackageInfoToMap(package)));
-    }
-    result->Success(flutter::EncodableValue(list));
+          TizenPackageManager &package_manager =
+              TizenPackageManager::GetInstance();
+          std::optional<std::vector<PackageInfo>> packages =
+              package_manager.GetAllPackagesInfo();
+          if (packages.has_value()) {
+            flutter::EncodableList list;
+            for (const PackageInfo &package : packages.value()) {
+              list.push_back(
+                  flutter::EncodableValue(PackageInfoToMap(package)));
+            }
+            result->Success(flutter::EncodableValue(list));
+          } else {
+            result->Error(std::to_string(package_manager.GetLastError()),
+                          package_manager.GetLastErrorString());
+          }
+          delete result;
+        },
+        nullptr, nullptr, result.release());
   }
 
   void Install(const flutter::EncodableMap *arguments,

--- a/packages/tizen_package_manager/tizen/src/tizen_package_manager_plugin.cc
+++ b/packages/tizen_package_manager/tizen/src/tizen_package_manager_plugin.cc
@@ -243,7 +243,13 @@ class TizenPackageManagerPlugin : public flutter::Plugin {
           }
           delete result;
         },
-        nullptr, nullptr, result.release());
+        nullptr,
+        [](void *data, Ecore_Thread *thread) {
+          auto *result = static_cast<FlMethodResult *>(data);
+          result->Error("Operation failed", "Failed to start a thread.");
+          delete result;
+        },
+        result.release());
   }
 
   void Install(const flutter::EncodableMap *arguments,


### PR DESCRIPTION
Calling `PackageManager.getPackagesInfo` makes the app become unresponsive (for up to 10 seconds) on wearable devices.