### PR TITLE
[webview_flutter] Clean up integration test and unused code

### DIFF
--- a/packages/webview_flutter/CHANGELOG.md
+++ b/packages/webview_flutter/CHANGELOG.md
@@ -1,3 +1,8 @@
+## NEXT
+
+* Remove unnecessary integration test.
+* Remove unused code.
+
 ## 0.7.0
 
 * Update webivew_flutter to 4.0.2.

--- a/packages/webview_flutter/lib/src/tizen_webview_controller.dart
+++ b/packages/webview_flutter/lib/src/tizen_webview_controller.dart
@@ -62,6 +62,14 @@ class TizenWebViewController extends PlatformWebViewController {
           'LoadRequestParams#uri is required to have a scheme.');
     }
 
+    if (params.headers.isNotEmpty) {
+      throw ArgumentError('LoadRequestParams#headers is not supported.');
+    }
+
+    if (params.body != null) {
+      throw ArgumentError('LoadRequestParams#body is not supported.');
+    }
+
     switch (params.method) {
       case LoadRequestMethod.get:
         return _webview.loadRequest(params.uri.toString());

--- a/packages/webview_flutter/tizen/src/webview.cc
+++ b/packages/webview_flutter/tizen/src/webview.cc
@@ -59,36 +59,6 @@ class NavigationRequestResult : public FlMethodResult {
   WebView* webview_;
 };
 
-std::string ErrorCodeToString(int error_code) {
-  switch (error_code) {
-    case EWK_ERROR_CODE_AUTHENTICATION:
-      return "authentication";
-    case EWK_ERROR_CODE_BAD_URL:
-      return "badUrl";
-    case EWK_ERROR_CODE_CANT_CONNECT:
-      return "connect";
-    case EWK_ERROR_CODE_FAILED_TLS_HANDSHAKE:
-      return "failedSslHandshake";
-    case EWK_ERROR_CODE_FAILED_FILE_IO:
-      return "file";
-    case EWK_ERROR_CODE_CANT_LOOKUP_HOST:
-      return "hostLookup";
-    case EWK_ERROR_CODE_TOO_MANY_REDIRECTS:
-      return "redirectLoop";
-    case EWK_ERROR_CODE_REQUEST_TIMEOUT:
-      return "timeout";
-    case EWK_ERROR_CODE_TOO_MANY_REQUESTS:
-      return "tooManyRequests";
-    case EWK_ERROR_CODE_UNKNOWN:
-      return "unknown";
-    case EWK_ERROR_CODE_UNSUPPORTED_SCHEME:
-      return "unsupportedScheme";
-    default:
-      LOG_ERROR("Unknown error type: %d", error_code);
-      return "unknown";
-  }
-}
-
 template <typename T>
 bool GetValueFromEncodableMap(const flutter::EncodableValue* arguments,
                               std::string key, T* out) {
@@ -601,8 +571,6 @@ void WebView::OnLoadError(void* data, Evas_Object* obj, void* event_info) {
        flutter::EncodableValue(ewk_error_code_get(error))},
       {flutter::EncodableValue("description"),
        flutter::EncodableValue(ewk_error_description_get(error))},
-      {flutter::EncodableValue("errorType"),
-       flutter::EncodableValue(ErrorCodeToString(ewk_error_code_get(error)))},
       {flutter::EncodableValue("failingUrl"),
        flutter::EncodableValue(ewk_error_url_get(error))},
   };


### PR DESCRIPTION
- Remove unnecessary integration test.
  - "loadRequest with headers"
    - Currently, requests with headers are not supported.
  - "Video playback policy", "Audio playback policy"
    - Doesn't work normally. (When there are multimedia elements, onPageFinished is not called from the ewk.)
  - "target _blank opens in same window"
    - Tizen ewk is not supported.
  - "clearLocalStorage"
    - TizenWebViewController has no implementation.
- Remove unused code in webview.cc