### PR TITLE
[messageport] Remove deprecated APIs

### DIFF
--- a/packages/messageport/CHANGELOG.md
+++ b/packages/messageport/CHANGELOG.md
@@ -1,6 +1,8 @@
-## Next
+## 0.3.0
 
+* Remove the deprecated class `TizenMessagePort`.
 * Refactor the C++ code.
+* Code cleanups.
 
 ## 0.2.0
 

--- a/packages/messageport/example/pubspec.yaml
+++ b/packages/messageport/example/pubspec.yaml
@@ -8,7 +8,6 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-
   messageport_tizen:
     path: ../
 

--- a/packages/messageport/lib/messageport_tizen.dart
+++ b/packages/messageport/lib/messageport_tizen.dart
@@ -6,7 +6,7 @@ import 'dart:async';
 
 import 'src/messageport_manager.dart';
 
-TizenMessagePortManager _manager = TizenMessagePortManager();
+MessagePortManager _manager = MessagePortManager();
 
 /// Called when a message is received on message port.
 ///
@@ -134,27 +134,4 @@ class RemotePort {
 
   /// Whether the remote port is trusted.
   final bool trusted;
-}
-
-// ignore: avoid_classes_with_only_static_members
-/// API for accessing MessagePorts in Tizen.
-class TizenMessagePort {
-  /// Creates a local port.
-  @Deprecated('Use LocalPort.create instead.')
-  static Future<LocalPort> createLocalPort(
-    String portName, {
-    bool trusted = true,
-  }) async {
-    return LocalPort.create(portName, trusted: trusted);
-  }
-
-  /// Connects to a remote port named [portName].
-  @Deprecated('Use RemotePort.connect instead.')
-  static Future<RemotePort> connectToRemotePort(
-    String remoteAppId,
-    String portName, {
-    bool trusted = true,
-  }) async {
-    return RemotePort.connect(remoteAppId, portName, trusted: trusted);
-  }
 }

--- a/packages/messageport/lib/src/messageport_manager.dart
+++ b/packages/messageport/lib/src/messageport_manager.dart
@@ -12,8 +12,12 @@ import '../messageport_tizen.dart';
 
 const MethodChannel _channel = MethodChannel('tizen/messageport');
 
-class TizenMessagePortManager {
-  TizenMessagePortManager();
+class MessagePortManager {
+  MessagePortManager();
+
+  final Map<String, Stream<dynamic>> _localPorts = <String, Stream<dynamic>>{};
+  final Map<String, Stream<dynamic>> _trustedLocalPorts =
+      <String, Stream<dynamic>>{};
 
   Future<void> createLocalPort(String portName, bool trusted) async {
     final Map<String, dynamic> args = <String, dynamic>{};
@@ -74,8 +78,4 @@ class TizenMessagePortManager {
     }
     return _localPorts[localPort.portName]!;
   }
-
-  final Map<String, Stream<dynamic>> _localPorts = <String, Stream<dynamic>>{};
-  final Map<String, Stream<dynamic>> _trustedLocalPorts =
-      <String, Stream<dynamic>>{};
 }

--- a/packages/messageport/pubspec.yaml
+++ b/packages/messageport/pubspec.yaml
@@ -2,7 +2,7 @@ name: messageport_tizen
 description: A Flutter plugin that allows communication between multiple applications on Tizen using Tizen Message Port.
 homepage: https://github.com/flutter-tizen/plugins
 repository: https://github.com/flutter-tizen/plugins/tree/master/packages/messageport
-version: 0.2.0
+version: 0.3.0
 
 environment:
   sdk: ">=2.12.0 <3.0.0"

--- a/packages/messageport/tizen/src/messageport.cc
+++ b/packages/messageport/tizen/src/messageport.cc
@@ -17,22 +17,16 @@ void LocalPort::OnMessageReceived(int local_port_id, const char* remote_app_id,
   int ret =
       bundle_get_byte(bundle, "bytes", reinterpret_cast<void**>(&bytes), &size);
   if (ret != BUNDLE_ERROR_NONE) {
-    if (self->error_callback_) {
-      self->error_callback_(ret, "Failed to get data from bundle.");
-    }
+    self->error_callback_(ret, "Failed to get data from bundle.");
     return;
   }
 
   std::vector<uint8_t> message(bytes, bytes + size);
   if (remote_port) {
     RemotePort port(remote_app_id, remote_port, trusted_remote_port);
-    if (self->message_callback_) {
-      self->message_callback_(message, &port);
-    }
+    self->message_callback_(message, &port);
   } else {
-    if (self->message_callback_) {
-      self->message_callback_(message, nullptr);
-    }
+    self->message_callback_(message, nullptr);
   }
 }
 
@@ -78,9 +72,6 @@ std::optional<MessagePortError> LocalPort::Unregister() {
     }
   }
   port_ = -1;
-
-  message_callback_ = nullptr;
-  error_callback_ = nullptr;
   return std::nullopt;
 }
 


### PR DESCRIPTION
- Remove the deprecated class `TizenMessagePort`.
- Various code cleanups.
  - Simplify the example app code.
  - [Dart] Rename the `TizenMessagePortManager` class to `MessagePortManager`.
  - [C++] Add missing includes.
  - [C++] Add an error callback for more explicit error handling.
 