### PR TITLE
Fix integration test log parsing when running on the CI

### DIFF
--- a/tools/lib/src/device.dart
+++ b/tools/lib/src/device.dart
@@ -95,9 +95,6 @@ class Device {
     return _serial != null;
   }
 
-  static final RegExp _logPattern =
-      RegExp(r'\d\d:\d\d\s+([(\+\d+\s+)|(~\d+\s+)|(\-\d+\s+)]+):\s+(.*)');
-
   String? _findSerial() {
     final List<SdbDeviceInfo> deviceInfos = _tizenSdk.sdbDevices();
     for (final SdbDeviceInfo deviceInfo in deviceInfos) {
@@ -163,19 +160,16 @@ class Device {
           'If you expect the test to finish before timeout, check if the tests '
           'require device screen to be awake or if they require manually '
           'clicking the UI button for permissions.';
-    } else if (lastLine.startsWith('No tests ran')) {
+    } else if (lastLine.contains('No tests ran')) {
       error =
           'Missing integration tests (use --exclude if this is intentional).';
-    } else if (lastLine.startsWith('No devices found')) {
+    } else if (lastLine.contains('No devices found')) {
       error = 'Device was disconnected during test.';
-    } else {
-      final RegExpMatch? match = _logPattern.firstMatch(lastLine);
-      if (match == null || match.group(2) == null) {
-        error = 'Could not parse the log output.';
-      } else if (!match.group(2)!.startsWith('All tests passed!')) {
-        error = 'flutter-tizen test integration_test failed, see the output '
-            'above for details.';
-      }
+    } else if (lastLine.contains('failed')) {
+      error = 'flutter-tizen test integration_test failed, see the output '
+          'above for details.';
+    } else if (!lastLine.contains('passed')) {
+      error = 'Could not parse the log output.';
     }
     return error;
   }

--- a/tools/test/device_test.dart
+++ b/tools/test/device_test.dart
@@ -108,11 +108,11 @@ void main() {
       expect(error!.contains('Device was disconnected during test'), true);
     });
 
-    test('correctly parses log "All tests passed!"', () async {
+    test('correctly parses log when all tests passed', () async {
       Future<void>.delayed(
         const Duration(seconds: 1),
         () {
-          controller.add('00:00 +0: All tests passed!');
+          controller.add('🎉 10 tests passed');
           completer.complete(0);
           controller.close();
         },
@@ -124,11 +124,11 @@ void main() {
       expect(error, isNull);
     });
 
-    test('correctly parses log "Some tests failed"', () async {
+    test('correctly parses log when tests failed', () async {
       Future<void>.delayed(
         const Duration(seconds: 1),
         () {
-          controller.add('00:00 +0 -1: Some tests failed');
+          controller.add('::error::8 tests passed, 2 failed.');
           completer.complete(0);
           controller.close();
         },


### PR DESCRIPTION
The log output format is different when running on GitHub Actions.

Local:
```sh
✓ Built build/tizen/tpk/org.tizen.messageport_tizen_example-1.0.0.tpk (28.0MB).
00:32 +0: loading /tmp/flutter_tools.VDWCKB/WLUBMS/messageport_test.dart                                                                                           I00:36 +0: loading /tmp/flutter_tools.VDWCKB/WLUBMS/messageport_test.dart                                                                                       3.2s
00:40 +13: All tests passed!
(or)
00:47 +12 -1: Some tests failed.
```

GitHub Actions:
```sh
...
::group::✅ Types test list
::endgroup::
::group::✅ Types test map
::endgroup::

🎉 13 tests passed.
(or)
::error::12 tests passed, 1 failed.
```

See https://github.com/dart-lang/test/tree/master/pkgs/test#selecting-a-test-reporter.