### PR TITLE
[video_player] Fix memory leak issue

### DIFF
--- a/packages/video_player/CHANGELOG.md
+++ b/packages/video_player/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.4.6
+
+* Fix memory leak issue.
+
 ## 2.4.5
 
 * Update README with supported devices information.

--- a/packages/video_player/CHANGELOG.md
+++ b/packages/video_player/CHANGELOG.md
@@ -1,9 +1,6 @@
 ## 2.4.6
 
 * Fix memory leak issue.
-
-## NEXT
-
 * Increase the minimum Flutter version to 3.3.
 
 ## 2.4.5

--- a/packages/video_player/README.md
+++ b/packages/video_player/README.md
@@ -15,7 +15,7 @@ This package is not an _endorsed_ implementation of `video_player`. Therefore, y
 ```yaml
 dependencies:
   video_player: ^2.4.2
-  video_player_tizen: ^2.4.5
+  video_player_tizen: ^2.4.6
 ```
 
 Then you can import `video_player` in your Dart code:

--- a/packages/video_player/pubspec.yaml
+++ b/packages/video_player/pubspec.yaml
@@ -3,7 +3,7 @@ description: Flutter plugin for displaying inline video with other Flutter
   widgets on Tizen.
 homepage: https://github.com/flutter-tizen/plugins
 repository: https://github.com/flutter-tizen/plugins/tree/master/packages/video_player
-version: 2.4.5
+version: 2.4.6
 
 flutter:
   plugin:


### PR DESCRIPTION
OnVideoFrameDecoded callback may be received during destory MM player. So check is_initialized_ value when receive frame decoded callback.