### PR TITLE
[tizen_app_control] Add static setAutoRestart method

### DIFF
--- a/packages/tizen_app_control/CHANGELOG.md
+++ b/packages/tizen_app_control/CHANGELOG.md
@@ -1,5 +1,6 @@
-## NEXT
+## 0.2.3
 
+* Add static `AppControl.setAutoRestart` method.
 * Increase the minimum Flutter version to 3.3.
 * Update README.
 * Remove unused code and clean up.

--- a/packages/tizen_app_control/README.md
+++ b/packages/tizen_app_control/README.md
@@ -10,7 +10,7 @@ To use this package, add `tizen_app_control` as a dependency in your `pubspec.ya
 
 ```yaml
 dependencies:
-  tizen_app_control: ^0.2.2
+  tizen_app_control: ^0.2.3
 ```
 
 ### Sending a launch request

--- a/packages/tizen_app_control/lib/src/app_control.dart
+++ b/packages/tizen_app_control/lib/src/app_control.dart
@@ -3,7 +3,9 @@
 // found in the LICENSE file.
 
 import 'dart:async';
+import 'dart:ffi';
 
+import 'package:ffi/ffi.dart';
 import 'package:flutter/services.dart';
 
 import 'ffi.dart';
@@ -216,6 +218,38 @@ class AppControl {
       'extraData': extraData,
     };
     await _methodChannel.invokeMethod<void>('setAppControlData', args);
+  }
+
+  /// Enables the auto restart setting.
+  ///
+  /// Calling this API makes the current app be automatically restarted upon
+  /// termination. The given [appControl] is passed to the restarting app.
+  ///
+  /// This API is for platform developers only. The app must be signed with a
+  /// platform-level certificate to use this API.
+  static Future<void> setAutoRestart(AppControl appControl) async {
+    final Map<String, dynamic> args = <String, dynamic>{'id': appControl._id};
+    final int? handleAddress =
+        await _methodChannel.invokeMethod<int>('getHandle', args);
+    final Pointer<Void> handle = Pointer<Void>.fromAddress(handleAddress!);
+
+    final int ret = appControlSetAutoRestart(handle);
+    if (ret != 0) {
+      final String message = getErrorMessage(ret).toDartString();
+      throw PlatformException(code: ret.toString(), message: message);
+    }
+  }
+
+  /// Disables the auto restart setting. See [setAutoRestart] for details.
+  ///
+  /// This API is for platform developers only. The app must be signed with a
+  /// platform-level certificate to use this API.
+  static Future<void> unsetAutoRestart() async {
+    final int ret = appControlUnsetAutoRestart();
+    if (ret != 0) {
+      final String message = getErrorMessage(ret).toDartString();
+      throw PlatformException(code: ret.toString(), message: message);
+    }
   }
 }
 

--- a/packages/tizen_app_control/lib/src/app_control.dart
+++ b/packages/tizen_app_control/lib/src/app_control.dart
@@ -69,7 +69,7 @@ class AppControl {
     this.extraData = const <String, dynamic>{},
   }) {
     _id = nativeCreateAppControl(this);
-    if (_id < 0) {
+    if (_id == -1) {
       throw Exception('Could not create an instance of AppControl.');
     }
   }
@@ -228,6 +228,8 @@ class AppControl {
   /// This API is for platform developers only. The app must be signed with a
   /// platform-level certificate to use this API.
   static Future<void> setAutoRestart(AppControl appControl) async {
+    await appControl._setAppControlData();
+
     final Map<String, dynamic> args = <String, dynamic>{'id': appControl._id};
     final int? handleAddress =
         await _methodChannel.invokeMethod<int>('getHandle', args);

--- a/packages/tizen_app_control/lib/src/ffi.dart
+++ b/packages/tizen_app_control/lib/src/ffi.dart
@@ -31,12 +31,21 @@ final AttachAppControl nativeAttachAppControl =
     _processLib.lookupFunction<_AttachAppControlNative, AttachAppControl>(
         'NativeAttachAppControl');
 
+typedef _SetAutoRestartNative = Int32 Function(Pointer<Void>);
+typedef SetAutoRestart = int Function(Pointer<Void>);
+typedef _UnsetAutoRestartNative = Int32 Function();
+typedef UnsetAutoRestart = int Function();
+
+final SetAutoRestart appControlSetAutoRestart =
+    _processLib.lookupFunction<_SetAutoRestartNative, SetAutoRestart>(
+        'app_control_set_auto_restart');
+final UnsetAutoRestart appControlUnsetAutoRestart =
+    _processLib.lookupFunction<_UnsetAutoRestartNative, UnsetAutoRestart>(
+        'app_control_unset_auto_restart');
+
 typedef _GetErrorMessageNative = Pointer<Utf8> Function(Int);
 typedef GetErrorMessage = Pointer<Utf8> Function(int);
 
-final DynamicLibrary _libBaseCommon =
-    DynamicLibrary.open('libcapi-base-common.so.0');
-
 final GetErrorMessage getErrorMessage =
-    _libBaseCommon.lookupFunction<_GetErrorMessageNative, GetErrorMessage>(
+    _processLib.lookupFunction<_GetErrorMessageNative, GetErrorMessage>(
         'get_error_message');

--- a/packages/tizen_app_control/pubspec.yaml
+++ b/packages/tizen_app_control/pubspec.yaml
@@ -2,7 +2,7 @@ name: tizen_app_control
 description: Tizen application control APIs. Used to launch apps on a Tizen device.
 homepage: https://github.com/flutter-tizen/plugins
 repository: https://github.com/flutter-tizen/plugins/tree/master/packages/tizen_app_control
-version: 0.2.2
+version: 0.2.3
 
 environment:
   sdk: ">=2.18.0 <4.0.0"


### PR DESCRIPTION
Add inhouse APIs related to the auto-restart feature as requested by an internal developer.

I don't have a Tizen 7.0 device that supports this feature. @hjhun Could you test the code?

Below is simple example code for testing. You can use the Send SMS and Pick image buttons to activate and deactivate the auto-restart setting.

```patch
diff --git a/packages/tizen_app_control/example/lib/main.dart b/packages/tizen_app_control/example/lib/main.dart
index ee06f16c..6d6fda84 100644
--- a/packages/tizen_app_control/example/lib/main.dart
+++ b/packages/tizen_app_control/example/lib/main.dart
@@ -87,9 +87,18 @@ class _MyAppState extends State<MyApp> {
     super.dispose();

     _localPort?.unregister();
+
+    AppControl.onAppControl.listen((ReceivedAppControl request) {
+      print('Received extra data: ${request.extraData}');
+    });
   }

   Future<void> _sendSms() async {
+    await AppControl.setAutoRestart(AppControl(
+      extraData: <String, dynamic>{'test_key': 'test_value'},
+    ));
+    return;
+
     final AppControl request = AppControl(
       operation: 'http://tizen.org/appcontrol/operation/share_text',
       uri: 'sms:',
@@ -109,6 +118,9 @@ class _MyAppState extends State<MyApp> {
   }

   Future<void> _pickImage() async {
+    await AppControl.unsetAutoRestart();
+    return;
+
     final AppControl request = AppControl(
       operation: 'http://tizen.org/appcontrol/operation/pick',
       mime: 'image/*',
```