### PR TITLE
Remove StreamHandlerError implementations

### DIFF
--- a/packages/battery_plus/CHANGELOG.md
+++ b/packages/battery_plus/CHANGELOG.md
@@ -1,5 +1,6 @@
-## NEXT
+## 1.1.2
 
+* Remove unnecessary `StreamHandlerError` implementation.
 * Increase the minimum Flutter version to 3.3.
 
 ## 1.1.1

--- a/packages/battery_plus/README.md
+++ b/packages/battery_plus/README.md
@@ -11,7 +11,7 @@ This package is not an _endorsed_ implementation of `battery_plus`. Therefore, y
 ```yaml
 dependencies:
   battery_plus: ^2.1.3
-  battery_plus_tizen: ^1.1.1
+  battery_plus_tizen: ^1.1.2
 ```
 
 Then you can import `battery_plus` in your Dart code:

--- a/packages/battery_plus/pubspec.yaml
+++ b/packages/battery_plus/pubspec.yaml
@@ -2,7 +2,7 @@ name: battery_plus_tizen
 description: Tizen implementation of the battery_plus plugin.
 homepage: https://github.com/flutter-tizen/plugins
 repository: https://github.com/flutter-tizen/plugins/tree/master/packages/battery_plus
-version: 1.1.1
+version: 1.1.2
 
 environment:
   sdk: ">=2.18.0 <4.0.0"

--- a/packages/battery_plus/tizen/src/battery_plus_tizen_plugin.cc
+++ b/packages/battery_plus/tizen/src/battery_plus_tizen_plugin.cc
@@ -11,6 +11,7 @@
 #include <flutter/plugin_registrar.h>
 #include <flutter/standard_method_codec.h>
 
+#include <cstdint>
 #include <memory>
 #include <string>
 
@@ -41,20 +42,6 @@ std::string BatteryStatusToString(BatteryStatus status) {
   }
 }
 
-class BatteryStatusStreamHandlerError : public FlStreamHandlerError {
- public:
-  BatteryStatusStreamHandlerError(const std::string &error_code,
-                                  const std::string &error_message,
-                                  const flutter::EncodableValue *error_details)
-      : error_code_(error_code),
-        error_message_(error_message),
-        FlStreamHandlerError(error_code_, error_message_, error_details) {}
-
- private:
-  std::string error_code_;
-  std::string error_message_;
-};
-
 class BatteryStatusStreamHandler : public FlStreamHandler {
  protected:
   std::unique_ptr<FlStreamHandlerError> OnListenInternal(
@@ -72,7 +59,7 @@ class BatteryStatusStreamHandler : public FlStreamHandler {
       }
     };
     if (!battery_.StartListen(callback)) {
-      return std::make_unique<BatteryStatusStreamHandlerError>(
+      return std::make_unique<FlStreamHandlerError>(
           std::to_string(battery_.GetLastError()),
           battery_.GetLastErrorString(), nullptr);
     }

--- a/packages/connectivity_plus/CHANGELOG.md
+++ b/packages/connectivity_plus/CHANGELOG.md
@@ -1,5 +1,6 @@
-## NEXT
+## 1.1.3
 
+* Remove unnecessary `StreamHandlerError` implementation.
 * Increase the minimum Flutter version to 3.3.
 
 ## 1.1.2

--- a/packages/connectivity_plus/README.md
+++ b/packages/connectivity_plus/README.md
@@ -11,7 +11,7 @@ This package is not an _endorsed_ implementation of `connectivity_plus`. Therefo
 ```yaml
 dependencies:
   connectivity_plus: ^2.3.0
-  connectivity_plus_tizen: ^1.1.2
+  connectivity_plus_tizen: ^1.1.3
 ```
 
 Then you can import `connectivity_plus` in your Dart code:

--- a/packages/connectivity_plus/pubspec.yaml
+++ b/packages/connectivity_plus/pubspec.yaml
@@ -2,7 +2,7 @@ name: connectivity_plus_tizen
 description: Tizen implementation of the connectivity_plus plugin.
 homepage: https://github.com/flutter-tizen/plugins
 repository: https://github.com/flutter-tizen/plugins/tree/master/packages/connectivity_plus
-version: 1.1.2
+version: 1.1.3
 
 environment:
   sdk: ">=2.18.0 <4.0.0"

--- a/packages/connectivity_plus/tizen/src/connectivity_plus_tizen_plugin.cc
+++ b/packages/connectivity_plus/tizen/src/connectivity_plus_tizen_plugin.cc
@@ -43,20 +43,6 @@ std::string ConnectionTypeToString(ConnectionType type) {
   }
 }
 
-class ConnectivityStreamHandlerError : public FlStreamHandlerError {
- public:
-  ConnectivityStreamHandlerError(const std::string &error_code,
-                                 const std::string &error_message,
-                                 const flutter::EncodableValue *error_details)
-      : error_code_(error_code),
-        error_message_(error_message),
-        FlStreamHandlerError(error_code_, error_message_, error_details) {}
-
- private:
-  std::string error_code_;
-  std::string error_message_;
-};
-
 class ConnectivityStreamHandler : public FlStreamHandler {
  protected:
   std::unique_ptr<FlStreamHandlerError> OnListenInternal(
@@ -73,7 +59,7 @@ class ConnectivityStreamHandler : public FlStreamHandler {
       }
     };
     if (!connection_.StartListen(callback)) {
-      return std::make_unique<ConnectivityStreamHandlerError>(
+      return std::make_unique<FlStreamHandlerError>(
           std::to_string(connection_.GetLastError()),
           connection_.GetLastErrorString(), nullptr);
     }

--- a/packages/geolocator/CHANGELOG.md
+++ b/packages/geolocator/CHANGELOG.md
@@ -1,5 +1,6 @@
-## NEXT
+## 1.0.6
 
+* Remove unnecessary `StreamHandlerError` implementation.
 * Increase the minimum Flutter version to 3.3.
 
 ## 1.0.5

--- a/packages/geolocator/README.md
+++ b/packages/geolocator/README.md
@@ -11,7 +11,7 @@ The Tizen implementation of [`geolocator`](https://pub.dev/packages/geolocator).
  ```yaml
 dependencies:
   geolocator: ^8.0.0
-  geolocator_tizen: ^1.0.5
+  geolocator_tizen: ^1.0.6
 ```
 
 Then you can import `geolocator` in your Dart code:

--- a/packages/geolocator/pubspec.yaml
+++ b/packages/geolocator/pubspec.yaml
@@ -2,7 +2,7 @@ name: geolocator_tizen
 description: Tizen implementation of the geolocator plugin.
 homepage: https://github.com/flutter-tizen/plugins
 repository: https://github.com/flutter-tizen/plugins/tree/master/packages/geolocator
-version: 1.0.5
+version: 1.0.6
 
 environment:
   sdk: ">=2.18.0 <4.0.0"

--- a/packages/geolocator/tizen/src/geolocator_tizen_plugin.cc
+++ b/packages/geolocator/tizen/src/geolocator_tizen_plugin.cc
@@ -31,33 +31,20 @@ typedef flutter::StreamHandlerError<flutter::EncodableValue>
 
 constexpr char kPrivilegeLocation[] = "http://tizen.org/privilege/location";
 
-class LocationStreamHandlerError : public FlStreamHandlerError {
- public:
-  LocationStreamHandlerError(const std::string &error_code,
-                             const std::string &error_message,
-                             const flutter::EncodableValue *error_details)
-      : error_code_(error_code),
-        error_message_(error_message),
-        FlStreamHandlerError(error_code_, error_message_, error_details) {}
-
- private:
-  std::string error_code_;
-  std::string error_message_;
-};
-
 class LocationStreamHandler : public FlStreamHandler {
  protected:
   std::unique_ptr<FlStreamHandlerError> OnListenInternal(
       const flutter::EncodableValue *arguments,
       std::unique_ptr<FlEventSink> &&events) override {
     events_ = std::move(events);
+
     LocationCallback callback = [this](Position position) -> void {
       events_->Success(position.ToEncodableValue());
     };
     try {
       location_manager_.StartListenLocationUpdate(callback);
     } catch (const LocationManagerError &error) {
-      return std::make_unique<LocationStreamHandlerError>(
+      return std::make_unique<FlStreamHandlerError>(
           std::to_string(error.GetErrorCode()), error.GetErrorString(),
           nullptr);
     }
@@ -69,7 +56,7 @@ class LocationStreamHandler : public FlStreamHandler {
     try {
       location_manager_.StopListenLocationUpdate();
     } catch (const LocationManagerError &error) {
-      return std::make_unique<LocationStreamHandlerError>(
+      return std::make_unique<FlStreamHandlerError>(
           std::to_string(error.GetErrorCode()), error.GetErrorString(),
           nullptr);
     }
@@ -88,13 +75,14 @@ class ServiceStatusStreamHandler : public FlStreamHandler {
       const flutter::EncodableValue *arguments,
       std::unique_ptr<FlEventSink> &&events) override {
     events_ = std::move(events);
+
     ServiceStatusCallback callback = [this](ServiceStatus status) -> void {
       events_->Success(flutter::EncodableValue(static_cast<int>(status)));
     };
     try {
       location_manager_.StartListenServiceStatusUpdate(callback);
     } catch (const LocationManagerError &error) {
-      return std::make_unique<LocationStreamHandlerError>(
+      return std::make_unique<FlStreamHandlerError>(
           std::to_string(error.GetErrorCode()), error.GetErrorString(),
           nullptr);
     }
@@ -106,7 +94,7 @@ class ServiceStatusStreamHandler : public FlStreamHandler {
     try {
       location_manager_.StopListenServiceStatusUpdate();
     } catch (const LocationManagerError &error) {
-      return std::make_unique<LocationStreamHandlerError>(
+      return std::make_unique<FlStreamHandlerError>(
           std::to_string(error.GetErrorCode()), error.GetErrorString(),
           nullptr);
     }

--- a/packages/messageport/CHANGELOG.md
+++ b/packages/messageport/CHANGELOG.md
@@ -1,5 +1,6 @@
-## NEXT
+## 0.3.2
 
+* Remove unnecessary `StreamHandlerError` implementation.
 * Increase the minimum Flutter version to 3.3.
 
 ## 0.3.1

--- a/packages/messageport/pubspec.yaml
+++ b/packages/messageport/pubspec.yaml
@@ -2,7 +2,7 @@ name: messageport_tizen
 description: A Flutter plugin that allows communication between multiple applications on Tizen using Tizen Message Port.
 homepage: https://github.com/flutter-tizen/plugins
 repository: https://github.com/flutter-tizen/plugins/tree/master/packages/messageport
-version: 0.3.1
+version: 0.3.2
 
 environment:
   sdk: ">=2.18.0 <4.0.0"

--- a/packages/messageport/tizen/src/messageport_tizen_plugin.cc
+++ b/packages/messageport/tizen/src/messageport_tizen_plugin.cc
@@ -46,20 +46,6 @@ bool GetValueFromEncodableMap(const flutter::EncodableMap *map, const char *key,
   return false;
 }
 
-class LocalPortStreamHandlerError : public FlStreamHandlerError {
- public:
-  LocalPortStreamHandlerError(const std::string &error_code,
-                              const std::string &error_message,
-                              const flutter::EncodableValue *error_details)
-      : error_code_(error_code),
-        error_message_(error_message),
-        FlStreamHandlerError(error_code_, error_message_, error_details) {}
-
- private:
-  std::string error_code_;
-  std::string error_message_;
-};
-
 class LocalPortStreamHandler : public FlStreamHandler {
  public:
   LocalPortStreamHandler(LocalPort *local_port) : local_port_(local_port) {}
@@ -91,7 +77,7 @@ class LocalPortStreamHandler : public FlStreamHandler {
           event_sink_->Error(std::to_string(error_code), error_message);
         });
     if (error.has_value()) {
-      return std::make_unique<LocalPortStreamHandlerError>(
+      return std::make_unique<FlStreamHandlerError>(
           std::to_string(error.value().code()), error.value().message(),
           nullptr);
     }
@@ -103,7 +89,7 @@ class LocalPortStreamHandler : public FlStreamHandler {
       const flutter::EncodableValue *arguments) override {
     std::optional<MessagePortError> error = local_port_->Unregister();
     if (error.has_value()) {
-      return std::make_unique<LocalPortStreamHandlerError>(
+      return std::make_unique<FlStreamHandlerError>(
           std::to_string(error.value().code()), error.value().message(),
           nullptr);
     }

--- a/packages/sensors_plus/CHANGELOG.md
+++ b/packages/sensors_plus/CHANGELOG.md
@@ -1,5 +1,6 @@
-## NEXT
+## 1.1.2
 
+* Remove unnecessary `StreamHandlerError` implementation.
 * Increase the minimum Flutter version to 3.3.
 
 ## 1.1.1

--- a/packages/sensors_plus/README.md
+++ b/packages/sensors_plus/README.md
@@ -11,7 +11,7 @@ This package is not an _endorsed_ implementation of 'sensors_plus'. Therefore, y
 ```yaml
 dependencies:
   sensors_plus: ^1.2.1
-  sensors_plus_tizen: ^1.1.1
+  sensors_plus_tizen: ^1.1.2
 ```
 
 Then you can import `sensors_plus` in your Dart code:

--- a/packages/sensors_plus/pubspec.yaml
+++ b/packages/sensors_plus/pubspec.yaml
@@ -2,7 +2,7 @@ name: sensors_plus_tizen
 description: Tizen implementation of the sensors plugin.
 homepage: https://github.com/flutter-tizen/plugins
 repository: https://github.com/flutter-tizen/plugins/tree/master/packages/sensors_plus
-version: 1.1.1
+version: 1.1.2
 
 environment:
   sdk: ">=2.18.0 <4.0.0"

--- a/packages/sensors_plus/tizen/src/sensors_plus_plugin.cc
+++ b/packages/sensors_plus/tizen/src/sensors_plus_plugin.cc
@@ -10,6 +10,8 @@
 #include <flutter/plugin_registrar.h>
 #include <flutter/standard_method_codec.h>
 
+#include <memory>
+
 #include "device_sensor.h"
 
 typedef flutter::EventChannel<flutter::EncodableValue> FlEventChannel;
@@ -17,20 +19,6 @@ typedef flutter::EventSink<flutter::EncodableValue> FlEventSink;
 typedef flutter::StreamHandler<flutter::EncodableValue> FlStreamHandler;
 typedef flutter::StreamHandlerError<flutter::EncodableValue>
     FlStreamHandlerError;
-
-class DeviceSensorStreamHandlerError : public FlStreamHandlerError {
- public:
-  DeviceSensorStreamHandlerError(const std::string &error_code,
-                                 const std::string &error_message,
-                                 const flutter::EncodableValue *error_details)
-      : error_code_(error_code),
-        error_message_(error_message),
-        FlStreamHandlerError(error_code_, error_message_, error_details) {}
-
- private:
-  std::string error_code_;
-  std::string error_message_;
-};
 
 class DeviceSensorStreamHandler : public FlStreamHandler {
  public:
@@ -46,7 +34,7 @@ class DeviceSensorStreamHandler : public FlStreamHandler {
       events_->Success(flutter::EncodableValue(sensor_event));
     };
     if (!sensor_.StartListen(callback)) {
-      return std::make_unique<DeviceSensorStreamHandlerError>(
+      return std::make_unique<FlStreamHandlerError>(
           std::to_string(sensor_.GetLastError()), sensor_.GetLastErrorString(),
           nullptr);
     }

--- a/packages/tizen_rpc_port/CHANGELOG.md
+++ b/packages/tizen_rpc_port/CHANGELOG.md
@@ -1,5 +1,6 @@
-## NEXT
+## 0.1.3
 
+* Remove unnecessary `StreamHandlerError` implementation.
 * Increase the minimum Flutter version to 3.3.
 
 ## 0.1.2

--- a/packages/tizen_rpc_port/README.md
+++ b/packages/tizen_rpc_port/README.md
@@ -21,7 +21,7 @@ The generated source files (`message_client.dart` and `message_server.dart`) dep
 
 ```yaml
 depenedencies:
-  tizen_rpc_port: ^0.1.2
+  tizen_rpc_port: ^0.1.3
 ```
 
 Assuming that the name of the interface defined in your interface file is `Message`, the client must first call its `connect` method to connect to the server before making any remote invocation.

--- a/packages/tizen_rpc_port/pubspec.yaml
+++ b/packages/tizen_rpc_port/pubspec.yaml
@@ -2,7 +2,7 @@ name: tizen_rpc_port
 description: Tizen RPC Port APIs. Used to make remote procedure calls between Tizen apps.
 homepage: https://github.com/flutter-tizen/plugins
 repository: https://github.com/flutter-tizen/plugins/tree/master/packages/tizen_rpc_port
-version: 0.1.2
+version: 0.1.3
 
 environment:
   sdk: ">=2.18.0 <4.0.0"

--- a/packages/wearable_rotary/CHANGELOG.md
+++ b/packages/wearable_rotary/CHANGELOG.md
@@ -1,5 +1,6 @@
-## NEXT
+## 2.0.1
 
+* Remove unnecessary `StreamHandlerError` implementation.
 * Increase the minimum Flutter version to 3.3.
 
 ## 2.0.0

--- a/packages/wearable_rotary/README.md
+++ b/packages/wearable_rotary/README.md
@@ -30,7 +30,7 @@ To use this plugin, add `wearable_rotary` as a dependency in your `pubspec.yaml`
 
 ```yaml
 dependencies:
-  wearable_rotary: ^2.0.0
+  wearable_rotary: ^2.0.1
 ```
 
 Then, import `wearable_rotary` in your Dart code.

--- a/packages/wearable_rotary/pubspec.yaml
+++ b/packages/wearable_rotary/pubspec.yaml
@@ -2,7 +2,7 @@ name: wearable_rotary
 description: Flutter plugin that can listen to rotary events on Wear OS and Tizen Galaxy watch devices.
 homepage: https://github.com/flutter-tizen/plugins
 repository: https://github.com/flutter-tizen/plugins/tree/master/packages/wearable_rotary
-version: 2.0.0
+version: 2.0.1
 
 environment:
   sdk: ">=2.18.0 <4.0.0"


### PR DESCRIPTION
This reverts https://github.com/flutter-tizen/plugins/pull/455.

The extended classes generate compile errors on Flutter 3.10 because they use the `StreamHandlerError` constructor. The constructor takes `std::unique_ptr&&` instead of a plain pointer since Flutter 3.10.

```cpp
src/messageport_tizen_plugin.cc:56:9: error: no matching constructor for initialization of 'FlStreamHandlerError' (aka 'StreamHandlerError<flutter::EncodableValue>')
        FlStreamHandlerError(error_code_, error_message_, error_details) {}
        ^                    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/home/swift/Git/flutter-tizen/flutter/bin/cache/artifacts/engine/tizen-common/cpp_client_wrapper/include/flutter/event_stream_handler.h:23:3: note: candidate constructor not
viable: no known conversion from 'const flutter::EncodableValue *' to 'std::unique_ptr<EncodableValue>' for 3rd argument
  StreamHandlerError(const std::string error_code,
  ^
```