### PR TITLE
[video_player] Add supported devices information to README

### DIFF
--- a/packages/video_player/CHANGELOG.md
+++ b/packages/video_player/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.4.5
+
+* Update README with supported devices information.
+
 ## 2.4.4
 
 * Update pigeon to 6.0.1.

--- a/packages/video_player/README.md
+++ b/packages/video_player/README.md
@@ -2,7 +2,11 @@
 
 [![pub package](https://img.shields.io/pub/v/video_player_tizen.svg)](https://pub.dev/packages/video_player_tizen)
 
-The Tizen implementation of [`video_player`](https://github.com/flutter/plugins/tree/main/packages/video_player).
+The Tizen implementation of [`video_player`](https://pub.dev/packages/video_player) based on the Tizen [Media Player](https://docs.tizen.org/application/native/api/iot-headed/latest/group__CAPI__MEDIA__PLAYER__MODULE.html) API.
+
+## Supported devices
+
+This plugin is **NOT** supported on TV emulators. This plugin is supported on Galaxy Watch devices and Smart TVs running Tizen 4.0 or above.
 
 ## Required privileges
 
@@ -29,7 +33,7 @@ This package is not an _endorsed_ implementation of `video_player`. Therefore, y
 ```yaml
 dependencies:
   video_player: ^2.4.2
-  video_player_tizen: ^2.4.4
+  video_player_tizen: ^2.4.5
 ```
 
 Then you can import `video_player` in your Dart code:

--- a/packages/video_player/README.md
+++ b/packages/video_player/README.md
@@ -8,24 +8,6 @@ The Tizen implementation of [`video_player`](https://pub.dev/packages/video_play
 
 This plugin is **NOT** supported on TV emulators. This plugin is supported on Galaxy Watch devices and Smart TVs running Tizen 4.0 or above.
 
-## Required privileges
-
-To use this plugin in a Tizen application, you may need to declare the following privileges in your `tizen-manifest.xml` file.
-
-```xml
-<privileges>
-  <privilege>http://tizen.org/privilege/mediastorage</privilege>
-  <privilege>http://tizen.org/privilege/externalstorage</privilege>
-  <privilege>http://tizen.org/privilege/internet</privilege>
-</privileges>
-```
-
-- The mediastorage privilege (`http://tizen.org/privilege/mediastorage`) is required to play video files located in the internal storage.
-- The externalstorage privilege (`http://tizen.org/privilege/externalstorage`) is required to play video files located in the external storage.
-- The internet privilege (`http://tizen.org/privilege/internet`) is required to play any URLs from network.
-
-For detailed information on Tizen privileges, see [Tizen Docs: API Privileges](https://docs.tizen.org/application/dotnet/get-started/api-privileges).
-
 ## Usage
 
 This package is not an _endorsed_ implementation of `video_player`. Therefore, you have to include `video_player_tizen` alongside `video_player` as dependencies in your `pubspec.yaml` file.
@@ -43,6 +25,24 @@ import 'package:video_player/video_player.dart';
 ```
 
 For detailed usage, see https://pub.dev/packages/video_player#example.
+
+## Required privileges
+
+To use this plugin in a Tizen application, you may need to declare the following privileges in your `tizen-manifest.xml` file.
+
+```xml
+<privileges>
+  <privilege>http://tizen.org/privilege/mediastorage</privilege>
+  <privilege>http://tizen.org/privilege/externalstorage</privilege>
+  <privilege>http://tizen.org/privilege/internet</privilege>
+</privileges>
+```
+
+- The mediastorage privilege (`http://tizen.org/privilege/mediastorage`) is required to play video files located in the internal storage.
+- The externalstorage privilege (`http://tizen.org/privilege/externalstorage`) is required to play video files located in the external storage.
+- The internet privilege (`http://tizen.org/privilege/internet`) is required to play any URLs from network.
+
+For detailed information on Tizen privileges, see [Tizen Docs: API Privileges](https://docs.tizen.org/application/dotnet/get-started/api-privileges).
 
 ## Limitations
 

--- a/packages/video_player/pubspec.yaml
+++ b/packages/video_player/pubspec.yaml
@@ -3,7 +3,7 @@ description: Flutter plugin for displaying inline video with other Flutter
   widgets on Tizen.
 homepage: https://github.com/flutter-tizen/plugins
 repository: https://github.com/flutter-tizen/plugins/tree/master/packages/video_player
-version: 2.4.4
+version: 2.4.5
 
 flutter:
   plugin:


### PR DESCRIPTION
Clarify that TV emulator is not supported.

Closes https://github.com/flutter-tizen/plugins/issues/533.