### PR TITLE
[tool] Log standard error on precache failure

### DIFF
--- a/tools/lib/src/integration_test_command.dart
+++ b/tools/lib/src/integration_test_command.dart
@@ -135,10 +135,11 @@ class IntegrationTestCommand extends PackageLoopingCommand {
     final io.ProcessResult processResult = await processRunner.run(
       'flutter-tizen',
       <String>['precache', '--tizen'],
+      logOnError: true,
     );
     if (processResult.exitCode != 0) {
-      print('Cannot cache tizen artifacts used for integration-test.');
-      throw ToolExit(exitCommandFoundErrors);
+      print('Cannot precache Tizen artifacts for integration test.');
+      throw ToolExit(processResult.exitCode);
     }
   }
 


### PR DESCRIPTION
The integration test workflow often fails due to `flutter-tizen precache` failure. We need more information (log output) to diagnose the problem.

Example of failed run: https://github.com/flutter-tizen/plugins/actions/runs/4361105042/jobs/7624679581