### PR TITLE
[ci] Temporarily exclude google_maps_flutter from integration test

### DIFF
--- a/.github/recipe.yaml
+++ b/.github/recipe.yaml
@@ -6,7 +6,6 @@ plugins:
   flutter_app_badger: ["wearable-5.5"]
   flutter_secure_storage: ["wearable-5.5", "tv-6.5"]
   flutter_tts: ["wearable-5.5", "tv-6.5"]
-  google_maps_flutter: ["wearable-5.5", "tv-6.5"]
   integration_test: ["wearable-5.5", "tv-6.5"]
   messageport: ["wearable-5.5", "tv-6.5"]
   package_info_plus: ["wearable-5.5", "tv-6.5"]
@@ -47,3 +46,6 @@ plugins:
   # https://github.com/flutter-tizen/plugins/pull/397#issuecomment-1139299838
   webview_flutter: []
   webview_flutter_lwe: []
+
+  # Temporarily disabled due to the test runner not responding issue.
+  google_maps_flutter: []


### PR DESCRIPTION
The test runner hangs right after launching the google_maps_flutter_tizen integration test. The problem is reproducible on any device. The exact cause is unknown. So we temporarily exclude the package from the test recipe to unblock the CI.