### PR TITLE
Increase the minimum Flutter version to 3.3

### DIFF
--- a/packages/audioplayers/CHANGELOG.md
+++ b/packages/audioplayers/CHANGELOG.md
@@ -1,3 +1,7 @@
+## NEXT
+
+* Increase the minimum Flutter version to 3.3.
+
 ## 2.0.0
 
 * Add audioplayers_platform_interface dependency and update method calls.

--- a/packages/audioplayers/example/lib/components/btn.dart
+++ b/packages/audioplayers/example/lib/components/btn.dart
@@ -4,8 +4,7 @@ class Btn extends StatelessWidget {
   final String txt;
   final VoidCallback onPressed;
 
-  const Btn({Key? key, required this.txt, required this.onPressed})
-      : super(key: key);
+  const Btn({super.key, required this.txt, required this.onPressed});
 
   @override
   Widget build(BuildContext context) {

--- a/packages/audioplayers/example/lib/components/cbx.dart
+++ b/packages/audioplayers/example/lib/components/cbx.dart
@@ -9,8 +9,8 @@ class Cbx extends StatelessWidget {
     this.label,
     this.value,
     this.update, {
-    Key? key,
-  }) : super(key: key);
+    super.key,
+  });
 
   @override
   Widget build(BuildContext context) {

--- a/packages/audioplayers/example/lib/components/dlg.dart
+++ b/packages/audioplayers/example/lib/components/dlg.dart
@@ -5,10 +5,10 @@ class SimpleDlg extends StatelessWidget {
   final String message, action;
 
   const SimpleDlg({
-    Key? key,
+    super.key,
     required this.message,
     required this.action,
-  }) : super(key: key);
+  });
 
   @override
   Widget build(BuildContext context) {
@@ -28,9 +28,9 @@ class Dlg extends StatelessWidget {
   final List<Widget> children;
 
   const Dlg({
-    Key? key,
+    super.key,
     required this.children,
-  }) : super(key: key);
+  });
 
   @override
   Widget build(BuildContext context) {

--- a/packages/audioplayers/example/lib/components/pad.dart
+++ b/packages/audioplayers/example/lib/components/pad.dart
@@ -3,7 +3,7 @@ import 'package:flutter/material.dart';
 class Pad extends StatelessWidget {
   final double width, height;
 
-  const Pad({Key? key, this.width = 0, this.height = 0}) : super(key: key);
+  const Pad({super.key, this.width = 0, this.height = 0});
 
   @override
   Widget build(BuildContext context) {

--- a/packages/audioplayers/example/lib/components/player_widget.dart
+++ b/packages/audioplayers/example/lib/components/player_widget.dart
@@ -7,9 +7,9 @@ class PlayerWidget extends StatefulWidget {
   final AudioPlayer player;
 
   const PlayerWidget({
-    Key? key,
+    super.key,
     required this.player,
-  }) : super(key: key);
+  });
 
   @override
   State<StatefulWidget> createState() {

--- a/packages/audioplayers/example/lib/components/tab_wrapper.dart
+++ b/packages/audioplayers/example/lib/components/tab_wrapper.dart
@@ -3,7 +3,7 @@ import 'package:flutter/material.dart';
 class TabWrapper extends StatelessWidget {
   final List<Widget> children;
 
-  const TabWrapper({Key? key, required this.children}) : super(key: key);
+  const TabWrapper({super.key, required this.children});
 
   @override
   Widget build(BuildContext context) {

--- a/packages/audioplayers/example/lib/components/tabs.dart
+++ b/packages/audioplayers/example/lib/components/tabs.dart
@@ -2,7 +2,7 @@ import 'package:flutter/material.dart';
 
 class Tabs extends StatelessWidget {
   final Map<String, Widget> tabs;
-  const Tabs({Key? key, required this.tabs}) : super(key: key);
+  const Tabs({super.key, required this.tabs});
 
   @override
   Widget build(BuildContext context) {

--- a/packages/audioplayers/example/lib/components/tgl.dart
+++ b/packages/audioplayers/example/lib/components/tgl.dart
@@ -6,18 +6,18 @@ class Tgl extends StatelessWidget {
   final void Function(int) onChange;
 
   const Tgl({
-    Key? key,
+    super.key,
     required this.options,
     required this.selected,
     required this.onChange,
-  }) : super(key: key);
+  });
 
   @override
   Widget build(BuildContext context) {
     return ToggleButtons(
       isSelected: options.asMap().keys.map((it) => it == selected).toList(),
       onPressed: onChange,
-      children: options.map((it) => Text(it)).toList(),
+      children: options.map(Text.new).toList(),
     );
   }
 }
@@ -28,11 +28,11 @@ class EnumTgl<T extends Enum> extends StatelessWidget {
   final void Function(T) onChange;
 
   const EnumTgl({
-    Key? key,
+    super.key,
     required this.options,
     required this.selected,
     required this.onChange,
-  }) : super(key: key);
+  });
 
   @override
   Widget build(BuildContext context) {

--- a/packages/audioplayers/example/lib/components/txt.dart
+++ b/packages/audioplayers/example/lib/components/txt.dart
@@ -4,10 +4,10 @@ class TxtBox extends StatefulWidget {
   final String value;
   final void Function(String) onChange;
   const TxtBox({
-    Key? key,
+    super.key,
     required this.value,
     required this.onChange,
-  }) : super(key: key);
+  });
 
   @override
   State<TxtBox> createState() => _TxtBoxState();

--- a/packages/audioplayers/example/lib/main.dart
+++ b/packages/audioplayers/example/lib/main.dart
@@ -15,7 +15,7 @@ void main() {
 }
 
 class ExampleApp extends StatefulWidget {
-  const ExampleApp({Key? key}) : super(key: key);
+  const ExampleApp({super.key});
 
   @override
   _ExampleAppState createState() => _ExampleAppState();

--- a/packages/audioplayers/example/lib/tabs/audio_context.dart
+++ b/packages/audioplayers/example/lib/tabs/audio_context.dart
@@ -8,7 +8,7 @@ import 'package:flutter/material.dart';
 class AudioContextTab extends StatefulWidget {
   final AudioPlayer player;
 
-  const AudioContextTab({Key? key, required this.player}) : super(key: key);
+  const AudioContextTab({super.key, required this.player});
 
   @override
   _AudioContextTabState createState() => _AudioContextTabState();

--- a/packages/audioplayers/example/lib/tabs/controls.dart
+++ b/packages/audioplayers/example/lib/tabs/controls.dart
@@ -9,7 +9,7 @@ import 'package:flutter/material.dart';
 class ControlsTab extends StatefulWidget {
   final AudioPlayer player;
 
-  const ControlsTab({Key? key, required this.player}) : super(key: key);
+  const ControlsTab({super.key, required this.player});
 
   @override
   State<ControlsTab> createState() => _ControlsTabState();

--- a/packages/audioplayers/example/lib/tabs/logger.dart
+++ b/packages/audioplayers/example/lib/tabs/logger.dart
@@ -4,7 +4,7 @@ import 'package:audioplayers_tizen_example/components/tab_wrapper.dart';
 import 'package:flutter/material.dart';
 
 class LoggerTab extends StatefulWidget {
-  const LoggerTab({Key? key}) : super(key: key);
+  const LoggerTab({super.key});
 
   @override
   _LoggerTabState createState() => _LoggerTabState();

--- a/packages/audioplayers/example/lib/tabs/sources.dart
+++ b/packages/audioplayers/example/lib/tabs/sources.dart
@@ -18,7 +18,7 @@ const _asset2 = 'nasa_on_a_mission.mp3';
 class SourcesTab extends StatefulWidget {
   final AudioPlayer player;
 
-  const SourcesTab({Key? key, required this.player}) : super(key: key);
+  const SourcesTab({super.key, required this.player});
 
   @override
   State<SourcesTab> createState() => _SourcesTabState();

--- a/packages/audioplayers/example/lib/tabs/streams.dart
+++ b/packages/audioplayers/example/lib/tabs/streams.dart
@@ -11,7 +11,7 @@ import 'package:flutter/material.dart';
 class StreamsTab extends StatefulWidget {
   final AudioPlayer player;
 
-  const StreamsTab({Key? key, required this.player}) : super(key: key);
+  const StreamsTab({super.key, required this.player});
 
   @override
   State<StreamsTab> createState() => _StreamsTabState();

--- a/packages/audioplayers/example/pubspec.yaml
+++ b/packages/audioplayers/example/pubspec.yaml
@@ -3,8 +3,8 @@ description: Demonstrates how to use the audioplayers plugin.
 publish_to: "none"
 
 environment:
-  sdk: ">=2.17.0 <4.0.0"
-  flutter: ">=3.0.0"
+  sdk: ">=2.18.0 <4.0.0"
+  flutter: ">=3.3.0"
 
 dependencies:
   audioplayers: ^1.0.1

--- a/packages/audioplayers/example/pubspec.yaml
+++ b/packages/audioplayers/example/pubspec.yaml
@@ -2,6 +2,10 @@ name: audioplayers_tizen_example
 description: Demonstrates how to use the audioplayers plugin.
 publish_to: "none"
 
+environment:
+  sdk: ">=2.17.0 <4.0.0"
+  flutter: ">=3.0.0"
+
 dependencies:
   audioplayers: ^1.0.1
   audioplayers_tizen:
@@ -29,7 +33,3 @@ flutter:
   uses-material-design: true
   assets:
     - assets/
-
-environment:
-  sdk: ">=2.14.0 <3.0.0"
-  flutter: ">=2.5.0"

--- a/packages/audioplayers/pubspec.yaml
+++ b/packages/audioplayers/pubspec.yaml
@@ -4,6 +4,10 @@ homepage: https://github.com/flutter-tizen/plugins
 repository: https://github.com/flutter-tizen/plugins/tree/master/packages/audioplayers
 version: 2.0.0
 
+environment:
+  sdk: ">=2.17.0 <4.0.0"
+  flutter: ">=3.0.0"
+
 flutter:
   plugin:
     platforms:
@@ -18,7 +22,3 @@ dependencies:
 
 dev_dependencies:
   flame_lint: ^0.1.0
-
-environment:
-  sdk: ">=2.14.0 <3.0.0"
-  flutter: ">=2.5.0"

--- a/packages/audioplayers/pubspec.yaml
+++ b/packages/audioplayers/pubspec.yaml
@@ -5,8 +5,8 @@ repository: https://github.com/flutter-tizen/plugins/tree/master/packages/audiop
 version: 2.0.0
 
 environment:
-  sdk: ">=2.17.0 <4.0.0"
-  flutter: ">=3.0.0"
+  sdk: ">=2.18.0 <4.0.0"
+  flutter: ">=3.3.0"
 
 flutter:
   plugin:

--- a/packages/battery_plus/CHANGELOG.md
+++ b/packages/battery_plus/CHANGELOG.md
@@ -1,3 +1,7 @@
+## NEXT
+
+* Increase the minimum Flutter version to 3.3.
+
 ## 1.1.1
 
 * Hold memory of StreamHandlerError's member to prevent crash.

--- a/packages/battery_plus/example/integration_test/battery_plus_test.dart
+++ b/packages/battery_plus/example/integration_test/battery_plus_test.dart
@@ -2,8 +2,6 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-// @dart=2.9
-
 import 'package:battery_plus/battery_plus.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter_test/flutter_test.dart';

--- a/packages/battery_plus/example/pubspec.yaml
+++ b/packages/battery_plus/example/pubspec.yaml
@@ -2,6 +2,10 @@ name: battery_plus_example
 description: Demonstrates how to use the battery_plus plugin.
 publish_to: "none"
 
+environment:
+  sdk: ">=2.17.0 <4.0.0"
+  flutter: ">=3.0.0"
+
 dependencies:
   battery_plus: ^2.1.3
   battery_plus_tizen:
@@ -22,7 +26,3 @@ dev_dependencies:
 
 flutter:
   uses-material-design: true
-
-environment:
-  sdk: ">=2.12.0 <3.0.0"
-  flutter: ">=2.2.0"

--- a/packages/battery_plus/example/pubspec.yaml
+++ b/packages/battery_plus/example/pubspec.yaml
@@ -3,8 +3,8 @@ description: Demonstrates how to use the battery_plus plugin.
 publish_to: "none"
 
 environment:
-  sdk: ">=2.17.0 <4.0.0"
-  flutter: ">=3.0.0"
+  sdk: ">=2.18.0 <4.0.0"
+  flutter: ">=3.3.0"
 
 dependencies:
   battery_plus: ^2.1.3

--- a/packages/battery_plus/pubspec.yaml
+++ b/packages/battery_plus/pubspec.yaml
@@ -1,8 +1,12 @@
 name: battery_plus_tizen
-description: Tizen implementation of the battery_plus plugin
+description: Tizen implementation of the battery_plus plugin.
 homepage: https://github.com/flutter-tizen/plugins
 repository: https://github.com/flutter-tizen/plugins/tree/master/packages/battery_plus
 version: 1.1.1
+
+environment:
+  sdk: ">=2.17.0 <4.0.0"
+  flutter: ">=3.0.0"
 
 flutter:
   plugin:
@@ -18,7 +22,3 @@ dependencies:
 
 dev_dependencies:
   flutter_lints: ^1.0.4
-
-environment:
-  sdk: ">=2.12.0 <3.0.0"
-  flutter: ">=2.0.0"

--- a/packages/battery_plus/pubspec.yaml
+++ b/packages/battery_plus/pubspec.yaml
@@ -5,8 +5,8 @@ repository: https://github.com/flutter-tizen/plugins/tree/master/packages/batter
 version: 1.1.1
 
 environment:
-  sdk: ">=2.17.0 <4.0.0"
-  flutter: ">=3.0.0"
+  sdk: ">=2.18.0 <4.0.0"
+  flutter: ">=3.3.0"
 
 flutter:
   plugin:

--- a/packages/camera/CHANGELOG.md
+++ b/packages/camera/CHANGELOG.md
@@ -1,3 +1,7 @@
+## NEXT
+
+* Increase the minimum Flutter version to 3.3.
+
 ## 0.3.4
 
 * Switch to an internal method channel implementation.

--- a/packages/camera/example/lib/main.dart
+++ b/packages/camera/example/lib/main.dart
@@ -14,7 +14,7 @@ import 'package:video_player/video_player.dart';
 /// Camera example home widget.
 class CameraExampleHome extends StatefulWidget {
   /// Default Constructor
-  const CameraExampleHome({Key? key}) : super(key: key);
+  const CameraExampleHome({super.key});
 
   @override
   State<CameraExampleHome> createState() {
@@ -1052,7 +1052,7 @@ class _CameraExampleHomeState extends State<CameraExampleHome>
 /// CameraApp is the Main Application.
 class CameraApp extends StatelessWidget {
   /// Default Constructor
-  const CameraApp({Key? key}) : super(key: key);
+  const CameraApp({super.key});
 
   @override
   Widget build(BuildContext context) {

--- a/packages/camera/example/pubspec.yaml
+++ b/packages/camera/example/pubspec.yaml
@@ -3,8 +3,8 @@ description: Demonstrates how to use the camera plugin.
 publish_to: "none"
 
 environment:
-  sdk: ">=2.17.0 <4.0.0"
-  flutter: ">=3.0.0"
+  sdk: ">=2.18.0 <4.0.0"
+  flutter: ">=3.3.0"
 
 dependencies:
   camera: ^0.9.4

--- a/packages/camera/example/pubspec.yaml
+++ b/packages/camera/example/pubspec.yaml
@@ -2,6 +2,10 @@ name: camera_example
 description: Demonstrates how to use the camera plugin.
 publish_to: "none"
 
+environment:
+  sdk: ">=2.17.0 <4.0.0"
+  flutter: ">=3.0.0"
+
 dependencies:
   camera: ^0.9.4
   camera_tizen:
@@ -25,7 +29,3 @@ dev_dependencies:
 
 flutter:
   uses-material-design: true
-
-environment:
-  sdk: ">=2.12.0 <3.0.0"
-  flutter: ">=2.0.0"

--- a/packages/camera/pubspec.yaml
+++ b/packages/camera/pubspec.yaml
@@ -4,6 +4,10 @@ homepage: https://github.com/flutter-tizen/plugins
 repository: https://github.com/flutter-tizen/plugins/tree/master/packages/camera
 version: 0.3.4
 
+environment:
+  sdk: ">=2.17.0 <4.0.0"
+  flutter: ">=3.0.0"
+
 dependencies:
   camera_platform_interface: ^2.1.1
   flutter:
@@ -17,7 +21,3 @@ flutter:
         pluginClass: CameraPlugin
         fileName: camera_plugin.h
         dartPluginClass: CameraTizen
-
-environment:
-  sdk: ">=2.12.0 <3.0.0"
-  flutter: ">=2.0.0"

--- a/packages/camera/pubspec.yaml
+++ b/packages/camera/pubspec.yaml
@@ -5,8 +5,8 @@ repository: https://github.com/flutter-tizen/plugins/tree/master/packages/camera
 version: 0.3.4
 
 environment:
-  sdk: ">=2.17.0 <4.0.0"
-  flutter: ">=3.0.0"
+  sdk: ">=2.18.0 <4.0.0"
+  flutter: ">=3.3.0"
 
 dependencies:
   camera_platform_interface: ^2.1.1

--- a/packages/connectivity_plus/CHANGELOG.md
+++ b/packages/connectivity_plus/CHANGELOG.md
@@ -1,3 +1,7 @@
+## NEXT
+
+* Increase the minimum Flutter version to 3.3.
+
 ## 1.1.2
 
 * Hold memory of StreamHandlerError's member to prevent crash.

--- a/packages/connectivity_plus/example/integration_test/connectivity_plus_test.dart
+++ b/packages/connectivity_plus/example/integration_test/connectivity_plus_test.dart
@@ -1,5 +1,3 @@
-//@dart=2.9
-
 // Copyright 2019 The Chromium Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
@@ -12,7 +10,7 @@ void main() {
   IntegrationTestWidgetsFlutterBinding.ensureInitialized();
 
   group('Connectivity test driver', () {
-    Connectivity _connectivity;
+    late Connectivity _connectivity;
 
     setUpAll(() async {
       _connectivity = Connectivity();

--- a/packages/connectivity_plus/example/pubspec.yaml
+++ b/packages/connectivity_plus/example/pubspec.yaml
@@ -2,6 +2,10 @@ name: connectivity_plus_example
 description: Demonstrates how to use the connectivity_plus_tizen plugin.
 publish_to: "none"
 
+environment:
+  sdk: ">=2.17.0 <4.0.0"
+  flutter: ">=3.0.0"
+
 dependencies:
   connectivity_plus: ^2.3.0
   connectivity_plus_tizen:
@@ -22,7 +26,3 @@ dev_dependencies:
 
 flutter:
   uses-material-design: true
-
-environment:
-  sdk: ">=2.12.0 <3.0.0"
-  flutter: ">=2.2.0"

--- a/packages/connectivity_plus/example/pubspec.yaml
+++ b/packages/connectivity_plus/example/pubspec.yaml
@@ -3,8 +3,8 @@ description: Demonstrates how to use the connectivity_plus_tizen plugin.
 publish_to: "none"
 
 environment:
-  sdk: ">=2.17.0 <4.0.0"
-  flutter: ">=3.0.0"
+  sdk: ">=2.18.0 <4.0.0"
+  flutter: ">=3.3.0"
 
 dependencies:
   connectivity_plus: ^2.3.0

--- a/packages/connectivity_plus/pubspec.yaml
+++ b/packages/connectivity_plus/pubspec.yaml
@@ -4,6 +4,10 @@ homepage: https://github.com/flutter-tizen/plugins
 repository: https://github.com/flutter-tizen/plugins/tree/master/packages/connectivity_plus
 version: 1.1.2
 
+environment:
+  sdk: ">=2.17.0 <4.0.0"
+  flutter: ">=3.0.0"
+
 flutter:
   plugin:
     platforms:
@@ -18,7 +22,3 @@ dependencies:
 
 dev_dependencies:
   flutter_lints: ^1.0.4
-
-environment:
-  sdk: ">=2.12.0 <3.0.0"
-  flutter: ">=2.0.0"

--- a/packages/connectivity_plus/pubspec.yaml
+++ b/packages/connectivity_plus/pubspec.yaml
@@ -5,8 +5,8 @@ repository: https://github.com/flutter-tizen/plugins/tree/master/packages/connec
 version: 1.1.2
 
 environment:
-  sdk: ">=2.17.0 <4.0.0"
-  flutter: ">=3.0.0"
+  sdk: ">=2.18.0 <4.0.0"
+  flutter: ">=3.3.0"
 
 flutter:
   plugin:

--- a/packages/device_info_plus/CHANGELOG.md
+++ b/packages/device_info_plus/CHANGELOG.md
@@ -1,3 +1,7 @@
+## NEXT
+
+* Increase the minimum Flutter version to 3.3.
+
 ## 1.1.0
 
 * Remove dependency on `device_info_plus_platform_interface`.

--- a/packages/device_info_plus/example/integration_test/device_info_plus_test.dart
+++ b/packages/device_info_plus/example/integration_test/device_info_plus_test.dart
@@ -2,8 +2,6 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-// @dart=2.9
-
 import 'package:flutter_test/flutter_test.dart';
 import 'package:device_info_plus_tizen/device_info_plus_tizen.dart';
 import 'package:integration_test/integration_test.dart';
@@ -11,7 +9,7 @@ import 'package:integration_test/integration_test.dart';
 void main() {
   IntegrationTestWidgetsFlutterBinding.ensureInitialized();
 
-  TizenDeviceInfo tizenInfo;
+  late TizenDeviceInfo tizenInfo;
 
   setUpAll(() async {
     final deviceInfoPlugin = DeviceInfoPluginTizen();

--- a/packages/device_info_plus/example/pubspec.yaml
+++ b/packages/device_info_plus/example/pubspec.yaml
@@ -2,6 +2,10 @@ name: device_info_plus_example
 description: Demonstrates how to use the device_info_plus_tizen plugin.
 publish_to: "none"
 
+environment:
+  sdk: ">=2.17.0 <4.0.0"
+  flutter: ">=3.0.0"
+
 dependencies:
   device_info_plus_tizen:
     path: ../
@@ -21,7 +25,3 @@ dev_dependencies:
 
 flutter:
   uses-material-design: true
-
-environment:
-  sdk: ">=2.12.0 <3.0.0"
-  flutter: ">=2.0.0"

--- a/packages/device_info_plus/example/pubspec.yaml
+++ b/packages/device_info_plus/example/pubspec.yaml
@@ -3,8 +3,8 @@ description: Demonstrates how to use the device_info_plus_tizen plugin.
 publish_to: "none"
 
 environment:
-  sdk: ">=2.17.0 <4.0.0"
-  flutter: ">=3.0.0"
+  sdk: ">=2.18.0 <4.0.0"
+  flutter: ">=3.3.0"
 
 dependencies:
   device_info_plus_tizen:

--- a/packages/device_info_plus/pubspec.yaml
+++ b/packages/device_info_plus/pubspec.yaml
@@ -5,6 +5,10 @@ homepage: https://github.com/flutter-tizen/plugins
 repository: https://github.com/flutter-tizen/plugins/tree/master/packages/device_info_plus
 version: 1.1.0
 
+environment:
+  sdk: ">=2.17.0 <4.0.0"
+  flutter: ">=3.0.0"
+
 flutter:
   plugin:
     platforms:
@@ -18,7 +22,3 @@ dependencies:
 
 dev_dependencies:
   flutter_lints: ^1.0.4
-
-environment:
-  sdk: '>=2.12.0 <3.0.0'
-  flutter: ">=2.0.0"

--- a/packages/device_info_plus/pubspec.yaml
+++ b/packages/device_info_plus/pubspec.yaml
@@ -6,8 +6,8 @@ repository: https://github.com/flutter-tizen/plugins/tree/master/packages/device
 version: 1.1.0
 
 environment:
-  sdk: ">=2.17.0 <4.0.0"
-  flutter: ">=3.0.0"
+  sdk: ">=2.18.0 <4.0.0"
+  flutter: ">=3.3.0"
 
 flutter:
   plugin:

--- a/packages/firebase_core/CHANGELOG.md
+++ b/packages/firebase_core/CHANGELOG.md
@@ -1,3 +1,7 @@
+## NEXT
+
+* Increase the minimum Flutter version to 3.3.
+
 ## 0.1.1
 
 * Update firebase_core to 2.4.0.

--- a/packages/firebase_core/example/pubspec.yaml
+++ b/packages/firebase_core/example/pubspec.yaml
@@ -3,8 +3,8 @@ description: An example application demonstrating calls to Firebase Core.
 publish_to: "none"
 
 environment:
-  sdk: ">=2.17.0 <4.0.0"
-  flutter: ">=3.0.0"
+  sdk: ">=2.18.0 <4.0.0"
+  flutter: ">=3.3.0"
 
 dependencies:
   firebase_core: ^2.4.0

--- a/packages/firebase_core/example/pubspec.yaml
+++ b/packages/firebase_core/example/pubspec.yaml
@@ -3,8 +3,8 @@ description: An example application demonstrating calls to Firebase Core.
 publish_to: "none"
 
 environment:
-  sdk: ">=2.17.0 <3.0.0"
-  flutter: ">=2.5.0"
+  sdk: ">=2.17.0 <4.0.0"
+  flutter: ">=3.0.0"
 
 dependencies:
   firebase_core: ^2.4.0

--- a/packages/firebase_core/pubspec.yaml
+++ b/packages/firebase_core/pubspec.yaml
@@ -5,8 +5,8 @@ repository: https://github.com/flutter-tizen/plugins/tree/master/packages/fireba
 version: 0.1.1
 
 environment:
-  sdk: ">=2.17.0 <4.0.0"
-  flutter: ">=3.0.0"
+  sdk: ">=2.18.0 <4.0.0"
+  flutter: ">=3.3.0"
 
 dependencies:
   firebase_core_dart: ^1.0.1

--- a/packages/firebase_core/pubspec.yaml
+++ b/packages/firebase_core/pubspec.yaml
@@ -5,8 +5,8 @@ repository: https://github.com/flutter-tizen/plugins/tree/master/packages/fireba
 version: 0.1.1
 
 environment:
-  sdk: ">=2.17.0 <3.0.0"
-  flutter: ">=2.5.0"
+  sdk: ">=2.17.0 <4.0.0"
+  flutter: ">=3.0.0"
 
 dependencies:
   firebase_core_dart: ^1.0.1

--- a/packages/flutter_app_badger/CHANGELOG.md
+++ b/packages/flutter_app_badger/CHANGELOG.md
@@ -1,3 +1,7 @@
+## NEXT
+
+* Increase the minimum Flutter version to 3.3.
+
 ## 0.1.0
 
 * Initial release.

--- a/packages/flutter_app_badger/example/pubspec.yaml
+++ b/packages/flutter_app_badger/example/pubspec.yaml
@@ -3,8 +3,8 @@ description: Demonstrates how to use the flutter_app_badger_tizen plugin.
 publish_to: "none"
 
 environment:
-  sdk: ">=2.17.0 <4.0.0"
-  flutter: ">=3.0.0"
+  sdk: ">=2.18.0 <4.0.0"
+  flutter: ">=3.3.0"
 
 dependencies:
   flutter:

--- a/packages/flutter_app_badger/example/pubspec.yaml
+++ b/packages/flutter_app_badger/example/pubspec.yaml
@@ -2,6 +2,10 @@ name: flutter_app_badger_tizen_example
 description: Demonstrates how to use the flutter_app_badger_tizen plugin.
 publish_to: "none"
 
+environment:
+  sdk: ">=2.17.0 <4.0.0"
+  flutter: ">=3.0.0"
+
 dependencies:
   flutter:
     sdk: flutter
@@ -20,7 +24,3 @@ dev_dependencies:
 
 flutter:
   uses-material-design: true
-
-environment:
-  sdk: ">=2.17.0 <3.0.0"
-  flutter: ">=2.0.0"

--- a/packages/flutter_app_badger/pubspec.yaml
+++ b/packages/flutter_app_badger/pubspec.yaml
@@ -1,8 +1,12 @@
 name: flutter_app_badger_tizen
-description: Tizen implementation of the flutter_app_badger plugin
+description: Tizen implementation of the flutter_app_badger plugin.
 homepage: https://github.com/flutter-tizen/plugins
 repository: https://github.com/flutter-tizen/plugins/tree/master/packages/flutter_app_badger_tizen
 version: 0.1.0
+
+environment:
+  sdk: ">=2.17.0 <4.0.0"
+  flutter: ">=3.0.0"
 
 flutter:
   plugin:
@@ -14,7 +18,3 @@ flutter:
 dependencies:
   flutter:
     sdk: flutter
-
-environment:
-  sdk: ">=2.12.0 <3.0.0"
-  flutter: ">=2.5.0"

--- a/packages/flutter_app_badger/pubspec.yaml
+++ b/packages/flutter_app_badger/pubspec.yaml
@@ -5,8 +5,8 @@ repository: https://github.com/flutter-tizen/plugins/tree/master/packages/flutte
 version: 0.1.0
 
 environment:
-  sdk: ">=2.17.0 <4.0.0"
-  flutter: ">=3.0.0"
+  sdk: ">=2.18.0 <4.0.0"
+  flutter: ">=3.3.0"
 
 flutter:
   plugin:

--- a/packages/flutter_secure_storage/CHANGELOG.md
+++ b/packages/flutter_secure_storage/CHANGELOG.md
@@ -1,3 +1,7 @@
+## NEXT
+
+* Increase the minimum Flutter version to 3.3.
+
 ## 0.1.0
 
-* initial release.
+* Initial release.

--- a/packages/flutter_secure_storage/example/lib/main.dart
+++ b/packages/flutter_secure_storage/example/lib/main.dart
@@ -11,7 +11,7 @@ void main() {
 }
 
 class ItemsWidget extends StatefulWidget {
-  const ItemsWidget({Key? key}) : super(key: key);
+  const ItemsWidget({super.key});
 
   @override
   ItemsWidgetState createState() => ItemsWidgetState();

--- a/packages/flutter_secure_storage/example/pubspec.yaml
+++ b/packages/flutter_secure_storage/example/pubspec.yaml
@@ -2,6 +2,10 @@ name: flutter_secure_storage_tizen_example
 description: Demonstrates how to use the flutter_secure_storage_tizen plugin.
 publish_to: "none"
 
+environment:
+  sdk: ">=2.17.0 <4.0.0"
+  flutter: ">=3.0.0"
+
 dependencies:
   flutter:
     sdk: flutter
@@ -18,12 +22,8 @@ dev_dependencies:
     sdk: flutter
   integration_test_tizen:
     path: ../../integration_test/
-  lint: ^1.10.0
+  lint: ^2.0.1
   test: any
 
 flutter:
   uses-material-design: true
-
-environment:
-  sdk: ">=2.12.0 <3.0.0"
-  flutter: ">=2.0.0"

--- a/packages/flutter_secure_storage/example/pubspec.yaml
+++ b/packages/flutter_secure_storage/example/pubspec.yaml
@@ -3,8 +3,8 @@ description: Demonstrates how to use the flutter_secure_storage_tizen plugin.
 publish_to: "none"
 
 environment:
-  sdk: ">=2.17.0 <4.0.0"
-  flutter: ">=3.0.0"
+  sdk: ">=2.18.0 <4.0.0"
+  flutter: ">=3.3.0"
 
 dependencies:
   flutter:

--- a/packages/flutter_secure_storage/pubspec.yaml
+++ b/packages/flutter_secure_storage/pubspec.yaml
@@ -1,8 +1,12 @@
 name: flutter_secure_storage_tizen
-description: Tizen implementation of the flutter_secure_storage plugin
+description: Tizen implementation of the flutter_secure_storage plugin.
 homepage: https://github.com/flutter-tizen/plugins
 repository: https://github.com/flutter-tizen/plugins/tree/master/packages/flutter_secure_storage
 version: 0.1.0
+
+environment:
+  sdk: ">=2.17.0 <4.0.0"
+  flutter: ">=3.0.0"
 
 flutter:
   plugin:
@@ -19,8 +23,4 @@ dependencies:
 dev_dependencies:
   flutter_test:
     sdk: flutter
-  lint: ^1.10.0
-
-environment:
-  sdk: ">=2.17.0 <3.0.0"
-  flutter: ">=2.5.0"
+  lint: ^2.0.1

--- a/packages/flutter_secure_storage/pubspec.yaml
+++ b/packages/flutter_secure_storage/pubspec.yaml
@@ -5,8 +5,8 @@ repository: https://github.com/flutter-tizen/plugins/tree/master/packages/flutte
 version: 0.1.0
 
 environment:
-  sdk: ">=2.17.0 <4.0.0"
-  flutter: ">=3.0.0"
+  sdk: ">=2.18.0 <4.0.0"
+  flutter: ">=3.3.0"
 
 flutter:
   plugin:

--- a/packages/flutter_tts/CHANGELOG.md
+++ b/packages/flutter_tts/CHANGELOG.md
@@ -1,3 +1,7 @@
+## NEXT
+
+* Increase the minimum Flutter version to 3.3.
+
 ## 1.3.0
 
 * Limit the range of `setSpeechRate` to be between 0.0 and 1.0.

--- a/packages/flutter_tts/analysis_options.yaml
+++ b/packages/flutter_tts/analysis_options.yaml
@@ -1,8 +1,4 @@
-# This file was copied from flutter_tts/analysis_options.yaml.
-
 analyzer:
-  strong-mode:
-    implicit-casts: false
   errors:
     unused_import: error
     unused_local_variable: error

--- a/packages/flutter_tts/example/pubspec.yaml
+++ b/packages/flutter_tts/example/pubspec.yaml
@@ -3,8 +3,8 @@ description: Demonstrates how to use the flutter_tts_tizen plugin.
 publish_to: "none"
 
 environment:
-  sdk: ">=2.17.0 <4.0.0"
-  flutter: ">=3.0.0"
+  sdk: ">=2.18.0 <4.0.0"
+  flutter: ">=3.3.0"
 
 dependencies:
   flutter:

--- a/packages/flutter_tts/example/pubspec.yaml
+++ b/packages/flutter_tts/example/pubspec.yaml
@@ -2,6 +2,10 @@ name: flutter_tts_tizen_example
 description: Demonstrates how to use the flutter_tts_tizen plugin.
 publish_to: "none"
 
+environment:
+  sdk: ">=2.17.0 <4.0.0"
+  flutter: ">=3.0.0"
+
 dependencies:
   flutter:
     sdk: flutter
@@ -21,7 +25,3 @@ dev_dependencies:
 
 flutter:
   uses-material-design: true
-
-environment:
-  sdk: ">=2.12.0 <3.0.0"
-  flutter: ">=2.0.0"

--- a/packages/flutter_tts/pubspec.yaml
+++ b/packages/flutter_tts/pubspec.yaml
@@ -4,6 +4,10 @@ homepage: https://github.com/flutter-tizen/plugins
 repository: https://github.com/flutter-tizen/plugins/tree/master/packages/flutter_tts
 version: 1.3.0
 
+environment:
+  sdk: ">=2.17.0 <4.0.0"
+  flutter: ">=3.0.0"
+
 dependencies:
   flutter:
     sdk: flutter
@@ -14,7 +18,3 @@ flutter:
       tizen:
         pluginClass: FlutterTtsTizenPlugin
         fileName: flutter_tts_tizen_plugin.h
-
-environment:
-  sdk: ">=2.12.0 <3.0.0"
-  flutter: ">=2.0.0"

--- a/packages/flutter_tts/pubspec.yaml
+++ b/packages/flutter_tts/pubspec.yaml
@@ -5,8 +5,8 @@ repository: https://github.com/flutter-tizen/plugins/tree/master/packages/flutte
 version: 1.3.0
 
 environment:
-  sdk: ">=2.17.0 <4.0.0"
-  flutter: ">=3.0.0"
+  sdk: ">=2.18.0 <4.0.0"
+  flutter: ">=3.3.0"
 
 dependencies:
   flutter:

--- a/packages/flutter_webrtc/CHANGELOG.md
+++ b/packages/flutter_webrtc/CHANGELOG.md
@@ -1,13 +1,17 @@
+## NEXT
+
+* Increase the minimum Flutter version to 3.3.
+
 ## 0.1.2
 
 * Update flutter_webrtc to 0.9.28.
-* Fix the data channel does not work in flutter_webrtc_demo.
+* Fix the data channel not working issue in flutter_webrtc_demo.
 * Support frame cryptor.
 
 ## 0.1.1
 
 * Update flutter_webrtc to 0.9.23.
-* Fix coredump issue when exit app.
+* Fix crash on application exit.
 
 ## 0.1.0
 

--- a/packages/flutter_webrtc/example/flutter_webrtc_demo/pubspec.yaml
+++ b/packages/flutter_webrtc/example/flutter_webrtc_demo/pubspec.yaml
@@ -1,11 +1,10 @@
 name: flutter_webrtc_demo
 description: A new Flutter application.
-version: 1.2.0
-publish_to: none
+publish_to: "none"
 
 environment:
-  sdk: ">=2.15.0 <3.0.0"
-  flutter: ">=1.22.0"
+  sdk: ">=2.17.0 <4.0.0"
+  flutter: ">=3.0.0"
 
 dependencies:
   cupertino_icons: ^1.0.3
@@ -18,12 +17,12 @@ dependencies:
   path_provider: ^2.0.7
   path_provider_tizen: ^2.0.2
   shared_preferences: ^2.0.9
-  shared_preferences_tizen: ^2.0.2
+  shared_preferences_tizen:
+    path: ../../../shared_preferences/
 
 dev_dependencies:
   flutter_test:
     sdk: flutter
-  lints: ^2.0.1
   pedantic: ^1.11.0
 
 flutter:

--- a/packages/flutter_webrtc/example/flutter_webrtc_demo/pubspec.yaml
+++ b/packages/flutter_webrtc/example/flutter_webrtc_demo/pubspec.yaml
@@ -3,8 +3,8 @@ description: A new Flutter application.
 publish_to: "none"
 
 environment:
-  sdk: ">=2.17.0 <4.0.0"
-  flutter: ">=3.0.0"
+  sdk: ">=2.18.0 <4.0.0"
+  flutter: ">=3.3.0"
 
 dependencies:
   cupertino_icons: ^1.0.3

--- a/packages/flutter_webrtc/example/flutter_webrtc_example/pubspec.yaml
+++ b/packages/flutter_webrtc/example/flutter_webrtc_example/pubspec.yaml
@@ -1,67 +1,25 @@
 name: flutter_webrtc_example
 description: Demonstrates how to use the webrtc plugin.
-version: 1.0.0
-publish_to: none
+publish_to: "none"
+
 environment:
-  sdk: ">=2.12.0 <3.0.0"
+  sdk: ">=2.17.0 <4.0.0"
+  flutter: ">=3.0.0"
 
 dependencies:
-  # The following adds the Cupertino Icons font to your application.
-  # Use with the CupertinoIcons class for iOS style icons.
-  cupertino_icons: ^1.0.2
   flutter:
     sdk: flutter
   flutter_background: ^1.0.0
-  flutter_webrtc: ^0.9.23
+  flutter_webrtc: ^0.9.27
   flutter_webrtc_tizen:
     path: ../../
-  # Required for MediaRecorder example
   path_provider: ^2.0.7
   path_provider_tizen: ^2.0.2
 
 dev_dependencies:
   flutter_test:
     sdk: flutter
-
   pedantic: ^1.11.0
 
-# For information on the generic Dart part of this file, see the
-# following page: https://www.dartlang.org/tools/pub/pubspec
-
-# The following section is specific to Flutter.
 flutter:
-  # The following line ensures that the Material Icons font is
-  # included with your application, so that you can use the icons in
-  # the material Icons class.
   uses-material-design: true
-
-  # To add assets to your application, add an assets section, like this:
-  # assets:
-  #  - images/a_dot_burr.jpeg
-  #  - images/a_dot_ham.jpeg
-
-  # An image asset can refer to one or more resolution-specific "variants", see
-  # https://flutter.io/assets-and-images/#resolution-aware.
-
-  # For details regarding adding assets from package dependencies, see
-  # https://flutter.io/assets-and-images/#from-packages
-
-  # To add custom fonts to your application, add a fonts section here,
-  # in this "flutter" section. Each entry in this list should have a
-  # "family" key with the font family name, and a "fonts" key with a
-  # list giving the asset and other descriptors for the font. For
-  # example:
-  # fonts:
-  #   - family: Schyler
-  #     fonts:
-  #       - asset: fonts/Schyler-Regular.ttf
-  #       - asset: fonts/Schyler-Italic.ttf
-  #         style: italic
-  #   - family: Trajan Pro
-  #     fonts:
-  #       - asset: fonts/TrajanPro.ttf
-  #       - asset: fonts/TrajanPro_Bold.ttf
-  #         weight: 700
-  #
-  # For details regarding fonts from package dependencies,
-  # see https://flutter.io/custom-fonts/#from-packages

--- a/packages/flutter_webrtc/example/flutter_webrtc_example/pubspec.yaml
+++ b/packages/flutter_webrtc/example/flutter_webrtc_example/pubspec.yaml
@@ -3,8 +3,8 @@ description: Demonstrates how to use the webrtc plugin.
 publish_to: "none"
 
 environment:
-  sdk: ">=2.17.0 <4.0.0"
-  flutter: ">=3.0.0"
+  sdk: ">=2.18.0 <4.0.0"
+  flutter: ">=3.3.0"
 
 dependencies:
   flutter:

--- a/packages/flutter_webrtc/pubspec.yaml
+++ b/packages/flutter_webrtc/pubspec.yaml
@@ -4,6 +4,10 @@ description: Flutter WebRTC plugin for Tizen, based on GoogleWebRTC.
 repository: https://github.com/flutter-tizen/plugins/tree/master/packages/flutter_webrtc
 version: 0.1.1
 
+environment:
+  sdk: ">=2.17.0 <4.0.0"
+  flutter: ">=3.0.0"
+
 flutter:
   plugin:
     platforms:
@@ -15,7 +19,3 @@ dependencies:
   flutter:
     sdk: flutter
   path_provider_tizen: ^2.0.2
-
-environment:
-  sdk: ">=2.12.0 <3.0.0"
-  flutter: ">=2.0.0"

--- a/packages/flutter_webrtc/pubspec.yaml
+++ b/packages/flutter_webrtc/pubspec.yaml
@@ -5,8 +5,8 @@ repository: https://github.com/flutter-tizen/plugins/tree/master/packages/flutte
 version: 0.1.1
 
 environment:
-  sdk: ">=2.17.0 <4.0.0"
-  flutter: ">=3.0.0"
+  sdk: ">=2.18.0 <4.0.0"
+  flutter: ">=3.3.0"
 
 flutter:
   plugin:

--- a/packages/geolocator/CHANGELOG.md
+++ b/packages/geolocator/CHANGELOG.md
@@ -1,3 +1,7 @@
+## NEXT
+
+* Increase the minimum Flutter version to 3.3.
+
 ## 1.0.5
 
 * Hold memory of StreamHandlerError's member to prevent crash

--- a/packages/geolocator/example/pubspec.yaml
+++ b/packages/geolocator/example/pubspec.yaml
@@ -3,7 +3,8 @@ description: Demonstrates how to use the geolocator_tizen plugin.
 publish_to: "none"
 
 environment:
-  sdk: ">=2.12.0 <3.0.0"
+  sdk: ">=2.17.0 <4.0.0"
+  flutter: ">=3.0.0"
 
 dependencies:
   baseflow_plugin_template: ^2.1.1

--- a/packages/geolocator/example/pubspec.yaml
+++ b/packages/geolocator/example/pubspec.yaml
@@ -3,8 +3,8 @@ description: Demonstrates how to use the geolocator_tizen plugin.
 publish_to: "none"
 
 environment:
-  sdk: ">=2.17.0 <4.0.0"
-  flutter: ">=3.0.0"
+  sdk: ">=2.18.0 <4.0.0"
+  flutter: ">=3.3.0"
 
 dependencies:
   baseflow_plugin_template: ^2.1.1

--- a/packages/geolocator/pubspec.yaml
+++ b/packages/geolocator/pubspec.yaml
@@ -5,8 +5,8 @@ repository: https://github.com/flutter-tizen/plugins/tree/master/packages/geoloc
 version: 1.0.5
 
 environment:
-  sdk: ">=2.17.0 <4.0.0"
-  flutter: ">=3.0.0"
+  sdk: ">=2.18.0 <4.0.0"
+  flutter: ">=3.3.0"
 
 flutter:
   plugin:

--- a/packages/geolocator/pubspec.yaml
+++ b/packages/geolocator/pubspec.yaml
@@ -1,8 +1,12 @@
 name: geolocator_tizen
-description: Geolocation plugin for Flutter. This plugin provides the Tizen implementation for the geolocator.
+description: Tizen implementation of the geolocator plugin.
 homepage: https://github.com/flutter-tizen/plugins
 repository: https://github.com/flutter-tizen/plugins/tree/master/packages/geolocator
 version: 1.0.5
+
+environment:
+  sdk: ">=2.17.0 <4.0.0"
+  flutter: ">=3.0.0"
 
 flutter:
   plugin:
@@ -16,7 +20,3 @@ dependencies:
     sdk: flutter
   flutter_lints: ^1.0.4
   geolocator_platform_interface: ^3.0.0
-
-environment:
-  sdk: ">=2.12.0 <3.0.0"
-  flutter: ">=1.20.0"

--- a/packages/google_maps_flutter/CHANGELOG.md
+++ b/packages/google_maps_flutter/CHANGELOG.md
@@ -1,3 +1,7 @@
+## NEXT
+
+* Increase the minimum Flutter version to 3.3.
+
 ## 0.1.5
 
 * Update the example app (`9990a4b1d72158a14924d712e89d4efef3f178d2`).

--- a/packages/google_maps_flutter/example/lib/animate_camera.dart
+++ b/packages/google_maps_flutter/example/lib/animate_camera.dart
@@ -20,7 +20,7 @@ class AnimateCameraPage extends GoogleMapExampleAppPage {
 }
 
 class AnimateCamera extends StatefulWidget {
-  const AnimateCamera({Key? key}) : super(key: key);
+  const AnimateCamera({super.key});
   @override
   State createState() => AnimateCameraState();
 }

--- a/packages/google_maps_flutter/example/lib/main.dart
+++ b/packages/google_maps_flutter/example/lib/main.dart
@@ -42,7 +42,7 @@ final List<GoogleMapExampleAppPage> _allPages = <GoogleMapExampleAppPage>[
 /// MapsDemo is the Main Application.
 class MapsDemo extends StatelessWidget {
   /// Default Constructor
-  const MapsDemo({Key? key}) : super(key: key);
+  const MapsDemo({super.key});
 
   void _pushPage(BuildContext context, GoogleMapExampleAppPage page) {
     Navigator.of(context).push(MaterialPageRoute<void>(

--- a/packages/google_maps_flutter/example/lib/map_ui.dart
+++ b/packages/google_maps_flutter/example/lib/map_ui.dart
@@ -26,7 +26,7 @@ class MapUiPage extends GoogleMapExampleAppPage {
 }
 
 class MapUiBody extends StatefulWidget {
-  const MapUiBody({Key? key}) : super(key: key);
+  const MapUiBody({super.key});
 
   @override
   State<StatefulWidget> createState() => MapUiBodyState();

--- a/packages/google_maps_flutter/example/lib/marker_icons.dart
+++ b/packages/google_maps_flutter/example/lib/marker_icons.dart
@@ -21,7 +21,7 @@ class MarkerIconsPage extends GoogleMapExampleAppPage {
 }
 
 class MarkerIconsBody extends StatefulWidget {
-  const MarkerIconsBody({Key? key}) : super(key: key);
+  const MarkerIconsBody({super.key});
 
   @override
   State<StatefulWidget> createState() => MarkerIconsBodyState();

--- a/packages/google_maps_flutter/example/lib/move_camera.dart
+++ b/packages/google_maps_flutter/example/lib/move_camera.dart
@@ -20,7 +20,7 @@ class MoveCameraPage extends GoogleMapExampleAppPage {
 }
 
 class MoveCamera extends StatefulWidget {
-  const MoveCamera({Key? key}) : super(key: key);
+  const MoveCamera({super.key});
   @override
   State createState() => MoveCameraState();
 }

--- a/packages/google_maps_flutter/example/lib/padding.dart
+++ b/packages/google_maps_flutter/example/lib/padding.dart
@@ -19,7 +19,7 @@ class PaddingPage extends GoogleMapExampleAppPage {
 }
 
 class MarkerIconsBody extends StatefulWidget {
-  const MarkerIconsBody({Key? key}) : super(key: key);
+  const MarkerIconsBody({super.key});
 
   @override
   State<StatefulWidget> createState() => MarkerIconsBodyState();

--- a/packages/google_maps_flutter/example/lib/page.dart
+++ b/packages/google_maps_flutter/example/lib/page.dart
@@ -7,8 +7,7 @@
 import 'package:flutter/material.dart';
 
 abstract class GoogleMapExampleAppPage extends StatelessWidget {
-  const GoogleMapExampleAppPage(this.leading, this.title, {Key? key})
-      : super(key: key);
+  const GoogleMapExampleAppPage(this.leading, this.title, {super.key});
 
   final Widget leading;
   final String title;

--- a/packages/google_maps_flutter/example/lib/place_circle.dart
+++ b/packages/google_maps_flutter/example/lib/place_circle.dart
@@ -20,7 +20,7 @@ class PlaceCirclePage extends GoogleMapExampleAppPage {
 }
 
 class PlaceCircleBody extends StatefulWidget {
-  const PlaceCircleBody({Key? key}) : super(key: key);
+  const PlaceCircleBody({super.key});
 
   @override
   State<StatefulWidget> createState() => PlaceCircleBodyState();

--- a/packages/google_maps_flutter/example/lib/place_marker.dart
+++ b/packages/google_maps_flutter/example/lib/place_marker.dart
@@ -25,7 +25,7 @@ class PlaceMarkerPage extends GoogleMapExampleAppPage {
 }
 
 class PlaceMarkerBody extends StatefulWidget {
-  const PlaceMarkerBody({Key? key}) : super(key: key);
+  const PlaceMarkerBody({super.key});
 
   @override
   State<StatefulWidget> createState() => PlaceMarkerBodyState();

--- a/packages/google_maps_flutter/example/lib/place_polygon.dart
+++ b/packages/google_maps_flutter/example/lib/place_polygon.dart
@@ -20,7 +20,7 @@ class PlacePolygonPage extends GoogleMapExampleAppPage {
 }
 
 class PlacePolygonBody extends StatefulWidget {
-  const PlacePolygonBody({Key? key}) : super(key: key);
+  const PlacePolygonBody({super.key});
 
   @override
   State<StatefulWidget> createState() => PlacePolygonBodyState();

--- a/packages/google_maps_flutter/example/lib/place_polyline.dart
+++ b/packages/google_maps_flutter/example/lib/place_polyline.dart
@@ -21,7 +21,7 @@ class PlacePolylinePage extends GoogleMapExampleAppPage {
 }
 
 class PlacePolylineBody extends StatefulWidget {
-  const PlacePolylineBody({Key? key}) : super(key: key);
+  const PlacePolylineBody({super.key});
 
   @override
   State<StatefulWidget> createState() => PlacePolylineBodyState();

--- a/packages/google_maps_flutter/example/lib/scrolling_map.dart
+++ b/packages/google_maps_flutter/example/lib/scrolling_map.dart
@@ -24,7 +24,7 @@ class ScrollingMapPage extends GoogleMapExampleAppPage {
 }
 
 class ScrollingMapBody extends StatelessWidget {
-  const ScrollingMapBody({Key? key}) : super(key: key);
+  const ScrollingMapBody({super.key});
 
   @override
   Widget build(BuildContext context) {
@@ -94,8 +94,8 @@ class ScrollingMapBody extends StatelessWidget {
                           ),
                         ),
                       },
-                      gestureRecognizers: <
-                          Factory<OneSequenceGestureRecognizer>>{
+                      gestureRecognizers: <Factory<
+                          OneSequenceGestureRecognizer>>{
                         Factory<OneSequenceGestureRecognizer>(
                           () => ScaleGestureRecognizer(),
                         ),

--- a/packages/google_maps_flutter/example/lib/tile_overlay.dart
+++ b/packages/google_maps_flutter/example/lib/tile_overlay.dart
@@ -23,7 +23,7 @@ class TileOverlayPage extends GoogleMapExampleAppPage {
 }
 
 class TileOverlayBody extends StatefulWidget {
-  const TileOverlayBody({Key? key}) : super(key: key);
+  const TileOverlayBody({super.key});
 
   @override
   State<StatefulWidget> createState() => TileOverlayBodyState();

--- a/packages/google_maps_flutter/example/pubspec.yaml
+++ b/packages/google_maps_flutter/example/pubspec.yaml
@@ -3,8 +3,8 @@ description: Demonstrates how to use the google_maps_flutter_tizen plugin.
 publish_to: "none"
 
 environment:
-  sdk: ">=2.17.0 <4.0.0"
-  flutter: ">=3.0.0"
+  sdk: ">=2.18.0 <4.0.0"
+  flutter: ">=3.3.0"
 
 dependencies:
   flutter:

--- a/packages/google_maps_flutter/example/pubspec.yaml
+++ b/packages/google_maps_flutter/example/pubspec.yaml
@@ -1,10 +1,10 @@
 name: google_maps_flutter_tizen_example
 description: Demonstrates how to use the google_maps_flutter_tizen plugin.
-publish_to: none
+publish_to: "none"
 
 environment:
-  sdk: ">=2.12.0 <3.0.0"
-  flutter: ">=2.0.0"
+  sdk: ">=2.17.0 <4.0.0"
+  flutter: ">=3.0.0"
 
 dependencies:
   flutter:

--- a/packages/google_maps_flutter/example/test_driver/integration_test.dart
+++ b/packages/google_maps_flutter/example/test_driver/integration_test.dart
@@ -1,5 +1,3 @@
-// @dart = 2.9
-
 import 'package:integration_test/integration_test_driver.dart';
 
 Future<void> main() => integrationDriver();

--- a/packages/google_maps_flutter/pubspec.yaml
+++ b/packages/google_maps_flutter/pubspec.yaml
@@ -4,6 +4,10 @@ homepage: https://github.com/flutter-tizen/plugins
 repository: https://github.com/flutter-tizen/plugins/tree/master/packages/google_maps_flutter
 version: 0.1.5
 
+environment:
+  sdk: ">=2.17.0 <4.0.0"
+  flutter: ">=3.0.0"
+
 flutter:
   plugin:
     platforms:
@@ -17,7 +21,3 @@ dependencies:
   stream_transform: ^2.0.0
   webview_flutter: ^3.0.4
   webview_flutter_lwe: ^0.1.0
-
-environment:
-  sdk: ">=2.17.0 <3.0.0"
-  flutter: ">=2.0.0"

--- a/packages/google_maps_flutter/pubspec.yaml
+++ b/packages/google_maps_flutter/pubspec.yaml
@@ -5,8 +5,8 @@ repository: https://github.com/flutter-tizen/plugins/tree/master/packages/google
 version: 0.1.5
 
 environment:
-  sdk: ">=2.17.0 <4.0.0"
-  flutter: ">=3.0.0"
+  sdk: ">=2.18.0 <4.0.0"
+  flutter: ">=3.3.0"
 
 flutter:
   plugin:

--- a/packages/google_sign_in/CHANGELOG.md
+++ b/packages/google_sign_in/CHANGELOG.md
@@ -1,3 +1,7 @@
+## NEXT
+
+* Increase the minimum Flutter version to 3.3.
+
 ## 0.1.3
 
 * Add dependency on flutter_secure_storage_tizen.

--- a/packages/google_sign_in/example/pubspec.yaml
+++ b/packages/google_sign_in/example/pubspec.yaml
@@ -2,6 +2,10 @@ name: google_sign_in_tizen_example
 description: Demonstrates how to use the google_sign_in_tizen plugin.
 publish_to: "none"
 
+environment:
+  sdk: ">=2.17.0 <4.0.0"
+  flutter: ">=3.0.0"
+
 dependencies:
   flutter:
     sdk: flutter
@@ -22,7 +26,3 @@ dev_dependencies:
 
 flutter:
   uses-material-design: true
-
-environment:
-  sdk: ">=2.17.0 <3.0.0"
-  flutter: ">=2.8.0"

--- a/packages/google_sign_in/example/pubspec.yaml
+++ b/packages/google_sign_in/example/pubspec.yaml
@@ -3,8 +3,8 @@ description: Demonstrates how to use the google_sign_in_tizen plugin.
 publish_to: "none"
 
 environment:
-  sdk: ">=2.17.0 <4.0.0"
-  flutter: ">=3.0.0"
+  sdk: ">=2.18.0 <4.0.0"
+  flutter: ">=3.3.0"
 
 dependencies:
   flutter:

--- a/packages/google_sign_in/pubspec.yaml
+++ b/packages/google_sign_in/pubspec.yaml
@@ -1,8 +1,12 @@
 name: google_sign_in_tizen
-description: Tizen implementation of the google_sign_in plugin
+description: Tizen implementation of the google_sign_in plugin.
 homepage: https://github.com/flutter-tizen/plugins
 repository: https://github.com/flutter-tizen/plugins/tree/master/packages/google_sign_in
 version: 0.1.3
+
+environment:
+  sdk: ">=2.17.0 <4.0.0"
+  flutter: ">=3.0.0"
 
 flutter:
   plugin:
@@ -24,10 +28,6 @@ dependencies:
 dev_dependencies:
   flutter_test:
     sdk: flutter
-
-environment:
-  sdk: ">=2.17.0 <3.0.0"
-  flutter: ">=2.5.0"
 
 # The example deliberately includes secrets.
 false_secrets:

--- a/packages/google_sign_in/pubspec.yaml
+++ b/packages/google_sign_in/pubspec.yaml
@@ -5,8 +5,8 @@ repository: https://github.com/flutter-tizen/plugins/tree/master/packages/google
 version: 0.1.3
 
 environment:
-  sdk: ">=2.17.0 <4.0.0"
-  flutter: ">=3.0.0"
+  sdk: ">=2.18.0 <4.0.0"
+  flutter: ">=3.3.0"
 
 flutter:
   plugin:

--- a/packages/image_picker/CHANGELOG.md
+++ b/packages/image_picker/CHANGELOG.md
@@ -1,3 +1,7 @@
+## NEXT
+
+* Increase the minimum Flutter version to 3.3.
+
 ## 2.2.0
 
 * Switch to an internal method channel implementation.

--- a/packages/image_picker/example/lib/main.dart
+++ b/packages/image_picker/example/lib/main.dart
@@ -17,7 +17,7 @@ void main() {
 }
 
 class MyApp extends StatelessWidget {
-  const MyApp({Key? key}) : super(key: key);
+  const MyApp({super.key});
 
   @override
   Widget build(BuildContext context) {
@@ -29,7 +29,7 @@ class MyApp extends StatelessWidget {
 }
 
 class MyHomePage extends StatefulWidget {
-  const MyHomePage({Key? key, this.title}) : super(key: key);
+  const MyHomePage({super.key, this.title});
 
   final String? title;
 
@@ -423,7 +423,7 @@ typedef OnPickImageCallback = void Function(
     double? maxWidth, double? maxHeight, int? quality);
 
 class AspectRatioVideo extends StatefulWidget {
-  const AspectRatioVideo(this.controller, {Key? key}) : super(key: key);
+  const AspectRatioVideo(this.controller, {super.key});
 
   final VideoPlayerController? controller;
 

--- a/packages/image_picker/example/pubspec.yaml
+++ b/packages/image_picker/example/pubspec.yaml
@@ -3,8 +3,8 @@ description: Demonstrates how to use the image_picker_tizen plugin.
 publish_to: "none"
 
 environment:
-  sdk: ">=2.17.0 <4.0.0"
-  flutter: ">=3.0.0"
+  sdk: ">=2.18.0 <4.0.0"
+  flutter: ">=3.3.0"
 
 dependencies:
   flutter:

--- a/packages/image_picker/example/pubspec.yaml
+++ b/packages/image_picker/example/pubspec.yaml
@@ -2,6 +2,10 @@ name: image_picker_tizen_example
 description: Demonstrates how to use the image_picker_tizen plugin.
 publish_to: "none"
 
+environment:
+  sdk: ">=2.17.0 <4.0.0"
+  flutter: ">=3.0.0"
+
 dependencies:
   flutter:
     sdk: flutter
@@ -22,7 +26,3 @@ dev_dependencies:
 
 flutter:
   uses-material-design: true
-
-environment:
-  sdk: ">=2.12.0 <3.0.0"
-  flutter: ">=2.0.0"

--- a/packages/image_picker/pubspec.yaml
+++ b/packages/image_picker/pubspec.yaml
@@ -5,8 +5,8 @@ repository: https://github.com/flutter-tizen/plugins/tree/master/packages/image_
 version: 2.2.0
 
 environment:
-  sdk: ">=2.17.0 <4.0.0"
-  flutter: ">=3.0.0"
+  sdk: ">=2.18.0 <4.0.0"
+  flutter: ">=3.3.0"
 
 flutter:
   plugin:

--- a/packages/image_picker/pubspec.yaml
+++ b/packages/image_picker/pubspec.yaml
@@ -1,9 +1,12 @@
 name: image_picker_tizen
 description: Tizen implementation of the image_picker plugin.
-  Used for picking images from the image library.
 homepage: https://github.com/flutter-tizen/plugins
 repository: https://github.com/flutter-tizen/plugins/tree/master/packages/image_picker
 version: 2.2.0
+
+environment:
+  sdk: ">=2.17.0 <4.0.0"
+  flutter: ">=3.0.0"
 
 flutter:
   plugin:
@@ -17,7 +20,3 @@ dependencies:
   flutter:
     sdk: flutter
   image_picker_platform_interface: ^2.6.2
-
-environment:
-  sdk: ">=2.12.0 <3.0.0"
-  flutter: ">=2.0.0"

--- a/packages/integration_test/CHANGELOG.md
+++ b/packages/integration_test/CHANGELOG.md
@@ -1,3 +1,7 @@
+## NEXT
+
+* Increase the minimum Flutter version to 3.3.
+
 ## 2.0.1
 
 * Change the project type to `staticLib`.

--- a/packages/integration_test/example/lib/main.dart
+++ b/packages/integration_test/example/lib/main.dart
@@ -10,7 +10,7 @@ import 'package:flutter/material.dart';
 void main() => runApp(const MyApp());
 
 class MyApp extends StatefulWidget {
-  const MyApp({Key? key}) : super(key: key);
+  const MyApp({super.key});
 
   @override
   State<MyApp> createState() => _MyAppState();

--- a/packages/integration_test/example/pubspec.yaml
+++ b/packages/integration_test/example/pubspec.yaml
@@ -2,6 +2,10 @@ name: integration_test_example
 description: Demonstrates how to use the integration_test_tizen plugin.
 publish_to: "none"
 
+environment:
+  sdk: ">=2.17.0 <4.0.0"
+  flutter: ">=3.0.0"
+
 dependencies:
   flutter:
     sdk: flutter
@@ -19,7 +23,3 @@ dev_dependencies:
 
 flutter:
   uses-material-design: true
-
-environment:
-  sdk: ">=2.12.0 <3.0.0"
-  flutter: ">=2.0.0"

--- a/packages/integration_test/example/pubspec.yaml
+++ b/packages/integration_test/example/pubspec.yaml
@@ -3,8 +3,8 @@ description: Demonstrates how to use the integration_test_tizen plugin.
 publish_to: "none"
 
 environment:
-  sdk: ">=2.17.0 <4.0.0"
-  flutter: ">=3.0.0"
+  sdk: ">=2.18.0 <4.0.0"
+  flutter: ">=3.3.0"
 
 dependencies:
   flutter:

--- a/packages/integration_test/pubspec.yaml
+++ b/packages/integration_test/pubspec.yaml
@@ -1,8 +1,12 @@
 name: integration_test_tizen
-description: Tizen implementation of the integration_test plugin
+description: Tizen implementation of the integration_test plugin.
 homepage: https://github.com/flutter-tizen/plugins
 repository: https://github.com/flutter-tizen/plugins/tree/master/packages/integration_test
 version: 2.0.1
+
+environment:
+  sdk: ">=2.17.0 <4.0.0"
+  flutter: ">=3.0.0"
 
 flutter:
   plugin:
@@ -14,7 +18,3 @@ flutter:
 dependencies:
   flutter:
     sdk: flutter
-
-environment:
-  sdk: ">=2.12.0 <3.0.0"
-  flutter: ">=2.0.0"

--- a/packages/integration_test/pubspec.yaml
+++ b/packages/integration_test/pubspec.yaml
@@ -5,8 +5,8 @@ repository: https://github.com/flutter-tizen/plugins/tree/master/packages/integr
 version: 2.0.1
 
 environment:
-  sdk: ">=2.17.0 <4.0.0"
-  flutter: ">=3.0.0"
+  sdk: ">=2.18.0 <4.0.0"
+  flutter: ">=3.3.0"
 
 flutter:
   plugin:

--- a/packages/messageport/CHANGELOG.md
+++ b/packages/messageport/CHANGELOG.md
@@ -1,3 +1,7 @@
+## NEXT
+
+* Increase the minimum Flutter version to 3.3.
+
 ## 0.3.1
 
 * Fix unexpected `PlatformException` when sending a null message.

--- a/packages/messageport/example/lib/main.dart
+++ b/packages/messageport/example/lib/main.dart
@@ -16,7 +16,7 @@ void main() {
 }
 
 class MyApp extends StatefulWidget {
-  const MyApp({Key? key}) : super(key: key);
+  const MyApp({super.key});
 
   @override
   State<MyApp> createState() => _MyAppState();

--- a/packages/messageport/example/pubspec.yaml
+++ b/packages/messageport/example/pubspec.yaml
@@ -3,8 +3,8 @@ description: Demonstrates how to use the messageport_tizen plugin.
 publish_to: "none"
 
 environment:
-  sdk: ">=2.17.0 <4.0.0"
-  flutter: ">=3.0.0"
+  sdk: ">=2.18.0 <4.0.0"
+  flutter: ">=3.3.0"
 
 dependencies:
   flutter:

--- a/packages/messageport/example/pubspec.yaml
+++ b/packages/messageport/example/pubspec.yaml
@@ -3,7 +3,8 @@ description: Demonstrates how to use the messageport_tizen plugin.
 publish_to: "none"
 
 environment:
-  sdk: ">=2.12.0 <3.0.0"
+  sdk: ">=2.17.0 <4.0.0"
+  flutter: ">=3.0.0"
 
 dependencies:
   flutter:

--- a/packages/messageport/pubspec.yaml
+++ b/packages/messageport/pubspec.yaml
@@ -5,8 +5,8 @@ repository: https://github.com/flutter-tizen/plugins/tree/master/packages/messag
 version: 0.3.1
 
 environment:
-  sdk: ">=2.12.0 <3.0.0"
-  flutter: ">=2.0.0"
+  sdk: ">=2.17.0 <4.0.0"
+  flutter: ">=3.0.0"
 
 flutter:
   plugin:

--- a/packages/messageport/pubspec.yaml
+++ b/packages/messageport/pubspec.yaml
@@ -5,8 +5,8 @@ repository: https://github.com/flutter-tizen/plugins/tree/master/packages/messag
 version: 0.3.1
 
 environment:
-  sdk: ">=2.17.0 <4.0.0"
-  flutter: ">=3.0.0"
+  sdk: ">=2.18.0 <4.0.0"
+  flutter: ">=3.3.0"
 
 flutter:
   plugin:

--- a/packages/network_info_plus/CHANGELOG.md
+++ b/packages/network_info_plus/CHANGELOG.md
@@ -1,3 +1,7 @@
+## NEXT
+
+* Increase the minimum Flutter version to 3.3.
+
 ## 1.1.3
 
 * Update network_info_plus to 2.3.2.

--- a/packages/network_info_plus/example/integration_test/network_info_plus_test.dart
+++ b/packages/network_info_plus/example/integration_test/network_info_plus_test.dart
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart=2.9
-
 import 'package:flutter_test/flutter_test.dart';
 import 'package:integration_test/integration_test.dart';
 import 'package:network_info_plus/network_info_plus.dart';
@@ -12,7 +10,7 @@ void main() {
   IntegrationTestWidgetsFlutterBinding.ensureInitialized();
 
   group('NetworkInfo test driver', () {
-    NetworkInfo _networkInfo;
+    late NetworkInfo _networkInfo;
 
     setUpAll(() async {
       _networkInfo = NetworkInfo();

--- a/packages/network_info_plus/example/pubspec.yaml
+++ b/packages/network_info_plus/example/pubspec.yaml
@@ -2,6 +2,10 @@ name: network_info_plus_example
 description: Demonstrates how to use the network_info_plus_tizen plugin.
 publish_to: "none"
 
+environment:
+  sdk: ">=2.17.0 <4.0.0"
+  flutter: ">=3.0.0"
+
 dependencies:
   flutter:
     sdk: flutter
@@ -20,7 +24,3 @@ dev_dependencies:
 
 flutter:
   uses-material-design: true
-
-environment:
-  sdk: ">=2.12.0 <3.0.0"
-  flutter: ">=2.2.0"

--- a/packages/network_info_plus/example/pubspec.yaml
+++ b/packages/network_info_plus/example/pubspec.yaml
@@ -3,8 +3,8 @@ description: Demonstrates how to use the network_info_plus_tizen plugin.
 publish_to: "none"
 
 environment:
-  sdk: ">=2.17.0 <4.0.0"
-  flutter: ">=3.0.0"
+  sdk: ">=2.18.0 <4.0.0"
+  flutter: ">=3.3.0"
 
 dependencies:
   flutter:

--- a/packages/network_info_plus/pubspec.yaml
+++ b/packages/network_info_plus/pubspec.yaml
@@ -4,6 +4,10 @@ homepage: https://github.com/flutter-tizen/plugins
 repository: https://github.com/flutter-tizen/plugins/tree/master/packages/network_info_plus
 version: 1.1.3
 
+environment:
+  sdk: ">=2.17.0 <4.0.0"
+  flutter: ">=3.0.0"
+
 flutter:
   plugin:
     platforms:
@@ -18,7 +22,3 @@ dependencies:
 
 dev_dependencies:
   flutter_lints: ^1.0.4
-
-environment:
-  sdk: ">=2.12.0 <3.0.0"
-  flutter: ">=2.0.0"

--- a/packages/network_info_plus/pubspec.yaml
+++ b/packages/network_info_plus/pubspec.yaml
@@ -5,8 +5,8 @@ repository: https://github.com/flutter-tizen/plugins/tree/master/packages/networ
 version: 1.1.3
 
 environment:
-  sdk: ">=2.17.0 <4.0.0"
-  flutter: ">=3.0.0"
+  sdk: ">=2.18.0 <4.0.0"
+  flutter: ">=3.3.0"
 
 flutter:
   plugin:

--- a/packages/package_info_plus/CHANGELOG.md
+++ b/packages/package_info_plus/CHANGELOG.md
@@ -1,3 +1,7 @@
+## NEXT
+
+* Increase the minimum Flutter version to 3.3.
+
 ## 1.0.2
 
 * Update package_info_plus to 1.3.1.

--- a/packages/package_info_plus/example/pubspec.yaml
+++ b/packages/package_info_plus/example/pubspec.yaml
@@ -4,8 +4,8 @@ version: 1.2.3+4
 publish_to: "none"
 
 environment:
-  sdk: ">=2.17.0 <4.0.0"
-  flutter: ">=3.0.0"
+  sdk: ">=2.18.0 <4.0.0"
+  flutter: ">=3.3.0"
 
 dependencies:
   flutter:

--- a/packages/package_info_plus/example/pubspec.yaml
+++ b/packages/package_info_plus/example/pubspec.yaml
@@ -3,6 +3,10 @@ description: Demonstrates how to use the package_info_plus_tizen plugin.
 version: 1.2.3+4
 publish_to: "none"
 
+environment:
+  sdk: ">=2.17.0 <4.0.0"
+  flutter: ">=3.0.0"
+
 dependencies:
   flutter:
     sdk: flutter
@@ -23,7 +27,3 @@ dev_dependencies:
 
 flutter:
   uses-material-design: true
-
-environment:
-  sdk: ">=2.12.0 <3.0.0"
-  flutter: ">=2.0.0"

--- a/packages/package_info_plus/pubspec.yaml
+++ b/packages/package_info_plus/pubspec.yaml
@@ -5,8 +5,8 @@ repository: https://github.com/flutter-tizen/plugins/tree/master/packages/packag
 version: 1.0.2
 
 environment:
-  sdk: ">=2.17.0 <4.0.0"
-  flutter: ">=3.0.0"
+  sdk: ">=2.18.0 <4.0.0"
+  flutter: ">=3.3.0"
 
 flutter:
   plugin:

--- a/packages/package_info_plus/pubspec.yaml
+++ b/packages/package_info_plus/pubspec.yaml
@@ -1,8 +1,12 @@
 name: package_info_plus_tizen
-description: Tizen implementation of the package_info_plus plugin
+description: Tizen implementation of the package_info_plus plugin.
 homepage: https://github.com/flutter-tizen/plugins
 repository: https://github.com/flutter-tizen/plugins/tree/master/packages/package_info_plus
 version: 1.0.2
+
+environment:
+  sdk: ">=2.17.0 <4.0.0"
+  flutter: ">=3.0.0"
 
 flutter:
   plugin:
@@ -18,7 +22,3 @@ dependencies:
 
 dev_dependencies:
   flutter_lints: ^1.0.4
-
-environment:
-  sdk: ">=2.12.0 <3.0.0"
-  flutter: ">=2.0.0"

--- a/packages/path_provider/CHANGELOG.md
+++ b/packages/path_provider/CHANGELOG.md
@@ -1,3 +1,7 @@
+## NEXT
+
+* Increase the minimum Flutter version to 3.3.
+
 ## 2.1.0
 
 * Migrate FFI implementation to tizen_interop.

--- a/packages/path_provider/example/lib/main.dart
+++ b/packages/path_provider/example/lib/main.dart
@@ -14,7 +14,7 @@ void main() {
 }
 
 class MyApp extends StatelessWidget {
-  const MyApp({Key? key}) : super(key: key);
+  const MyApp({super.key});
 
   @override
   Widget build(BuildContext context) {
@@ -29,7 +29,7 @@ class MyApp extends StatelessWidget {
 }
 
 class MyHomePage extends StatefulWidget {
-  const MyHomePage({Key? key, required this.title}) : super(key: key);
+  const MyHomePage({super.key, required this.title});
   final String title;
 
   @override

--- a/packages/path_provider/example/pubspec.yaml
+++ b/packages/path_provider/example/pubspec.yaml
@@ -3,8 +3,8 @@ description: Demonstrates how to use the path_provider_tizen plugin.
 publish_to: "none"
 
 environment:
-  sdk: ">=2.17.0 <4.0.0"
-  flutter: ">=3.0.0"
+  sdk: ">=2.18.0 <4.0.0"
+  flutter: ">=3.3.0"
 
 dependencies:
   flutter:

--- a/packages/path_provider/example/pubspec.yaml
+++ b/packages/path_provider/example/pubspec.yaml
@@ -2,6 +2,10 @@ name: path_provider_tizen_example
 description: Demonstrates how to use the path_provider_tizen plugin.
 publish_to: "none"
 
+environment:
+  sdk: ">=2.17.0 <4.0.0"
+  flutter: ">=3.0.0"
+
 dependencies:
   flutter:
     sdk: flutter
@@ -21,7 +25,3 @@ dev_dependencies:
 
 flutter:
   uses-material-design: true
-
-environment:
-  sdk: ">=2.12.0 <3.0.0"
-  flutter: ">=2.0.0"

--- a/packages/path_provider/pubspec.yaml
+++ b/packages/path_provider/pubspec.yaml
@@ -1,8 +1,12 @@
 name: path_provider_tizen
-description: Tizen implementation of the path_provider plugin
+description: Tizen implementation of the path_provider plugin.
 homepage: https://github.com/flutter-tizen/plugins
 repository: https://github.com/flutter-tizen/plugins/tree/master/packages/path_provider
 version: 2.1.0
+
+environment:
+  sdk: ">=2.17.0 <4.0.0"
+  flutter: ">=3.0.0"
 
 flutter:
   plugin:
@@ -16,7 +20,3 @@ dependencies:
     sdk: flutter
   path_provider_platform_interface: ^2.0.1
   tizen_interop: ^0.2.0
-
-environment:
-  sdk: ">=2.17.0 <3.0.0"
-  flutter: ">=2.0.0"

--- a/packages/path_provider/pubspec.yaml
+++ b/packages/path_provider/pubspec.yaml
@@ -5,8 +5,8 @@ repository: https://github.com/flutter-tizen/plugins/tree/master/packages/path_p
 version: 2.1.0
 
 environment:
-  sdk: ">=2.17.0 <4.0.0"
-  flutter: ">=3.0.0"
+  sdk: ">=2.18.0 <4.0.0"
+  flutter: ">=3.3.0"
 
 flutter:
   plugin:

--- a/packages/permission_handler/CHANGELOG.md
+++ b/packages/permission_handler/CHANGELOG.md
@@ -1,3 +1,7 @@
+## NEXT
+
+* Replace effective_dart dependency with flutter_lints.
+
 ## 1.2.1
 
 * Code refactoring.

--- a/packages/permission_handler/CHANGELOG.md
+++ b/packages/permission_handler/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## NEXT
 
+* Increase the minimum Flutter version to 3.3.
 * Replace effective_dart dependency with flutter_lints.
 
 ## 1.2.1

--- a/packages/permission_handler/analysis_options.yaml
+++ b/packages/permission_handler/analysis_options.yaml
@@ -1,6 +1,4 @@
-# This file was copied from Baseflow/flutter-permission-handler/analysis_options.yaml.
-
-include: package:effective_dart/analysis_options.1.2.0.yaml
+include: package:flutter_lints/flutter.yaml
 
 linter:
   rules:

--- a/packages/permission_handler/example/lib/main.dart
+++ b/packages/permission_handler/example/lib/main.dart
@@ -61,7 +61,7 @@ class _PermissionHandlerWidgetState extends State<PermissionHandlerWidget> {
                       permission != Permission.criticalAlerts;
                 }
               })
-              .map((permission) => PermissionWidget(permission))
+              .map(PermissionWidget.new)
               .toList()),
     );
   }

--- a/packages/permission_handler/example/pubspec.yaml
+++ b/packages/permission_handler/example/pubspec.yaml
@@ -3,8 +3,8 @@ description: Demonstrates how to use the permission_handler_tizen plugin.
 publish_to: "none"
 
 environment:
-  sdk: ">=2.17.0 <4.0.0"
-  flutter: ">=3.0.0"
+  sdk: ">=2.18.0 <4.0.0"
+  flutter: ">=3.3.0"
 
 dependencies:
   baseflow_plugin_template: ^2.1.1

--- a/packages/permission_handler/example/pubspec.yaml
+++ b/packages/permission_handler/example/pubspec.yaml
@@ -2,6 +2,10 @@ name: permission_handler_example
 description: Demonstrates how to use the permission_handler_tizen plugin.
 publish_to: "none"
 
+environment:
+  sdk: ">=2.17.0 <4.0.0"
+  flutter: ">=3.0.0"
+
 dependencies:
   baseflow_plugin_template: ^2.1.1
   flutter:
@@ -22,7 +26,6 @@ dev_dependencies:
     sdk: flutter
   integration_test_tizen:
     path: ../../integration_test/
-  effective_dart: ^1.3.0
 
 flutter:
   uses-material-design: true
@@ -31,7 +34,3 @@ flutter:
     - packages/baseflow_plugin_template/poweredByBaseflow.png
     - packages/baseflow_plugin_template/assets/logo.png
     - packages/baseflow_plugin_template/assets/poweredByBaseflow.png
-
-environment:
-  sdk: ">=2.12.0 <3.0.0"
-  flutter: ">=2.0.0"

--- a/packages/permission_handler/pubspec.yaml
+++ b/packages/permission_handler/pubspec.yaml
@@ -1,8 +1,12 @@
 name: permission_handler_tizen
-description: Tizen implementation of the permission_handler plugin
+description: Tizen implementation of the permission_handler plugin.
 homepage: https://github.com/flutter-tizen/plugins
 repository: https://github.com/flutter-tizen/plugins/tree/master/packages/permission_handler
 version: 1.2.1
+
+environment:
+  sdk: ">=2.17.0 <4.0.0"
+  flutter: ">=3.0.0"
 
 flutter:
   plugin:
@@ -17,8 +21,4 @@ dependencies:
   permission_handler_platform_interface: ^3.7.0
 
 dev_dependencies:
-  effective_dart: ^1.3.0
-
-environment:
-  sdk: ">=2.12.0 <3.0.0"
-  flutter: ">=2.0.0"
+  flutter_lints: ^1.0.4

--- a/packages/permission_handler/pubspec.yaml
+++ b/packages/permission_handler/pubspec.yaml
@@ -5,8 +5,8 @@ repository: https://github.com/flutter-tizen/plugins/tree/master/packages/permis
 version: 1.2.1
 
 environment:
-  sdk: ">=2.17.0 <4.0.0"
-  flutter: ">=3.0.0"
+  sdk: ">=2.18.0 <4.0.0"
+  flutter: ">=3.3.0"
 
 flutter:
   plugin:

--- a/packages/sensors_plus/CHANGELOG.md
+++ b/packages/sensors_plus/CHANGELOG.md
@@ -1,3 +1,7 @@
+## NEXT
+
+* Increase the minimum Flutter version to 3.3.
+
 ## 1.1.1
 
 * Hold memory of StreamHandlerError's member to prevent crash.

--- a/packages/sensors_plus/example/integration_test/sensors_plus_test.dart
+++ b/packages/sensors_plus/example/integration_test/sensors_plus_test.dart
@@ -2,8 +2,6 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-// @dart=2.9
-
 import 'dart:async';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:sensors_plus/sensors_plus.dart';
@@ -15,7 +13,7 @@ void main() {
   testWidgets('Can subscript to accelerometerEvents and get non-null events',
       (WidgetTester tester) async {
     final completer = Completer<AccelerometerEvent>();
-    StreamSubscription<AccelerometerEvent> subscription;
+    late StreamSubscription<AccelerometerEvent> subscription;
     subscription = accelerometerEvents.listen((AccelerometerEvent event) {
       completer.complete(event);
       subscription.cancel();

--- a/packages/sensors_plus/example/pubspec.yaml
+++ b/packages/sensors_plus/example/pubspec.yaml
@@ -2,6 +2,10 @@ name: sensors_plus_example
 description: Demonstrates how to use the sensors_plus plugin.
 publish_to: "none"
 
+environment:
+  sdk: ">=2.17.0 <4.0.0"
+  flutter: ">=3.0.0"
+
 dependencies:
   flutter:
     sdk: flutter
@@ -20,7 +24,3 @@ dev_dependencies:
 
 flutter:
   uses-material-design: true
-
-environment:
-  sdk: ">=2.12.0 <3.0.0"
-  flutter: ">=2.0.0"

--- a/packages/sensors_plus/example/pubspec.yaml
+++ b/packages/sensors_plus/example/pubspec.yaml
@@ -3,8 +3,8 @@ description: Demonstrates how to use the sensors_plus plugin.
 publish_to: "none"
 
 environment:
-  sdk: ">=2.17.0 <4.0.0"
-  flutter: ">=3.0.0"
+  sdk: ">=2.18.0 <4.0.0"
+  flutter: ">=3.3.0"
 
 dependencies:
   flutter:

--- a/packages/sensors_plus/pubspec.yaml
+++ b/packages/sensors_plus/pubspec.yaml
@@ -1,8 +1,12 @@
 name: sensors_plus_tizen
-description: Tizen implementation of the sensors plugin
+description: Tizen implementation of the sensors plugin.
 homepage: https://github.com/flutter-tizen/plugins
 repository: https://github.com/flutter-tizen/plugins/tree/master/packages/sensors_plus
 version: 1.1.1
+
+environment:
+  sdk: ">=2.17.0 <4.0.0"
+  flutter: ">=3.0.0"
 
 flutter:
   plugin:
@@ -18,7 +22,3 @@ dependencies:
 
 dev_dependencies:
   flutter_lints: ^1.0.4
-
-environment:
-  sdk: ">=2.12.0 <3.0.0"
-  flutter: ">=2.0.0"

--- a/packages/sensors_plus/pubspec.yaml
+++ b/packages/sensors_plus/pubspec.yaml
@@ -5,8 +5,8 @@ repository: https://github.com/flutter-tizen/plugins/tree/master/packages/sensor
 version: 1.1.1
 
 environment:
-  sdk: ">=2.17.0 <4.0.0"
-  flutter: ">=3.0.0"
+  sdk: ">=2.18.0 <4.0.0"
+  flutter: ">=3.3.0"
 
 flutter:
   plugin:

--- a/packages/shared_preferences/CHANGELOG.md
+++ b/packages/shared_preferences/CHANGELOG.md
@@ -1,3 +1,7 @@
+## NEXT
+
+* Increase the minimum Flutter version to 3.3.
+
 ## 2.1.0
 
 * Migrate FFI implementation to tizen_interop.

--- a/packages/shared_preferences/example/lib/main.dart
+++ b/packages/shared_preferences/example/lib/main.dart
@@ -14,7 +14,7 @@ void main() {
 }
 
 class MyApp extends StatelessWidget {
-  const MyApp({Key? key}) : super(key: key);
+  const MyApp({super.key});
 
   @override
   Widget build(BuildContext context) {
@@ -26,7 +26,7 @@ class MyApp extends StatelessWidget {
 }
 
 class SharedPreferencesDemo extends StatefulWidget {
-  const SharedPreferencesDemo({Key? key}) : super(key: key);
+  const SharedPreferencesDemo({super.key});
 
   @override
   SharedPreferencesDemoState createState() => SharedPreferencesDemoState();

--- a/packages/shared_preferences/example/pubspec.yaml
+++ b/packages/shared_preferences/example/pubspec.yaml
@@ -2,6 +2,10 @@ name: shared_preferences_tizen_example
 description: Demonstrates how to use the shared_preferences_tizen plugin.
 publish_to: "none"
 
+environment:
+  sdk: ">=2.17.0 <4.0.0"
+  flutter: ">=3.0.0"
+
 dependencies:
   flutter:
     sdk: flutter
@@ -21,7 +25,3 @@ dev_dependencies:
 
 flutter:
   uses-material-design: true
-
-environment:
-  sdk: ">=2.12.0 <3.0.0"
-  flutter: ">=2.0.0"

--- a/packages/shared_preferences/example/pubspec.yaml
+++ b/packages/shared_preferences/example/pubspec.yaml
@@ -3,8 +3,8 @@ description: Demonstrates how to use the shared_preferences_tizen plugin.
 publish_to: "none"
 
 environment:
-  sdk: ">=2.17.0 <4.0.0"
-  flutter: ">=3.0.0"
+  sdk: ">=2.18.0 <4.0.0"
+  flutter: ">=3.3.0"
 
 dependencies:
   flutter:

--- a/packages/shared_preferences/pubspec.yaml
+++ b/packages/shared_preferences/pubspec.yaml
@@ -1,8 +1,12 @@
 name: shared_preferences_tizen
-description: Tizen implementation of the shared_preferences plugin
+description: Tizen implementation of the shared_preferences plugin.
 homepage: https://github.com/flutter-tizen/plugins
 repository: https://github.com/flutter-tizen/plugins/tree/master/packages/shared_preferences
 version: 2.1.0
+
+environment:
+  sdk: ">=2.17.0 <4.0.0"
+  flutter: ">=3.0.0"
 
 flutter:
   plugin:
@@ -16,7 +20,3 @@ dependencies:
     sdk: flutter
   shared_preferences_platform_interface: ^2.0.0
   tizen_interop: ^0.2.0
-
-environment:
-  sdk: ">=2.12.0 <3.0.0"
-  flutter: ">=2.0.0"

--- a/packages/shared_preferences/pubspec.yaml
+++ b/packages/shared_preferences/pubspec.yaml
@@ -5,8 +5,8 @@ repository: https://github.com/flutter-tizen/plugins/tree/master/packages/shared
 version: 2.1.0
 
 environment:
-  sdk: ">=2.17.0 <4.0.0"
-  flutter: ">=3.0.0"
+  sdk: ">=2.18.0 <4.0.0"
+  flutter: ">=3.3.0"
 
 flutter:
   plugin:

--- a/packages/sqflite/CHANGELOG.md
+++ b/packages/sqflite/CHANGELOG.md
@@ -1,3 +1,7 @@
+## NEXT
+
+* Increase the minimum Flutter version to 3.3.
+
 ## 0.1.2
 
 * Add sqflite dependency.

--- a/packages/sqflite/analysis_options.yaml
+++ b/packages/sqflite/analysis_options.yaml
@@ -11,10 +11,6 @@ include: package:flutter_lints/flutter.yaml
 # https://github.com/flutter/flutter/blob/master/analysis_options.yaml
 
 analyzer:
-  # Strong mode is sometimes harder to keep
-  strong-mode:
-    implicit-casts: false
-
   errors:
     # treat missing required parameters as a warning (not a hint)
     missing_required_param: warning
@@ -88,7 +84,6 @@ linter:
     - prefer_adjacent_string_concatenation
     - prefer_collection_literals
     - prefer_contains
-    - prefer_equal_for_default_values
     - slash_for_doc_comments
     - type_init_formals
     - unnecessary_const

--- a/packages/sqflite/example/lib/src/expect.dart
+++ b/packages/sqflite/example/lib/src/expect.dart
@@ -5,7 +5,6 @@
 import 'dart:async';
 
 import 'package:matcher/matcher.dart';
-import 'package:meta/meta.dart';
 
 /// An exception thrown when a test assertion fails.
 class TestFailure {
@@ -117,7 +116,6 @@ FutureOr _expect(actual, matcher,
 
 /// Convenience method for throwing a new [TestFailure] with the provided
 /// [message].
-@alwaysThrows
 void fail([String? message]) => throw TestFailure(message ?? 'should fail');
 
 /// index text helper.

--- a/packages/sqflite/example/pubspec.yaml
+++ b/packages/sqflite/example/pubspec.yaml
@@ -3,8 +3,8 @@ description: Demonstrates how to use the sqflite_tizen plugin.
 publish_to: "none"
 
 environment:
-  sdk: ">=2.17.0 <4.0.0"
-  flutter: ">=3.0.0"
+  sdk: ">=2.18.0 <4.0.0"
+  flutter: ">=3.3.0"
 
 dependencies:
   path: any

--- a/packages/sqflite/example/pubspec.yaml
+++ b/packages/sqflite/example/pubspec.yaml
@@ -3,7 +3,8 @@ description: Demonstrates how to use the sqflite_tizen plugin.
 publish_to: "none"
 
 environment:
-  sdk: ">=2.12.0 <3.0.0"
+  sdk: ">=2.17.0 <4.0.0"
+  flutter: ">=3.0.0"
 
 dependencies:
   path: any
@@ -30,7 +31,7 @@ dev_dependencies:
   integration_test_tizen:
     path: ../../integration_test/
   test:
-  process_run: '>=0.11.0+2'
+  process_run: ^0.12.0
 
 flutter:
   uses-material-design: true

--- a/packages/sqflite/pubspec.yaml
+++ b/packages/sqflite/pubspec.yaml
@@ -4,6 +4,10 @@ homepage: https://github.com/flutter-tizen/plugins
 repository: https://github.com/flutter-tizen/plugins/tree/master/packages/sqflite
 version: 0.1.2
 
+environment:
+  sdk: ">=2.17.0 <4.0.0"
+  flutter: ">=3.0.0"
+
 flutter:
   plugin:
     platforms:
@@ -19,7 +23,3 @@ dependencies:
 
 dev_dependencies:
   flutter_lints: ^1.0.4
-
-environment:
-  sdk: ">=2.12.0 <3.0.0"
-  flutter: ">=1.20.0"

--- a/packages/sqflite/pubspec.yaml
+++ b/packages/sqflite/pubspec.yaml
@@ -5,8 +5,8 @@ repository: https://github.com/flutter-tizen/plugins/tree/master/packages/sqflit
 version: 0.1.2
 
 environment:
-  sdk: ">=2.17.0 <4.0.0"
-  flutter: ">=3.0.0"
+  sdk: ">=2.18.0 <4.0.0"
+  flutter: ">=3.3.0"
 
 flutter:
   plugin:

--- a/packages/tizen_app_control/CHANGELOG.md
+++ b/packages/tizen_app_control/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## NEXT
 
+* Increase the minimum Flutter version to 3.3.
 * Update README.
 * Remove unused code and clean up.
 

--- a/packages/tizen_app_control/README.md
+++ b/packages/tizen_app_control/README.md
@@ -2,7 +2,7 @@
 
 [![pub package](https://img.shields.io/pub/v/tizen_app_control.svg)](https://pub.dev/packages/tizen_app_control)
 
-Tizen application control APIs. Used for launching and terminating applications on a Tizen device.
+Tizen application control APIs. Used to launch apps on a Tizen device.
 
 ## Usage
 

--- a/packages/tizen_app_control/example/lib/main.dart
+++ b/packages/tizen_app_control/example/lib/main.dart
@@ -54,7 +54,7 @@ void serviceMain() {
 /// The main UI app widget.
 class MyApp extends StatefulWidget {
   /// The main UI app widget.
-  const MyApp({Key? key}) : super(key: key);
+  const MyApp({super.key});
 
   @override
   State<MyApp> createState() => _MyAppState();

--- a/packages/tizen_app_control/example/pubspec.yaml
+++ b/packages/tizen_app_control/example/pubspec.yaml
@@ -2,6 +2,10 @@ name: tizen_app_control_example
 description: Demonstrates how to use the tizen_app_control plugin.
 publish_to: "none"
 
+environment:
+  sdk: ">=2.17.0 <4.0.0"
+  flutter: ">=3.0.0"
+
 dependencies:
   flutter:
     sdk: flutter
@@ -21,6 +25,3 @@ dev_dependencies:
     sdk: flutter
   integration_test_tizen:
     path: ../../integration_test/
-
-environment:
-  sdk: ">=2.13.0 <3.0.0"

--- a/packages/tizen_app_control/example/pubspec.yaml
+++ b/packages/tizen_app_control/example/pubspec.yaml
@@ -3,8 +3,8 @@ description: Demonstrates how to use the tizen_app_control plugin.
 publish_to: "none"
 
 environment:
-  sdk: ">=2.17.0 <4.0.0"
-  flutter: ">=3.0.0"
+  sdk: ">=2.18.0 <4.0.0"
+  flutter: ">=3.3.0"
 
 dependencies:
   flutter:

--- a/packages/tizen_app_control/lib/src/app_control.dart
+++ b/packages/tizen_app_control/lib/src/app_control.dart
@@ -221,10 +221,10 @@ class AppControl {
 
 /// Represents a received [AppControl] message.
 class ReceivedAppControl extends AppControl {
-  ReceivedAppControl._fromMap(Map<String, dynamic> map)
+  ReceivedAppControl._fromMap(super.map)
       : callerAppId = map['callerAppId'] as String?,
         shouldReply = map['shouldReply'] as bool,
-        super._fromMap(map);
+        super._fromMap();
 
   /// The caller application ID.
   final String? callerAppId;

--- a/packages/tizen_app_control/pubspec.yaml
+++ b/packages/tizen_app_control/pubspec.yaml
@@ -5,8 +5,8 @@ repository: https://github.com/flutter-tizen/plugins/tree/master/packages/tizen_
 version: 0.2.2
 
 environment:
-  sdk: ">=2.17.0 <4.0.0"
-  flutter: ">=3.0.0"
+  sdk: ">=2.18.0 <4.0.0"
+  flutter: ">=3.3.0"
 
 dependencies:
   ffi: ">=1.1.2 <3.0.0"

--- a/packages/tizen_app_control/pubspec.yaml
+++ b/packages/tizen_app_control/pubspec.yaml
@@ -1,15 +1,14 @@
 name: tizen_app_control
-description: Tizen application control APIs. Used for launching and terminating
-  applications on a Tizen device.
+description: Tizen application control APIs. Used to launch apps on a Tizen device.
 homepage: https://github.com/flutter-tizen/plugins
 repository: https://github.com/flutter-tizen/plugins/tree/master/packages/tizen_app_control
 version: 0.2.2
+
+environment:
+  sdk: ">=2.17.0 <4.0.0"
+  flutter: ">=3.0.0"
 
 dependencies:
   ffi: ">=1.1.2 <3.0.0"
   flutter:
     sdk: flutter
-
-environment:
-  sdk: ">=2.13.0 <3.0.0"
-  flutter: ">=2.2.0"

--- a/packages/tizen_app_manager/CHANGELOG.md
+++ b/packages/tizen_app_manager/CHANGELOG.md
@@ -1,3 +1,7 @@
+## NEXT
+
+* Increase the minimum Flutter version to 3.3.
+
 ## 0.2.2
 
 * Add threading to `AppManager.getInstalledApps` to prevent app freezing.

--- a/packages/tizen_app_manager/README.md
+++ b/packages/tizen_app_manager/README.md
@@ -2,7 +2,7 @@
 
  [![pub package](https://img.shields.io/pub/v/tizen_app_manager.svg)](https://pub.dev/packages/tizen_app_manager)
 
-Tizen application manager APIs. Used for getting app info and getting app running context on a Tizen device.
+Tizen application manager APIs. Used to get app info and app running context on a Tizen device.
 
 ## Usage
 

--- a/packages/tizen_app_manager/example/lib/main.dart
+++ b/packages/tizen_app_manager/example/lib/main.dart
@@ -26,7 +26,7 @@ void main() {
 }
 
 class MyApp extends StatelessWidget {
-  const MyApp({Key? key}) : super(key: key);
+  const MyApp({super.key});
 
   @override
   Widget build(BuildContext context) {
@@ -39,7 +39,7 @@ class MyApp extends StatelessWidget {
 }
 
 class MyHomePage extends StatefulWidget {
-  const MyHomePage({Key? key}) : super(key: key);
+  const MyHomePage({super.key});
 
   @override
   State<MyHomePage> createState() => _MyHomePageState();
@@ -75,7 +75,7 @@ class _MyHomePageState extends State<MyHomePage> {
 }
 
 class _CurrentAppScreen extends StatefulWidget {
-  const _CurrentAppScreen({Key? key}) : super(key: key);
+  const _CurrentAppScreen();
 
   @override
   State<_CurrentAppScreen> createState() => _CurrentAppScreenState();
@@ -124,7 +124,7 @@ class _CurrentAppScreenState extends State<_CurrentAppScreen> {
 }
 
 class _AppListScreen extends StatefulWidget {
-  const _AppListScreen({Key? key}) : super(key: key);
+  const _AppListScreen();
 
   @override
   State<_AppListScreen> createState() => _AppListScreenState();
@@ -189,7 +189,7 @@ class _AppEvent {
 }
 
 class _AppEventsScreen extends StatefulWidget {
-  const _AppEventsScreen({Key? key}) : super(key: key);
+  const _AppEventsScreen();
 
   @override
   State<_AppEventsScreen> createState() => _AppEventsScreenState();

--- a/packages/tizen_app_manager/example/pubspec.yaml
+++ b/packages/tizen_app_manager/example/pubspec.yaml
@@ -3,8 +3,8 @@ description: Demonstrates how to use the tizen_app_manager plugin.
 publish_to: "none"
 
 environment:
-  sdk: ">=2.17.0 <4.0.0"
-  flutter: ">=3.0.0"
+  sdk: ">=2.18.0 <4.0.0"
+  flutter: ">=3.3.0"
 
 dependencies:
   device_info_plus_tizen:

--- a/packages/tizen_app_manager/example/pubspec.yaml
+++ b/packages/tizen_app_manager/example/pubspec.yaml
@@ -1,9 +1,10 @@
 name: tizen_app_manager_example
 description: Demonstrates how to use the tizen_app_manager plugin.
-publish_to: 'none' 
+publish_to: "none"
 
 environment:
-  sdk: ">=2.14.1 <3.0.0"
+  sdk: ">=2.17.0 <4.0.0"
+  flutter: ">=3.0.0"
 
 dependencies:
   device_info_plus_tizen:

--- a/packages/tizen_app_manager/pubspec.yaml
+++ b/packages/tizen_app_manager/pubspec.yaml
@@ -5,8 +5,8 @@ repository: https://github.com/flutter-tizen/plugins/tree/master/packages/tizen_
 version: 0.2.2
 
 environment:
-  sdk: ">=2.17.0 <4.0.0"
-  flutter: ">=3.0.0"
+  sdk: ">=2.18.0 <4.0.0"
+  flutter: ">=3.3.0"
 
 dependencies:
   ffi: ^2.0.1

--- a/packages/tizen_app_manager/pubspec.yaml
+++ b/packages/tizen_app_manager/pubspec.yaml
@@ -1,12 +1,12 @@
 name: tizen_app_manager
-description: Tizen application manager APIs. Used for getting app info and getting app running context on a Tizen device.
+description: Tizen application manager APIs. Used to get app info and app running context on a Tizen device.
 homepage: https://github.com/flutter-tizen/plugins
 repository: https://github.com/flutter-tizen/plugins/tree/master/packages/tizen_app_manager
 version: 0.2.2
 
 environment:
-  sdk: ">=2.15.1 <3.0.0"
-  flutter: ">=2.5.0"
+  sdk: ">=2.17.0 <4.0.0"
+  flutter: ">=3.0.0"
 
 dependencies:
   ffi: ^2.0.1

--- a/packages/tizen_audio_manager/CHANGELOG.md
+++ b/packages/tizen_audio_manager/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## NEXT
 
-* Remove unused flutter_lints dependency.
+* Increase the minimum Flutter version to 3.3.
 
 ## 0.1.1
 

--- a/packages/tizen_audio_manager/CHANGELOG.md
+++ b/packages/tizen_audio_manager/CHANGELOG.md
@@ -1,3 +1,7 @@
+## NEXT
+
+* Remove unused flutter_lints dependency.
+
 ## 0.1.1
 
 * Code refactoring.

--- a/packages/tizen_audio_manager/example/lib/main.dart
+++ b/packages/tizen_audio_manager/example/lib/main.dart
@@ -14,7 +14,7 @@ void main() {
 }
 
 class MyApp extends StatelessWidget {
-  const MyApp({Key? key}) : super(key: key);
+  const MyApp({super.key});
 
   @override
   Widget build(BuildContext context) {
@@ -27,7 +27,7 @@ class MyApp extends StatelessWidget {
 }
 
 class VolumeControlScreen extends StatefulWidget {
-  const VolumeControlScreen({Key? key}) : super(key: key);
+  const VolumeControlScreen({super.key});
 
   @override
   State<StatefulWidget> createState() => _VolumeControlScreenState();

--- a/packages/tizen_audio_manager/example/pubspec.yaml
+++ b/packages/tizen_audio_manager/example/pubspec.yaml
@@ -1,10 +1,10 @@
 name: tizen_audio_manager_example
 description: Demonstrates how to use the tizen_audio_manager plugin.
-
-publish_to: 'none'
+publish_to: "none"
 
 environment:
-  sdk: ">=2.15.1 <3.0.0"
+  sdk: ">=2.17.0 <4.0.0"
+  flutter: ">=3.0.0"
 
 dependencies:
   flutter:
@@ -15,7 +15,6 @@ dependencies:
 dev_dependencies:
   flutter_driver:
     sdk: flutter
-  flutter_lints: ^1.0.4
   flutter_test:
     sdk: flutter
   integration_test:

--- a/packages/tizen_audio_manager/example/pubspec.yaml
+++ b/packages/tizen_audio_manager/example/pubspec.yaml
@@ -3,8 +3,8 @@ description: Demonstrates how to use the tizen_audio_manager plugin.
 publish_to: "none"
 
 environment:
-  sdk: ">=2.17.0 <4.0.0"
-  flutter: ">=3.0.0"
+  sdk: ">=2.18.0 <4.0.0"
+  flutter: ">=3.3.0"
 
 dependencies:
   flutter:

--- a/packages/tizen_audio_manager/pubspec.yaml
+++ b/packages/tizen_audio_manager/pubspec.yaml
@@ -5,8 +5,8 @@ repository: https://github.com/flutter-tizen/plugins/tree/master/packages/tizen_
 version: 0.1.1
 
 environment:
-  sdk: ">=2.17.0 <4.0.0"
-  flutter: ">=3.0.0"
+  sdk: ">=2.18.0 <4.0.0"
+  flutter: ">=3.3.0"
 
 dependencies:
   flutter:

--- a/packages/tizen_audio_manager/pubspec.yaml
+++ b/packages/tizen_audio_manager/pubspec.yaml
@@ -5,15 +5,12 @@ repository: https://github.com/flutter-tizen/plugins/tree/master/packages/tizen_
 version: 0.1.1
 
 environment:
-  sdk: ">=2.15.1 <3.0.0"
-  flutter: ">=2.5.0"
+  sdk: ">=2.17.0 <4.0.0"
+  flutter: ">=3.0.0"
 
 dependencies:
   flutter:
     sdk: flutter
-
-dev_dependencies:
-  flutter_lints: ^1.0.0
 
 flutter:
   plugin:

--- a/packages/tizen_bundle/CHANGELOG.md
+++ b/packages/tizen_bundle/CHANGELOG.md
@@ -1,3 +1,7 @@
+## NEXT
+
+* Increase the minimum Flutter version to 3.3.
+
 ## 0.1.1
 
 * General cleanups.

--- a/packages/tizen_bundle/example/pubspec.yaml
+++ b/packages/tizen_bundle/example/pubspec.yaml
@@ -3,8 +3,8 @@ description: Demonstrates how to use the tizen_bundle plugin.
 publish_to: "none"
 
 environment:
-  sdk: ">=2.17.0 <4.0.0"
-  flutter: ">=3.0.0"
+  sdk: ">=2.18.0 <4.0.0"
+  flutter: ">=3.3.0"
 
 dependencies:
   flutter:

--- a/packages/tizen_bundle/example/pubspec.yaml
+++ b/packages/tizen_bundle/example/pubspec.yaml
@@ -1,10 +1,10 @@
 name: tizen_bundle_example
 description: Demonstrates how to use the tizen_bundle plugin.
-publish_to: 'none'
+publish_to: "none"
 
 environment:
-  sdk: ">=2.17.0 <3.0.0"
-  flutter: ">=2.0.0"
+  sdk: ">=2.17.0 <4.0.0"
+  flutter: ">=3.0.0"
 
 dependencies:
   flutter:

--- a/packages/tizen_bundle/pubspec.yaml
+++ b/packages/tizen_bundle/pubspec.yaml
@@ -5,8 +5,8 @@ repository: https://github.com/flutter-tizen/plugins/tree/master/packages/tizen_
 version: 0.1.1
 
 environment:
-  sdk: ">=2.17.0 <4.0.0"
-  flutter: ">=3.0.0"
+  sdk: ">=2.18.0 <4.0.0"
+  flutter: ">=3.3.0"
 
 dependencies:
   ffi: ^2.0.1

--- a/packages/tizen_bundle/pubspec.yaml
+++ b/packages/tizen_bundle/pubspec.yaml
@@ -1,12 +1,12 @@
 name: tizen_bundle
-description: Tizen bundle APIs.
+description: Tizen data bundle APIs.
 homepage: https://github.com/flutter-tizen/plugins
 repository: https://github.com/flutter-tizen/plugins/tree/master/packages/tizen_bundle
 version: 0.1.1
 
 environment:
-  sdk: ">=2.17.0 <3.0.0"
-  flutter: ">=2.5.0"
+  sdk: ">=2.17.0 <4.0.0"
+  flutter: ">=3.0.0"
 
 dependencies:
   ffi: ^2.0.1

--- a/packages/tizen_log/CHANGELOG.md
+++ b/packages/tizen_log/CHANGELOG.md
@@ -1,3 +1,7 @@
+## NEXT
+
+* Increase the minimum Flutter version to 3.3.
+
 ## 0.1.2
 
 * Bump ffi dependency.

--- a/packages/tizen_log/example/lib/main.dart
+++ b/packages/tizen_log/example/lib/main.dart
@@ -12,7 +12,7 @@ void main() {
 }
 
 class MyApp extends StatelessWidget {
-  const MyApp({Key? key}) : super(key: key);
+  const MyApp({super.key});
 
   static const String _logTag = 'tizen_log_example';
 

--- a/packages/tizen_log/example/pubspec.yaml
+++ b/packages/tizen_log/example/pubspec.yaml
@@ -3,7 +3,8 @@ description: Demonstrates how to use the tizen_log plugin.
 publish_to: "none"
 
 environment:
-  sdk: ">=2.15.1 <3.0.0"
+  sdk: ">=2.17.0 <4.0.0"
+  flutter: ">=3.0.0"
 
 dependencies:
   flutter:

--- a/packages/tizen_log/example/pubspec.yaml
+++ b/packages/tizen_log/example/pubspec.yaml
@@ -3,8 +3,8 @@ description: Demonstrates how to use the tizen_log plugin.
 publish_to: "none"
 
 environment:
-  sdk: ">=2.17.0 <4.0.0"
-  flutter: ">=3.0.0"
+  sdk: ">=2.18.0 <4.0.0"
+  flutter: ">=3.3.0"
 
 dependencies:
   flutter:

--- a/packages/tizen_log/pubspec.yaml
+++ b/packages/tizen_log/pubspec.yaml
@@ -5,7 +5,8 @@ repository: https://github.com/flutter-tizen/plugins/tree/master/packages/tizen_
 version: 0.1.2
 
 environment:
-  sdk: ">=2.15.1 <3.0.0"
+  sdk: ">=2.17.0 <4.0.0"
+  flutter: ">=3.0.0"
 
 dependencies:
   ffi: ">=1.1.2 <3.0.0"

--- a/packages/tizen_log/pubspec.yaml
+++ b/packages/tizen_log/pubspec.yaml
@@ -5,8 +5,8 @@ repository: https://github.com/flutter-tizen/plugins/tree/master/packages/tizen_
 version: 0.1.2
 
 environment:
-  sdk: ">=2.17.0 <4.0.0"
-  flutter: ">=3.0.0"
+  sdk: ">=2.18.0 <4.0.0"
+  flutter: ">=3.3.0"
 
 dependencies:
   ffi: ">=1.1.2 <3.0.0"

--- a/packages/tizen_notification/CHANGELOG.md
+++ b/packages/tizen_notification/CHANGELOG.md
@@ -1,3 +1,7 @@
+## NEXT
+
+* Increase the minimum Flutter version to 3.3.
+
 ## 0.2.0
 
 * Clean up the API.

--- a/packages/tizen_notification/example/lib/main.dart
+++ b/packages/tizen_notification/example/lib/main.dart
@@ -12,7 +12,7 @@ void main() {
 }
 
 class MyApp extends StatelessWidget {
-  MyApp({Key? key}) : super(key: key);
+  MyApp({super.key});
 
   final TizenNotificationPlugin _tizenNotificationPlugin =
       TizenNotificationPlugin();

--- a/packages/tizen_notification/example/pubspec.yaml
+++ b/packages/tizen_notification/example/pubspec.yaml
@@ -3,8 +3,8 @@ description: Demonstrates how to use the tizen_notification plugin.
 publish_to: "none"
 
 environment:
-  sdk: ">=2.17.0 <4.0.0"
-  flutter: ">=3.0.0"
+  sdk: ">=2.18.0 <4.0.0"
+  flutter: ">=3.3.0"
 
 dependencies:
   flutter:

--- a/packages/tizen_notification/example/pubspec.yaml
+++ b/packages/tizen_notification/example/pubspec.yaml
@@ -3,8 +3,8 @@ description: Demonstrates how to use the tizen_notification plugin.
 publish_to: "none"
 
 environment:
-  sdk: ">=2.12.0 <3.0.0"
-  flutter: ">=2.0.0"
+  sdk: ">=2.17.0 <4.0.0"
+  flutter: ">=3.0.0"
 
 dependencies:
   flutter:

--- a/packages/tizen_notification/pubspec.yaml
+++ b/packages/tizen_notification/pubspec.yaml
@@ -5,8 +5,8 @@ repository: https://github.com/flutter-tizen/plugins/tree/master/packages/tizen_
 version: 0.2.0
 
 environment:
-  sdk: ">=2.12.0 <3.0.0"
-  flutter: ">=2.0.0"
+  sdk: ">=2.17.0 <4.0.0"
+  flutter: ">=3.0.0"
 
 dependencies:
   flutter:

--- a/packages/tizen_notification/pubspec.yaml
+++ b/packages/tizen_notification/pubspec.yaml
@@ -5,8 +5,8 @@ repository: https://github.com/flutter-tizen/plugins/tree/master/packages/tizen_
 version: 0.2.0
 
 environment:
-  sdk: ">=2.17.0 <4.0.0"
-  flutter: ">=3.0.0"
+  sdk: ">=2.18.0 <4.0.0"
+  flutter: ">=3.3.0"
 
 dependencies:
   flutter:

--- a/packages/tizen_package_manager/CHANGELOG.md
+++ b/packages/tizen_package_manager/CHANGELOG.md
@@ -1,3 +1,7 @@
+## NEXT
+
+* Increase the minimum Flutter version to 3.3.
+
 ## 0.2.1
 
 * Add threading to `PackageManager.getPackagesInfo` to prevent app freezing.

--- a/packages/tizen_package_manager/README.md
+++ b/packages/tizen_package_manager/README.md
@@ -2,7 +2,7 @@
 
  [![pub package](https://img.shields.io/pub/v/tizen_package_manager.svg)](https://pub.dev/packages/tizen_package_manager)
 
-Tizen package manager APIs. Used for getting information of packages installed on a Tizen device.
+Tizen package manager APIs. Used to get information about packages installed on a Tizen device.
 
 ## Usage
 

--- a/packages/tizen_package_manager/example/lib/main.dart
+++ b/packages/tizen_package_manager/example/lib/main.dart
@@ -17,7 +17,7 @@ void main() {
 }
 
 class MyApp extends StatelessWidget {
-  const MyApp({Key? key}) : super(key: key);
+  const MyApp({super.key});
 
   @override
   Widget build(BuildContext context) {
@@ -30,7 +30,7 @@ class MyApp extends StatelessWidget {
 }
 
 class MyHomePage extends StatefulWidget {
-  const MyHomePage({Key? key}) : super(key: key);
+  const MyHomePage({super.key});
 
   @override
   State<MyHomePage> createState() => _MyHomePageState();
@@ -66,7 +66,7 @@ class _MyHomePageState extends State<MyHomePage> {
 }
 
 class _CurrentPackageScreen extends StatefulWidget {
-  const _CurrentPackageScreen({Key? key}) : super(key: key);
+  const _CurrentPackageScreen();
 
   @override
   State<_CurrentPackageScreen> createState() => _CurrentPackageScreenState();
@@ -107,7 +107,7 @@ class _CurrentPackageScreenState extends State<_CurrentPackageScreen> {
 }
 
 class _PackageListScreen extends StatefulWidget {
-  const _PackageListScreen({Key? key}) : super(key: key);
+  const _PackageListScreen();
 
   @override
   State<_PackageListScreen> createState() => _PackageListScreenState();
@@ -158,7 +158,7 @@ class _PackageListScreenState extends State<_PackageListScreen>
 }
 
 class _PackageEventsScreen extends StatefulWidget {
-  const _PackageEventsScreen({Key? key}) : super(key: key);
+  const _PackageEventsScreen();
 
   @override
   State<_PackageEventsScreen> createState() => _PackageEventsScreenState();

--- a/packages/tizen_package_manager/example/pubspec.yaml
+++ b/packages/tizen_package_manager/example/pubspec.yaml
@@ -4,8 +4,8 @@ version: 1.0.0
 publish_to: "none"
 
 environment:
-  sdk: ">=2.17.0 <4.0.0"
-  flutter: ">=3.0.0"
+  sdk: ">=2.18.0 <4.0.0"
+  flutter: ">=3.3.0"
 
 dependencies:
   flutter:

--- a/packages/tizen_package_manager/example/pubspec.yaml
+++ b/packages/tizen_package_manager/example/pubspec.yaml
@@ -1,10 +1,11 @@
 name: tizen_package_manager_example
 description: Demonstrates how to use the tizen_package_manager plugin.
 version: 1.0.0
-publish_to: 'none' 
+publish_to: "none"
 
 environment:
-  sdk: ">=2.14.1 <3.0.0"
+  sdk: ">=2.17.0 <4.0.0"
+  flutter: ">=3.0.0"
 
 dependencies:
   flutter:

--- a/packages/tizen_package_manager/pubspec.yaml
+++ b/packages/tizen_package_manager/pubspec.yaml
@@ -1,12 +1,12 @@
 name: tizen_package_manager
-description: Tizen package manager APIs. Used for getting installed package info.
+description: Tizen package manager APIs. Used to get information about packages installed on a Tizen device.
 homepage: https://github.com/flutter-tizen/plugins
 repository: https://github.com/flutter-tizen/plugins/tree/master/packages/tizen_package_manager
 version: 0.2.1
 
 environment:
-  sdk: ">=2.15.1 <3.0.0"
-  flutter: ">=2.5.0"
+  sdk: ">=2.17.0 <4.0.0"
+  flutter: ">=3.0.0"
 
 dependencies:
   flutter:

--- a/packages/tizen_package_manager/pubspec.yaml
+++ b/packages/tizen_package_manager/pubspec.yaml
@@ -5,8 +5,8 @@ repository: https://github.com/flutter-tizen/plugins/tree/master/packages/tizen_
 version: 0.2.1
 
 environment:
-  sdk: ">=2.17.0 <4.0.0"
-  flutter: ">=3.0.0"
+  sdk: ">=2.18.0 <4.0.0"
+  flutter: ">=3.3.0"
 
 dependencies:
   flutter:

--- a/packages/tizen_rpc_port/CHANGELOG.md
+++ b/packages/tizen_rpc_port/CHANGELOG.md
@@ -1,3 +1,7 @@
+## NEXT
+
+* Increase the minimum Flutter version to 3.3.
+
 ## 0.1.2
 
 * Update the TIDLC version to 1.10.6.

--- a/packages/tizen_rpc_port/example/client/pubspec.yaml
+++ b/packages/tizen_rpc_port/example/client/pubspec.yaml
@@ -3,7 +3,8 @@ description: Demonstrates how to use the tizen_rpc_port client API.
 publish_to: "none"
 
 environment:
-  sdk: ">=2.17.0 <3.0.0"
+  sdk: ">=2.17.0 <4.0.0"
+  flutter: ">=3.0.0"
 
 dependencies:
   flutter:

--- a/packages/tizen_rpc_port/example/client/pubspec.yaml
+++ b/packages/tizen_rpc_port/example/client/pubspec.yaml
@@ -3,8 +3,8 @@ description: Demonstrates how to use the tizen_rpc_port client API.
 publish_to: "none"
 
 environment:
-  sdk: ">=2.17.0 <4.0.0"
-  flutter: ">=3.0.0"
+  sdk: ">=2.18.0 <4.0.0"
+  flutter: ">=3.3.0"
 
 dependencies:
   flutter:

--- a/packages/tizen_rpc_port/example/server/pubspec.yaml
+++ b/packages/tizen_rpc_port/example/server/pubspec.yaml
@@ -3,7 +3,8 @@ description: Demonstrates how to use the tizen_rpc_port server API.
 publish_to: "none"
 
 environment:
-  sdk: ">=2.17.0 <3.0.0"
+  sdk: ">=2.17.0 <4.0.0"
+  flutter: ">=3.0.0"
 
 dependencies:
   flutter:

--- a/packages/tizen_rpc_port/example/server/pubspec.yaml
+++ b/packages/tizen_rpc_port/example/server/pubspec.yaml
@@ -3,8 +3,8 @@ description: Demonstrates how to use the tizen_rpc_port server API.
 publish_to: "none"
 
 environment:
-  sdk: ">=2.17.0 <4.0.0"
-  flutter: ">=3.0.0"
+  sdk: ">=2.18.0 <4.0.0"
+  flutter: ">=3.3.0"
 
 dependencies:
   flutter:

--- a/packages/tizen_rpc_port/pubspec.yaml
+++ b/packages/tizen_rpc_port/pubspec.yaml
@@ -5,8 +5,8 @@ repository: https://github.com/flutter-tizen/plugins/tree/master/packages/tizen_
 version: 0.1.2
 
 environment:
-  sdk: ">=2.17.0 <3.0.0"
-  flutter: ">=2.5.0"
+  sdk: ">=2.17.0 <4.0.0"
+  flutter: ">=3.0.0"
 
 dependencies:
   ffi: ^2.0.1

--- a/packages/tizen_rpc_port/pubspec.yaml
+++ b/packages/tizen_rpc_port/pubspec.yaml
@@ -5,8 +5,8 @@ repository: https://github.com/flutter-tizen/plugins/tree/master/packages/tizen_
 version: 0.1.2
 
 environment:
-  sdk: ">=2.17.0 <4.0.0"
-  flutter: ">=3.0.0"
+  sdk: ">=2.18.0 <4.0.0"
+  flutter: ">=3.3.0"
 
 dependencies:
   ffi: ^2.0.1

--- a/packages/url_launcher/CHANGELOG.md
+++ b/packages/url_launcher/CHANGELOG.md
@@ -1,3 +1,7 @@
+## NEXT
+
+* Increase the minimum Flutter version to 3.3.
+
 ## 2.1.2
 
 * Update tizen_app_control to 0.2.2.

--- a/packages/url_launcher/example/lib/main.dart
+++ b/packages/url_launcher/example/lib/main.dart
@@ -15,7 +15,7 @@ void main() {
 }
 
 class MyApp extends StatelessWidget {
-  const MyApp({Key? key}) : super(key: key);
+  const MyApp({super.key});
 
   @override
   Widget build(BuildContext context) {
@@ -30,7 +30,7 @@ class MyApp extends StatelessWidget {
 }
 
 class MyHomePage extends StatefulWidget {
-  const MyHomePage({Key? key, required this.title}) : super(key: key);
+  const MyHomePage({super.key, required this.title});
   final String title;
 
   @override

--- a/packages/url_launcher/example/pubspec.yaml
+++ b/packages/url_launcher/example/pubspec.yaml
@@ -3,8 +3,8 @@ description: Demonstrates how to use the url_launcher_tizen plugin.
 publish_to: "none"
 
 environment:
-  sdk: ">=2.17.0 <4.0.0"
-  flutter: ">=3.0.0"
+  sdk: ">=2.18.0 <4.0.0"
+  flutter: ">=3.3.0"
 
 dependencies:
   flutter:

--- a/packages/url_launcher/example/pubspec.yaml
+++ b/packages/url_launcher/example/pubspec.yaml
@@ -2,6 +2,10 @@ name: url_launcher_example
 description: Demonstrates how to use the url_launcher_tizen plugin.
 publish_to: "none"
 
+environment:
+  sdk: ">=2.17.0 <4.0.0"
+  flutter: ">=3.0.0"
+
 dependencies:
   flutter:
     sdk: flutter
@@ -21,7 +25,3 @@ dev_dependencies:
 
 flutter:
   uses-material-design: true
-
-environment:
-  sdk: ">=2.13.0 <3.0.0"
-  flutter: ">=2.2.0"

--- a/packages/url_launcher/pubspec.yaml
+++ b/packages/url_launcher/pubspec.yaml
@@ -5,8 +5,8 @@ repository: https://github.com/flutter-tizen/plugins/tree/master/packages/url_la
 version: 2.1.2
 
 environment:
-  sdk: ">=2.17.0 <4.0.0"
-  flutter: ">=3.0.0"
+  sdk: ">=2.18.0 <4.0.0"
+  flutter: ">=3.3.0"
 
 flutter:
   plugin:

--- a/packages/url_launcher/pubspec.yaml
+++ b/packages/url_launcher/pubspec.yaml
@@ -4,6 +4,10 @@ homepage: https://github.com/flutter-tizen/plugins
 repository: https://github.com/flutter-tizen/plugins/tree/master/packages/url_launcher
 version: 2.1.2
 
+environment:
+  sdk: ">=2.17.0 <4.0.0"
+  flutter: ">=3.0.0"
+
 flutter:
   plugin:
     platforms:
@@ -15,7 +19,3 @@ dependencies:
     sdk: flutter
   tizen_app_control: ^0.2.2
   url_launcher_platform_interface: ^2.0.5
-
-environment:
-  sdk: ">=2.13.0 <3.0.0"
-  flutter: ">=2.2.0"

--- a/packages/video_player/CHANGELOG.md
+++ b/packages/video_player/CHANGELOG.md
@@ -1,3 +1,7 @@
+## NEXT
+
+* Increase the minimum Flutter version to 3.3.
+
 ## 2.4.5
 
 * Update README with supported devices information.

--- a/packages/video_player/example/lib/main.dart
+++ b/packages/video_player/example/lib/main.dart
@@ -106,7 +106,7 @@ class _ButterFlyAssetVideoInList extends StatelessWidget {
 
 /// A filler card to show the video in a list of scrolling contents.
 class _ExampleCard extends StatelessWidget {
-  const _ExampleCard({Key? key, required this.title}) : super(key: key);
+  const _ExampleCard({required this.title});
 
   final String title;
 
@@ -264,8 +264,7 @@ class _BumbleBeeRemoteVideoState extends State<_BumbleBeeRemoteVideo> {
 }
 
 class _ControlsOverlay extends StatelessWidget {
-  const _ControlsOverlay({Key? key, required this.controller})
-      : super(key: key);
+  const _ControlsOverlay({required this.controller});
 
   static const List<Duration> _exampleCaptionOffsets = <Duration>[
     Duration(seconds: -10),

--- a/packages/video_player/example/pubspec.yaml
+++ b/packages/video_player/example/pubspec.yaml
@@ -3,8 +3,8 @@ description: Demonstrates how to use the video_player_tizen plugin.
 publish_to: "none"
 
 environment:
-  sdk: ">=2.17.0 <4.0.0"
-  flutter: ">=3.0.0"
+  sdk: ">=2.18.0 <4.0.0"
+  flutter: ">=3.3.0"
 
 dependencies:
   flutter:

--- a/packages/video_player/example/pubspec.yaml
+++ b/packages/video_player/example/pubspec.yaml
@@ -2,6 +2,10 @@ name: video_player_example
 description: Demonstrates how to use the video_player_tizen plugin.
 publish_to: "none"
 
+environment:
+  sdk: ">=2.17.0 <4.0.0"
+  flutter: ">=3.0.0"
+
 dependencies:
   flutter:
     sdk: flutter
@@ -32,7 +36,3 @@ flutter:
     - assets/bumble_bee_captions.vtt
     - assets/Audio.mp3
   uses-material-design: true
-
-environment:
-  flutter: ">=2.0.0"
-  sdk: ">=2.12.0 <3.0.0"

--- a/packages/video_player/pubspec.yaml
+++ b/packages/video_player/pubspec.yaml
@@ -5,8 +5,8 @@ repository: https://github.com/flutter-tizen/plugins/tree/master/packages/video_
 version: 2.4.5
 
 environment:
-  sdk: ">=2.17.0 <4.0.0"
-  flutter: ">=3.0.0"
+  sdk: ">=2.18.0 <4.0.0"
+  flutter: ">=3.3.0"
 
 flutter:
   plugin:

--- a/packages/video_player/pubspec.yaml
+++ b/packages/video_player/pubspec.yaml
@@ -1,9 +1,12 @@
 name: video_player_tizen
-description: Flutter plugin for displaying inline video with other Flutter
-  widgets on Tizen.
+description: Tizen implementation of the video_player plugin.
 homepage: https://github.com/flutter-tizen/plugins
 repository: https://github.com/flutter-tizen/plugins/tree/master/packages/video_player
 version: 2.4.5
+
+environment:
+  sdk: ">=2.17.0 <4.0.0"
+  flutter: ">=3.0.0"
 
 flutter:
   plugin:
@@ -20,7 +23,3 @@ dependencies:
 
 dev_dependencies:
   pigeon: ^6.0.1
-
-environment:
-  flutter: ">=2.0.0"
-  sdk: ">=2.12.0<3.0.0"

--- a/packages/video_player_videohole/CHANGELOG.md
+++ b/packages/video_player_videohole/CHANGELOG.md
@@ -1,3 +1,7 @@
+## NEXT
+
+* Remove use of the deprecated API `WidgetsBinding.instance.window`.
+
 ## 0.1.1
 
 * Update pigeon to 10.0.0.

--- a/packages/video_player_videohole/CHANGELOG.md
+++ b/packages/video_player_videohole/CHANGELOG.md
@@ -1,7 +1,6 @@
 ## NEXT
 
 * Increase the minimum Flutter version to 3.3.
-* Remove use of deprecated `WidgetsBinding.instance.window`.
 
 ## 0.1.1
 

--- a/packages/video_player_videohole/CHANGELOG.md
+++ b/packages/video_player_videohole/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## NEXT
 
-* Remove use of the deprecated API `WidgetsBinding.instance.window`.
+* Increase the minimum Flutter version to 3.3.
+* Remove use of deprecated `WidgetsBinding.instance.window`.
 
 ## 0.1.1
 

--- a/packages/video_player_videohole/example/lib/main.dart
+++ b/packages/video_player_videohole/example/lib/main.dart
@@ -371,8 +371,7 @@ class _DrmRemoteVideoState2 extends State<_DrmRemoteVideo2> {
 }
 
 class _ControlsOverlay extends StatelessWidget {
-  const _ControlsOverlay({Key? key, required this.controller})
-      : super(key: key);
+  const _ControlsOverlay({required this.controller});
 
   static const List<Duration> _exampleCaptionOffsets = <Duration>[
     Duration(seconds: -10),

--- a/packages/video_player_videohole/example/pubspec.yaml
+++ b/packages/video_player_videohole/example/pubspec.yaml
@@ -2,6 +2,10 @@ name: video_player_videohole_example
 description: Demonstrates how to use the video_player_videohole plugin.
 publish_to: "none"
 
+environment:
+  sdk: ">=2.17.0 <4.0.0"
+  flutter: ">=3.0.0"
+
 dependencies:
   flutter:
     sdk: flutter
@@ -28,7 +32,3 @@ flutter:
     - assets/Butterfly-209.mp4
     - assets/Audio.mp3
   uses-material-design: true
-
-environment:
-  flutter: ">=3.0.0"
-  sdk: ">=2.12.0 <3.0.0"

--- a/packages/video_player_videohole/example/pubspec.yaml
+++ b/packages/video_player_videohole/example/pubspec.yaml
@@ -3,8 +3,8 @@ description: Demonstrates how to use the video_player_videohole plugin.
 publish_to: "none"
 
 environment:
-  sdk: ">=2.17.0 <4.0.0"
-  flutter: ">=3.0.0"
+  sdk: ">=2.18.0 <4.0.0"
+  flutter: ">=3.3.0"
 
 dependencies:
   flutter:

--- a/packages/video_player_videohole/lib/src/hole.dart
+++ b/packages/video_player_videohole/lib/src/hole.dart
@@ -10,7 +10,7 @@ import 'package:flutter/rendering.dart';
 /// A widget that creates a transparent hole in the Flutter UI.
 class Hole extends LeafRenderObjectWidget {
   /// Creates a [Hole].
-  const Hole({Key? key}) : super(key: key);
+  const Hole({super.key});
 
   @override
   RenderBox createRenderObject(BuildContext context) => _HoleBox();

--- a/packages/video_player_videohole/lib/video_player.dart
+++ b/packages/video_player_videohole/lib/video_player.dart
@@ -761,7 +761,7 @@ class _VideoAppLifeCycleObserver extends Object with WidgetsBindingObserver {
 /// Widget that displays the video controlled by [controller].
 class VideoPlayer extends StatefulWidget {
   /// Uses the given [controller] for all video rendered in this widget.
-  const VideoPlayer(this.controller, {Key? key}) : super(key: key);
+  const VideoPlayer(this.controller, {super.key});
 
   /// The [VideoPlayerController] responsible for the video being rendered in
   /// this widget.
@@ -803,7 +803,7 @@ class _VideoPlayerState extends State<VideoPlayer> {
 
   void _afterFrameLayout(_) {
     if (widget.controller.value.isInitialized) {
-      final Rect currentRect = _currentRect;
+      final Rect currentRect = _getCurrentRect();
       if (currentRect != Rect.zero && _playerRect != currentRect) {
         _videoPlayerPlatform.setDisplayGeometry(
           _playerId,
@@ -818,13 +818,14 @@ class _VideoPlayerState extends State<VideoPlayer> {
     WidgetsBinding.instance.addPostFrameCallback(_afterFrameLayout);
   }
 
-  Rect get _currentRect {
+  Rect _getCurrentRect() {
     final RenderObject? renderObject =
         _videoBoxKey.currentContext?.findRenderObject();
     if (renderObject == null) {
       return Rect.zero;
     }
-    final double pixelRatio = WidgetsBinding.instance.window.devicePixelRatio;
+    final double pixelRatio =
+        View.of(_videoBoxKey.currentContext!).devicePixelRatio;
     final RenderBox renderBox = renderObject as RenderBox;
     final Offset offset = renderBox.localToGlobal(Offset.zero) * pixelRatio;
     final Size size = renderBox.size * pixelRatio;
@@ -969,11 +970,11 @@ class VideoProgressIndicator extends StatefulWidget {
   /// to `top: 5.0`.
   const VideoProgressIndicator(
     this.controller, {
-    Key? key,
+    super.key,
     this.colors = const VideoProgressColors(),
     required this.allowScrubbing,
     this.padding = const EdgeInsets.only(top: 5.0),
-  }) : super(key: key);
+  });
 
   /// The [VideoPlayerController] that actually associates a video with this
   /// widget.
@@ -1089,7 +1090,7 @@ class ClosedCaption extends StatelessWidget {
   /// [VideoPlayerValue.caption].
   ///
   /// If [text] is null or empty, nothing will be displayed.
-  const ClosedCaption({Key? key, this.text, this.textStyle}) : super(key: key);
+  const ClosedCaption({super.key, this.text, this.textStyle});
 
   /// The text that will be shown in the closed caption, or null if no caption
   /// should be shown.

--- a/packages/video_player_videohole/lib/video_player.dart
+++ b/packages/video_player_videohole/lib/video_player.dart
@@ -824,8 +824,8 @@ class _VideoPlayerState extends State<VideoPlayer> {
     if (renderObject == null) {
       return Rect.zero;
     }
-    final double pixelRatio =
-        View.of(_videoBoxKey.currentContext!).devicePixelRatio;
+    // ignore: deprecated_member_use
+    final double pixelRatio = WidgetsBinding.instance.window.devicePixelRatio;
     final RenderBox renderBox = renderObject as RenderBox;
     final Offset offset = renderBox.localToGlobal(Offset.zero) * pixelRatio;
     final Size size = renderBox.size * pixelRatio;

--- a/packages/video_player_videohole/pubspec.yaml
+++ b/packages/video_player_videohole/pubspec.yaml
@@ -1,11 +1,11 @@
 name: video_player_videohole
-description: Flutter plugin for displaying inline video.
+description: Flutter plugin for displaying inline video on Tizen TV devices.
 homepage: https://github.com/flutter-tizen/plugins
 repository: https://github.com/flutter-tizen/plugins/tree/master/packages/video_player_videohole
 version: 0.1.1
 
 environment:
-  sdk: ">=2.12.0 <3.0.0"
+  sdk: ">=2.17.0 <4.0.0"
   flutter: ">=3.0.0"
 
 flutter:

--- a/packages/video_player_videohole/pubspec.yaml
+++ b/packages/video_player_videohole/pubspec.yaml
@@ -5,8 +5,8 @@ repository: https://github.com/flutter-tizen/plugins/tree/master/packages/video_
 version: 0.1.1
 
 environment:
-  sdk: ">=2.17.0 <4.0.0"
-  flutter: ">=3.0.0"
+  sdk: ">=2.18.0 <4.0.0"
+  flutter: ">=3.3.0"
 
 flutter:
   plugin:

--- a/packages/wakelock/CHANGELOG.md
+++ b/packages/wakelock/CHANGELOG.md
@@ -1,3 +1,7 @@
+## NEXT
+
+* Increase the minimum Flutter version to 3.3.
+
 ## 1.0.1
 
 * Update wakelock to 0.5.6.

--- a/packages/wakelock/example/pubspec.yaml
+++ b/packages/wakelock/example/pubspec.yaml
@@ -3,8 +3,8 @@ description: Demonstrates how to use the wakelock_tizen plugin.
 publish_to: "none"
 
 environment:
-  sdk: ">=2.12.0 <3.0.0"
-  flutter: ">=2.0.0"
+  sdk: ">=2.17.0 <4.0.0"
+  flutter: ">=3.0.0"
 
 dependencies:
   flutter:

--- a/packages/wakelock/example/pubspec.yaml
+++ b/packages/wakelock/example/pubspec.yaml
@@ -3,8 +3,8 @@ description: Demonstrates how to use the wakelock_tizen plugin.
 publish_to: "none"
 
 environment:
-  sdk: ">=2.17.0 <4.0.0"
-  flutter: ">=3.0.0"
+  sdk: ">=2.18.0 <4.0.0"
+  flutter: ">=3.3.0"
 
 dependencies:
   flutter:

--- a/packages/wakelock/pubspec.yaml
+++ b/packages/wakelock/pubspec.yaml
@@ -1,8 +1,12 @@
 name: wakelock_tizen
-description: Tizen implementation of the wakelock plugin
+description: Tizen implementation of the wakelock plugin.
 homepage: https://github.com/flutter-tizen/plugins
 repository: https://github.com/flutter-tizen/plugins/tree/master/packages/wakelock
 version: 1.0.1
+
+environment:
+  sdk: ">=2.17.0 <4.0.0"
+  flutter: ">=3.0.0"
 
 flutter:
   plugin:
@@ -18,7 +22,3 @@ dependencies:
 
 dev_dependencies:
   pedantic: ^1.11.0
-
-environment:
-  sdk: ">=2.12.0 <3.0.0"
-  flutter: ">=2.0.0"

--- a/packages/wakelock/pubspec.yaml
+++ b/packages/wakelock/pubspec.yaml
@@ -5,8 +5,8 @@ repository: https://github.com/flutter-tizen/plugins/tree/master/packages/wakelo
 version: 1.0.1
 
 environment:
-  sdk: ">=2.17.0 <4.0.0"
-  flutter: ">=3.0.0"
+  sdk: ">=2.18.0 <4.0.0"
+  flutter: ">=3.3.0"
 
 flutter:
   plugin:

--- a/packages/wearable_rotary/CHANGELOG.md
+++ b/packages/wearable_rotary/CHANGELOG.md
@@ -1,3 +1,7 @@
+## NEXT
+
+* Increase the minimum Flutter version to 3.3.
+
 ## 2.0.0
 
 * [BREAKING] `RotaryEvent` is now a class with `direction` and `magnitude` properties.

--- a/packages/wearable_rotary/example/pubspec.yaml
+++ b/packages/wearable_rotary/example/pubspec.yaml
@@ -1,11 +1,10 @@
 name: wearable_rotary_example
 description: Demonstrates how to use the wearable_rotary plugin.
-
 publish_to: "none"
 
 environment:
-  sdk: ">=2.17.0 <3.0.0"
-  flutter: ">=2.0.0"
+  sdk: ">=2.17.0 <4.0.0"
+  flutter: ">=3.0.0"
 
 dependencies:
   flutter:

--- a/packages/wearable_rotary/example/pubspec.yaml
+++ b/packages/wearable_rotary/example/pubspec.yaml
@@ -3,8 +3,8 @@ description: Demonstrates how to use the wearable_rotary plugin.
 publish_to: "none"
 
 environment:
-  sdk: ">=2.17.0 <4.0.0"
-  flutter: ">=3.0.0"
+  sdk: ">=2.18.0 <4.0.0"
+  flutter: ">=3.3.0"
 
 dependencies:
   flutter:

--- a/packages/wearable_rotary/pubspec.yaml
+++ b/packages/wearable_rotary/pubspec.yaml
@@ -5,8 +5,8 @@ repository: https://github.com/flutter-tizen/plugins/tree/master/packages/wearab
 version: 2.0.0
 
 environment:
-  sdk: '>=2.12.0 <3.0.0'
-  flutter: ">=2.0.0"
+  sdk: ">=2.17.0 <4.0.0"
+  flutter: ">=3.0.0"
 
 flutter:
   plugin:

--- a/packages/wearable_rotary/pubspec.yaml
+++ b/packages/wearable_rotary/pubspec.yaml
@@ -5,8 +5,8 @@ repository: https://github.com/flutter-tizen/plugins/tree/master/packages/wearab
 version: 2.0.0
 
 environment:
-  sdk: ">=2.17.0 <4.0.0"
-  flutter: ">=3.0.0"
+  sdk: ">=2.18.0 <4.0.0"
+  flutter: ">=3.3.0"
 
 flutter:
   plugin:

--- a/packages/webview_flutter/CHANGELOG.md
+++ b/packages/webview_flutter/CHANGELOG.md
@@ -1,5 +1,10 @@
+## NEXT
+
+* Increase the minimum Flutter version to 3.3.
+
 ## 0.7.1
-* Remove unnecessary integration test.
+
+* Remove inapplicable integration test cases.
 * Remove unused code.
 * Implements `LoadRequestMethod.post` of `PlatformWebViewController.loadRequest`.
 

--- a/packages/webview_flutter/example/pubspec.yaml
+++ b/packages/webview_flutter/example/pubspec.yaml
@@ -1,9 +1,9 @@
 name: webview_flutter_tizen_example
 description: Demonstrates how to use the webview_flutter_tizen plugin.
-publish_to: none
+publish_to: "none"
 
 environment:
-  sdk: ">=2.17.0 <3.0.0"
+  sdk: ">=2.17.0 <4.0.0"
   flutter: ">=3.0.0"
 
 dependencies:

--- a/packages/webview_flutter/example/pubspec.yaml
+++ b/packages/webview_flutter/example/pubspec.yaml
@@ -3,8 +3,8 @@ description: Demonstrates how to use the webview_flutter_tizen plugin.
 publish_to: "none"
 
 environment:
-  sdk: ">=2.17.0 <4.0.0"
-  flutter: ">=3.0.0"
+  sdk: ">=2.18.0 <4.0.0"
+  flutter: ">=3.3.0"
 
 dependencies:
   flutter:

--- a/packages/webview_flutter/pubspec.yaml
+++ b/packages/webview_flutter/pubspec.yaml
@@ -5,7 +5,7 @@ repository: https://github.com/flutter-tizen/plugins/tree/master/packages/webvie
 version: 0.7.1
 
 environment:
-  sdk: ">=2.17.0 <3.0.0"
+  sdk: ">=2.17.0 <4.0.0"
   flutter: ">=3.0.0"
 
 flutter:

--- a/packages/webview_flutter/pubspec.yaml
+++ b/packages/webview_flutter/pubspec.yaml
@@ -5,8 +5,8 @@ repository: https://github.com/flutter-tizen/plugins/tree/master/packages/webvie
 version: 0.7.1
 
 environment:
-  sdk: ">=2.17.0 <4.0.0"
-  flutter: ">=3.0.0"
+  sdk: ">=2.18.0 <4.0.0"
+  flutter: ">=3.3.0"
 
 flutter:
   plugin:

--- a/packages/webview_flutter_lwe/CHANGELOG.md
+++ b/packages/webview_flutter_lwe/CHANGELOG.md
@@ -1,3 +1,7 @@
+## NEXT
+
+* Increase the minimum Flutter version to 3.3.
+
 ## 0.2.0
 
 * Update webivew_flutter to 4.0.2.

--- a/packages/webview_flutter_lwe/example/pubspec.yaml
+++ b/packages/webview_flutter_lwe/example/pubspec.yaml
@@ -3,8 +3,8 @@ description: Demonstrates how to use the webview_flutter_lwe plugin.
 publish_to: "none"
 
 environment:
-  sdk: ">=2.17.0 <4.0.0"
-  flutter: ">=3.0.0"
+  sdk: ">=2.18.0 <4.0.0"
+  flutter: ">=3.3.0"
 
 dependencies:
   flutter:

--- a/packages/webview_flutter_lwe/example/pubspec.yaml
+++ b/packages/webview_flutter_lwe/example/pubspec.yaml
@@ -1,9 +1,9 @@
 name: webview_flutter_lwe_example
 description: Demonstrates how to use the webview_flutter_lwe plugin.
-publish_to: none
+publish_to: "none"
 
 environment:
-  sdk: ">=2.17.0 <3.0.0"
+  sdk: ">=2.17.0 <4.0.0"
   flutter: ">=3.0.0"
 
 dependencies:

--- a/packages/webview_flutter_lwe/pubspec.yaml
+++ b/packages/webview_flutter_lwe/pubspec.yaml
@@ -5,8 +5,8 @@ repository: https://github.com/flutter-tizen/plugins/tree/master/packages/webvie
 version: 0.2.0
 
 environment:
-  sdk: ">=2.17.0 <4.0.0"
-  flutter: ">=3.0.0"
+  sdk: ">=2.18.0 <4.0.0"
+  flutter: ">=3.3.0"
 
 flutter:
   plugin:

--- a/packages/webview_flutter_lwe/pubspec.yaml
+++ b/packages/webview_flutter_lwe/pubspec.yaml
@@ -5,7 +5,7 @@ repository: https://github.com/flutter-tizen/plugins/tree/master/packages/webvie
 version: 0.2.0
 
 environment:
-  sdk: ">=2.17.0 <3.0.0"
+  sdk: ">=2.17.0 <4.0.0"
   flutter: ">=3.0.0"
 
 flutter:


### PR DESCRIPTION
- Align Dart and Flutter SDK constraints.
- Update the minimum Flutter version to 3.3.

This resolves all Dart analyze issues introduced by the recent Flutter 3.10 release. This PR must be merged before any other currently open PR.

Related commits: https://github.com/flutter/packages/commit/789e3a72c9d439336bb50e5d291128347f7f6967, https://github.com/flutter/packages/commit/e893fdc9617c84b69737edbbdc681501289ed8d4, https://github.com/flutter/packages/commit/7319ca81814973a350bbb589696c2b23b2fc1488