### PR TITLE
[sqflite] Set the default factory implementation

### DIFF
--- a/packages/sqflite/CHANGELOG.md
+++ b/packages/sqflite/CHANGELOG.md
@@ -1,7 +1,12 @@
+## 0.1.2
+
+* Add sqflite dependency.
+* Fix the `databaseFactory` not initialized error.
+
 ## 0.1.1
 
 * Resolve linter warnings.
-* Implement databaseExists method.
+* Implement the `databaseExists` method.
 
 ## 0.1.0
 

--- a/packages/sqflite/README.md
+++ b/packages/sqflite/README.md
@@ -10,8 +10,8 @@ This package is not an _endorsed_ implementation of `sqflite`. Therefore, you ha
 
 ```yaml
 dependencies:
-  sqflite: ^2.0.1
-  sqflite_tizen: ^0.1.1
+  sqflite: ^2.2.8
+  sqflite_tizen: ^0.1.2
 ```
 
 Then you can import `sqflite` in your Dart code:

--- a/packages/sqflite/example/pubspec.yaml
+++ b/packages/sqflite/example/pubspec.yaml
@@ -10,7 +10,7 @@ dependencies:
   collection: any
   flutter:
     sdk: flutter
-  sqflite: ^2.0.0
+  sqflite: ^2.2.8
   sqflite_common:
   sqflite_tizen:
     path: ../

--- a/packages/sqflite/lib/sqflite_tizen.dart
+++ b/packages/sqflite/lib/sqflite_tizen.dart
@@ -1,0 +1,15 @@
+// Copyright 2023 Samsung Electronics Co., Ltd. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:sqflite/sqflite.dart';
+
+/// A class to initialize the plugin.
+///
+/// This class is not intended for use by user code.
+class SqfliteTizen {
+  /// Sets the default factory implementation.
+  static void register() {
+    databaseFactory = databaseFactorySqflitePlugin;
+  }
+}

--- a/packages/sqflite/pubspec.yaml
+++ b/packages/sqflite/pubspec.yaml
@@ -1,8 +1,8 @@
 name: sqflite_tizen
-description: SQLite plugin for Flutter. This plugin provides the Tizen implementation for SQLite.
+description: Tizen implementation of the sqflite plugin.
 homepage: https://github.com/flutter-tizen/plugins
 repository: https://github.com/flutter-tizen/plugins/tree/master/packages/sqflite
-version: 0.1.1
+version: 0.1.2
 
 flutter:
   plugin:
@@ -10,10 +10,12 @@ flutter:
       tizen:
         pluginClass: SqflitePlugin
         fileName: sqflite_plugin.h
+        dartPluginClass: SqfliteTizen
 
 dependencies:
   flutter:
     sdk: flutter
+  sqflite: ^2.2.8
 
 dev_dependencies:
   flutter_lints: ^1.0.4


### PR DESCRIPTION
Fixes the "databaseFactory not initialized" CI error caused by [this recent change](https://github.com/tekartik/sqflite/commit/42fc7e279b80169ec146c755ec91764680efe3e8) in the plugin API.