### PR TITLE
[messageport] Fix PlatformException when sending a null message

### DIFF
--- a/packages/messageport/CHANGELOG.md
+++ b/packages/messageport/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.3.1
+
+* Fix unexpected `PlatformException` when sending a null message.
+
 ## 0.3.0
 
 * Remove the deprecated class `TizenMessagePort`.

--- a/packages/messageport/example/integration_test/messageport_test.dart
+++ b/packages/messageport/example/integration_test/messageport_test.dart
@@ -62,21 +62,36 @@ void main() {
     expect(await remotePort.check(), isFalse);
   }, timeout: const Timeout(Duration(seconds: 5)));
 
-  testWidgets('Send simple message', (WidgetTester tester) async {
+  testWidgets('Send null message', (WidgetTester tester) async {
     final LocalPort localPort = await LocalPort.create(kTestPort);
-    final Completer<List<dynamic>> completer = Completer<List<dynamic>>();
+    final Completer<dynamic> completer = Completer<dynamic>();
     localPort.register((dynamic message, [RemotePort? remotePort]) {
-      completer.complete(<dynamic>[message, remotePort]);
+      expect(remotePort, isNull);
+      completer.complete(message);
+    });
+
+    final RemotePort port = await RemotePort.connect(kTestAppId, kTestPort);
+    await port.send(null);
+
+    final dynamic message = await completer.future;
+    expect(message, isNull);
+
+    await localPort.unregister();
+  }, timeout: const Timeout(Duration(seconds: 5)));
+
+  testWidgets('Send string message', (WidgetTester tester) async {
+    final LocalPort localPort = await LocalPort.create(kTestPort);
+    final Completer<dynamic> completer = Completer<dynamic>();
+    localPort.register((dynamic message, [RemotePort? remotePort]) {
+      expect(remotePort, isNull);
+      completer.complete(message);
     });
 
     final RemotePort port = await RemotePort.connect(kTestAppId, kTestPort);
     await port.send('Test message 1');
 
-    final List<dynamic> value = await completer.future;
-    final String message = value[0] as String;
-    final RemotePort? remotePort = value[1] as RemotePort?;
+    final dynamic message = await completer.future;
     expect(message, equals('Test message 1'));
-    expect(remotePort, isNull);
 
     await localPort.unregister();
   }, timeout: const Timeout(Duration(seconds: 5)));

--- a/packages/messageport/pubspec.yaml
+++ b/packages/messageport/pubspec.yaml
@@ -2,7 +2,7 @@ name: messageport_tizen
 description: A Flutter plugin that allows communication between multiple applications on Tizen using Tizen Message Port.
 homepage: https://github.com/flutter-tizen/plugins
 repository: https://github.com/flutter-tizen/plugins/tree/master/packages/messageport
-version: 0.3.0
+version: 0.3.1
 
 environment:
   sdk: ">=2.12.0 <3.0.0"

--- a/packages/messageport/tizen/src/messageport_tizen_plugin.cc
+++ b/packages/messageport/tizen/src/messageport_tizen_plugin.cc
@@ -226,7 +226,7 @@ class MessageportTizenPlugin : public flutter::Plugin {
     bool trusted = false;
 
     auto iter = arguments->find(flutter::EncodableValue("message"));
-    if (iter != arguments->end() && !iter->second.IsNull()) {
+    if (iter != arguments->end()) {
       message = iter->second;
     } else {
       result->Error("Invalid arguments");


### PR DESCRIPTION
`null` is a valid message type as specified in the README.

The tizen_app_control example's dependency should be updated after releasing this change.