### PR TITLE
Publish unreleased changes

### DIFF
--- a/packages/firebase_core/CHANGELOG.md
+++ b/packages/firebase_core/CHANGELOG.md
@@ -1,4 +1,4 @@
-## NEXT
+## 0.1.1
 
 * Update firebase_core to 2.4.0.
 * Update firebase_core_platform_interface to 4.5.2.

--- a/packages/firebase_core/README.md
+++ b/packages/firebase_core/README.md
@@ -11,7 +11,7 @@ This package is not an _endorsed_ implementation of `firebase_core`. Therefore, 
 ```yaml
 dependencies:
   firebase_core: ^2.4.0
-  firebase_core_tizen: ^0.1.0
+  firebase_core_tizen: ^0.1.1
 ```
 
 For detailed usage, see https://github.com/invertase/flutterfire_desktop#flutterfire-desktop.

--- a/packages/firebase_core/pubspec.yaml
+++ b/packages/firebase_core/pubspec.yaml
@@ -1,8 +1,8 @@
 name: firebase_core_tizen
-description: Firebase Core for Tizen
+description: Tizen implementation of the firebase_core plugin.
 homepage: https://github.com/flutter-tizen/plugins
 repository: https://github.com/flutter-tizen/plugins/tree/master/packages/firebase_core
-version: 0.1.0
+version: 0.1.1
 
 environment:
   sdk: ">=2.17.0 <3.0.0"

--- a/packages/url_launcher/CHANGELOG.md
+++ b/packages/url_launcher/CHANGELOG.md
@@ -1,6 +1,6 @@
-## NEXT
+## 2.1.2
 
-* Update tizen_app_control to 0.2.0.
+* Update tizen_app_control to 0.2.2.
 
 ## 2.1.1
 

--- a/packages/url_launcher/README.md
+++ b/packages/url_launcher/README.md
@@ -11,7 +11,7 @@ This package is not an _endorsed_ implementation of `url_launcher`. Therefore, y
 ```yaml
 dependencies:
   url_launcher: ^6.1.0
-  url_launcher_tizen: ^2.1.1
+  url_launcher_tizen: ^2.1.2
 ```
 
 Then you can import `url_launcher` in your Dart code:

--- a/packages/url_launcher/pubspec.yaml
+++ b/packages/url_launcher/pubspec.yaml
@@ -1,8 +1,8 @@
 name: url_launcher_tizen
-description: Tizen implementation of the url_launcher plugin
+description: Tizen implementation of the url_launcher plugin.
 homepage: https://github.com/flutter-tizen/plugins
 repository: https://github.com/flutter-tizen/plugins/tree/master/packages/url_launcher
-version: 2.1.1
+version: 2.1.2
 
 flutter:
   plugin:
@@ -13,9 +13,9 @@ flutter:
 dependencies:
   flutter:
     sdk: flutter
-  tizen_app_control: ^0.2.0
+  tizen_app_control: ^0.2.2
   url_launcher_platform_interface: ^2.0.5
 
 environment:
-  sdk: '>=2.13.0 <3.0.0'
+  sdk: ">=2.13.0 <3.0.0"
   flutter: ">=2.2.0"

--- a/packages/webview_flutter/CHANGELOG.md
+++ b/packages/webview_flutter/CHANGELOG.md
@@ -1,4 +1,4 @@
-## NEXT
+## 0.6.3
 
 * Use only error type names defined in `web_resource_error.dart`.
 * Remove unused dependencies.

--- a/packages/webview_flutter/README.md
+++ b/packages/webview_flutter/README.md
@@ -23,7 +23,7 @@ This package is not an _endorsed_ implementation of `webview_flutter`. Therefore
 ```yaml
 dependencies:
   webview_flutter: ^3.0.4
-  webview_flutter_tizen: ^0.6.2
+  webview_flutter_tizen: ^0.6.3
 ```
 
 ## Example

--- a/packages/webview_flutter/pubspec.yaml
+++ b/packages/webview_flutter/pubspec.yaml
@@ -1,8 +1,8 @@
 name: webview_flutter_tizen
-description: Tizen implementation of the webview plugin
+description: Tizen implementation of the webview_flutter plugin.
 homepage: https://github.com/flutter-tizen/plugins
 repository: https://github.com/flutter-tizen/plugins/tree/master/packages/webview_flutter
-version: 0.6.2
+version: 0.6.3
 
 environment:
   sdk: ">=2.17.0 <3.0.0"

--- a/packages/webview_flutter_lwe/CHANGELOG.md
+++ b/packages/webview_flutter_lwe/CHANGELOG.md
@@ -1,4 +1,4 @@
-## NEXT
+## 0.1.1
 
 * Use only error type names defined in `web_resource_error.dart`.
 * Remove unused dependencies.

--- a/packages/webview_flutter_lwe/README.md
+++ b/packages/webview_flutter_lwe/README.md
@@ -21,7 +21,7 @@ This package is not an _endorsed_ implementation of `webview_flutter`. Therefore
 ```yaml
 dependencies:
   webview_flutter: ^3.0.4
-  webview_flutter_lwe: ^0.1.0
+  webview_flutter_lwe: ^0.1.1
 ```
 
 ## Example

--- a/packages/webview_flutter_lwe/pubspec.yaml
+++ b/packages/webview_flutter_lwe/pubspec.yaml
@@ -1,8 +1,8 @@
 name: webview_flutter_lwe
-description: Tizen implementation of the webview plugin backed by Lightweight Web Engine.
+description: Tizen implementation of the webview_flutter plugin backed by Lightweight Web Engine.
 homepage: https://github.com/flutter-tizen/plugins
 repository: https://github.com/flutter-tizen/plugins/tree/master/packages/webview_flutter_lwe
-version: 0.1.0
+version: 0.1.1
 
 environment:
   sdk: ">=2.17.0 <3.0.0"


### PR DESCRIPTION
The current version of `url_launcher_tizen` (2.1.1) is causing a dependency resolution failure because it hasn't been published for a while after updating the `tizen_app_control` dependency. Let's publish the package.

```sh
Because url_launcher_tizen <2.0.0 depends on ffi ^0.1.3 and url_launcher_tizen >=2.0.0 <2.0.1 depends on ffi ^1.0.0, url_launcher_tizen <2.0.1 requires ffi ^0.1.3
  or ^1.0.0.
And because url_launcher_tizen >=2.0.1 <2.1.0 depends on ffi ^1.1.2 and url_launcher_tizen >=2.1.0 <2.1.1 depends on tizen_app_control ^0.1.0, url_launcher_tizen
  <2.1.1 requires tizen_app_control ^0.1.0 or ffi ^0.1.3 or >=1.0.0 <2.0.0.
And because url_launcher_tizen >=2.1.1 depends on tizen_app_control ^0.1.1 which depends on ffi ^1.1.2, every version of url_launcher_tizen requires ffi ^0.1.3 or
  >=1.0.0 <2.0.0.
Because no versions of share_plus match >6.3.0 <7.0.0 and share_plus 6.3.0 depends on ffi ^2.0.1, share_plus ^6.3.0 requires ffi ^2.0.1.
Thus, share_plus ^6.3.0 is incompatible with url_launcher_tizen.
So, because wonders depends on both share_plus ^6.3.0 and url_launcher_tizen any, version solving failed.
```

edit) The webview plugins also have a similar problem.

```
Because google_maps_flutter_tizen >=0.1.4 depends on webview_flutter_lwe ^0.1.0 and google_maps_flutter_tizen <0.1.5 depends on flutter_lints ^1.0.4, every
  version of google_maps_flutter_tizen requires webview_flutter_lwe ^0.1.0 or flutter_lints ^1.0.4.
Because webview_flutter_lwe 0.1.0 depends on flutter_tizen ^0.2.0 and no versions of webview_flutter_lwe match >0.1.0 <0.2.0, webview_flutter_lwe ^0.1.0 requires
  flutter_tizen ^0.2.0.
Thus, every version of google_maps_flutter_tizen requires flutter_lints ^1.0.4 or flutter_tizen from hosted.
And because wonders depends on flutter_tizen from path, every version of google_maps_flutter_tizen requires flutter_lints ^1.0.4.
So, because wonders depends on both google_maps_flutter_tizen any and flutter_lints ^2.0.1, version solving failed.
```