### PR TITLE
[tool] Retry when the precache command failed

### DIFF
--- a/tools/lib/src/integration_test_command.dart
+++ b/tools/lib/src/integration_test_command.dart
@@ -132,13 +132,22 @@ class IntegrationTestCommand extends PackageLoopingCommand {
       }
     }
 
-    final io.ProcessResult processResult = await processRunner.run(
-      'flutter-tizen',
-      <String>['precache', '--tizen'],
-      logOnError: true,
-    );
+    late io.ProcessResult processResult;
+    for (int attempts = 0; attempts < 5; attempts++) {
+      // This operation often fails with an exit code 128.
+      processResult = await processRunner.run(
+        'flutter-tizen',
+        <String>['precache', '--tizen'],
+      );
+      if (processResult.exitCode == 0) {
+        break;
+      }
+      print('Waiting 5 seconds before trying again...');
+      await Future<void>.delayed(const Duration(seconds: 5));
+    }
     if (processResult.exitCode != 0) {
-      print('Cannot precache Tizen artifacts for integration test.');
+      print('Cannot precache Tizen artifacts for integration test:\n'
+          '${processResult.stderr}');
       throw ToolExit(processResult.exitCode);
     }
   }


### PR DESCRIPTION
Connecting to GitHub often fails with a "Connection timed out" error on our integration test server ([example](https://github.com/flutter-tizen/plugins/actions/runs/4684855976/attempts/4)). Automatically retry a maximum of 5 times before throwing a `ToolExit` error.