### PR TITLE
[package_info_plus] Update dependencies

### DIFF
--- a/packages/package_info_plus/CHANGELOG.md
+++ b/packages/package_info_plus/CHANGELOG.md
@@ -1,10 +1,9 @@
 ## NEXT
-
-* Increase the minimum Flutter version to 3.3.
-
 ## 1.0.3
 
-* Update package_info_plus to 2.0.1.
+* Update package_info_plus to 4.0.1.
+* Update package_info_plus_platform_interface to 2.0.1.
+* Increase the minimum Flutter version to 3.3.
 
 ## 1.0.2
 

--- a/packages/package_info_plus/CHANGELOG.md
+++ b/packages/package_info_plus/CHANGELOG.md
@@ -1,9 +1,10 @@
-## NEXT
 ## 1.0.3
 
 * Update package_info_plus to 4.0.1.
 * Update package_info_plus_platform_interface to 2.0.1.
 * Increase the minimum Flutter version to 3.3.
+* Update the example app and integration_test.
+* Minor cleanups.
 
 ## 1.0.2
 

--- a/packages/package_info_plus/CHANGELOG.md
+++ b/packages/package_info_plus/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 * Increase the minimum Flutter version to 3.3.
 
+## 1.0.3
+
+* Update package_info_plus to 2.0.1.
+
 ## 1.0.2
 
 * Update package_info_plus to 1.3.1.

--- a/packages/package_info_plus/README.md
+++ b/packages/package_info_plus/README.md
@@ -10,8 +10,8 @@ This package is not an _endorsed_ implementation of `package_info_plus`. Therefo
 
 ```yaml
 dependencies:
-  package_info_plus: ^1.3.1
-  package_info_plus_tizen: ^1.0.2
+  package_info_plus: ^4.0.1
+  package_info_plus_tizen: ^1.0.3
 ```
 
 Then you can import `package_info_plus` in your Dart code.

--- a/packages/package_info_plus/README.md
+++ b/packages/package_info_plus/README.md
@@ -29,3 +29,4 @@ For detailed usage, see https://pub.dev/packages/package_info_plus#usage.
 - [x] `PackageInfo.version`
 - [ ] `PackageInfo.buildNumber`
 - [ ] `PackageInfo.buildSignature`
+- [ ] `PackageInfo.installerStore`

--- a/packages/package_info_plus/example/integration_test/package_info_plus_test.dart
+++ b/packages/package_info_plus/example/integration_test/package_info_plus_test.dart
@@ -14,8 +14,11 @@ void main() {
     final info = await PackageInfo.fromPlatform();
     // These tests are based on the example app. The tests should be updated if any related info changes.
     expect(info.appName, 'package_info_plus_tizen_example');
+    expect(info.buildNumber, isEmpty);
+    expect(info.buildSignature, isEmpty);
     expect(info.packageName, 'org.tizen.package_info_plus_tizen_example');
     expect(info.version, '1.2.3');
+    expect(info.installerStore, null);
   });
 
   testWidgets('example', (WidgetTester tester) async {
@@ -25,5 +28,7 @@ void main() {
     expect(
         find.text('org.tizen.package_info_plus_tizen_example'), findsOneWidget);
     expect(find.text('1.2.3'), findsOneWidget);
+    expect(find.text('Not set'), findsNWidgets(2));
+    expect(find.text('not available'), findsOneWidget);
   });
 }

--- a/packages/package_info_plus/example/integration_test/package_info_plus_test.dart
+++ b/packages/package_info_plus/example/integration_test/package_info_plus_test.dart
@@ -28,7 +28,5 @@ void main() {
     expect(
         find.text('org.tizen.package_info_plus_tizen_example'), findsOneWidget);
     expect(find.text('1.2.3'), findsOneWidget);
-    expect(find.text('Not set'), findsNWidgets(2));
-    expect(find.text('not available'), findsOneWidget);
   });
 }

--- a/packages/package_info_plus/example/lib/main.dart
+++ b/packages/package_info_plus/example/lib/main.dart
@@ -19,20 +19,21 @@ class MyApp extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return MaterialApp(
-      title: 'PackageInfo Demo',
-      theme: ThemeData(primarySwatch: Colors.blue),
-      home: const MyHomePage(title: 'PackageInfo example app'),
+      title: 'PackageInfoPlus Demo',
+      theme: ThemeData(
+        useMaterial3: true,
+        colorSchemeSeed: const Color(0x9f4376f8),
+      ),
+      home: const MyHomePage(),
     );
   }
 }
 
 class MyHomePage extends StatefulWidget {
-  const MyHomePage({Key? key, this.title}) : super(key: key);
-
-  final String? title;
+  const MyHomePage({Key? key}) : super(key: key);
 
   @override
-  _MyHomePageState createState() => _MyHomePageState();
+  State<MyHomePage> createState() => _MyHomePageState();
 }
 
 class _MyHomePageState extends State<MyHomePage> {
@@ -42,6 +43,7 @@ class _MyHomePageState extends State<MyHomePage> {
     version: 'Unknown',
     buildNumber: 'Unknown',
     buildSignature: 'Unknown',
+    installerStore: 'Unknown',
   );
 
   @override
@@ -68,14 +70,20 @@ class _MyHomePageState extends State<MyHomePage> {
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(
-        title: Text(widget.title!),
+        title: const Text('PackageInfoPlus example'),
+        elevation: 4,
       ),
-      body: Column(
-        mainAxisAlignment: MainAxisAlignment.center,
+      body: ListView(
         children: <Widget>[
           _infoTile('App name', _packageInfo.appName),
           _infoTile('Package name', _packageInfo.packageName),
           _infoTile('App version', _packageInfo.version),
+          _infoTile('Build number', _packageInfo.buildNumber),
+          _infoTile('Build signature', _packageInfo.buildSignature),
+          _infoTile(
+            'Installer store',
+            _packageInfo.installerStore ?? 'not available',
+          ),
         ],
       ),
     );

--- a/packages/package_info_plus/example/pubspec.yaml
+++ b/packages/package_info_plus/example/pubspec.yaml
@@ -23,7 +23,6 @@ dev_dependencies:
     sdk: flutter
   integration_test_tizen:
     path: ../../integration_test/
-  flutter_lints: ^1.0.4
 
 flutter:
   uses-material-design: true

--- a/packages/package_info_plus/example/pubspec.yaml
+++ b/packages/package_info_plus/example/pubspec.yaml
@@ -10,7 +10,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  package_info_plus: ^1.3.1
+  package_info_plus: ^4.0.1
   package_info_plus_tizen:
     path: ../
 

--- a/packages/package_info_plus/pubspec.yaml
+++ b/packages/package_info_plus/pubspec.yaml
@@ -2,7 +2,7 @@ name: package_info_plus_tizen
 description: Tizen implementation of the package_info_plus plugin.
 homepage: https://github.com/flutter-tizen/plugins
 repository: https://github.com/flutter-tizen/plugins/tree/master/packages/package_info_plus
-version: 1.0.2
+version: 1.0.3
 
 environment:
   sdk: ">=2.18.0 <4.0.0"
@@ -18,7 +18,7 @@ flutter:
 dependencies:
   flutter:
     sdk: flutter
-  package_info_plus_platform_interface: ^1.0.2
+  package_info_plus_platform_interface: ^2.0.1
 
 dev_dependencies:
   flutter_lints: ^1.0.4

--- a/packages/package_info_plus/pubspec.yaml
+++ b/packages/package_info_plus/pubspec.yaml
@@ -21,4 +21,4 @@ dependencies:
   package_info_plus_platform_interface: ^2.0.1
 
 dev_dependencies:
-  flutter_lints: ^1.0.4
+  flutter_lints: ^2.0.1

--- a/packages/package_info_plus/tizen/src/package_info_plus_tizen_plugin.cc
+++ b/packages/package_info_plus/tizen/src/package_info_plus_tizen_plugin.cc
@@ -13,8 +13,6 @@
 #include <memory>
 #include <string>
 
-#include "log.h"
-
 namespace {
 
 class PackageInfoPlusTizenPlugin : public flutter::Plugin {
@@ -55,7 +53,7 @@ class PackageInfoPlusTizenPlugin : public flutter::Plugin {
     char *id = nullptr;
     int ret = app_get_id(&id);
     if (ret != APP_ERROR_NONE) {
-      result->Error(std::to_string(ret), "Failed to get find the app ID.",
+      result->Error(std::to_string(ret), "Failed to find the app ID.",
                     flutter::EncodableValue(get_error_message(ret)));
       return;
     }
@@ -107,9 +105,6 @@ class PackageInfoPlusTizenPlugin : public flutter::Plugin {
         flutter::EncodableValue(std::string(version));
     free(version);
     package_info_destroy(package_info);
-
-    map[flutter::EncodableValue("buildNumber")] =
-        flutter::EncodableValue("Not supported property");
 
     result->Success(flutter::EncodableValue(map));
   }


### PR DESCRIPTION
* Update package_info_plus to 4.0.1.
* Update package_info_plus_platform_interface to 2.0.1.
* Update flutter_lints to 2.0.1.
* Update the example app and integration_test.
* Let `buildNumber` return an empty string.
