### PR TITLE
[tool] Use new pub cache location for the publish command

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,6 +36,7 @@ jobs:
           verbose: false
       - name: Publish packages
         if: ${{ github.event_name == 'push' }}
+        timeout-minutes: 5
         env:
           PUB_CREDENTIALS: ${{ secrets.PUB_CREDENTIALS }}
         run: |

--- a/tools/lib/src/build_examples_command.dart
+++ b/tools/lib/src/build_examples_command.dart
@@ -11,15 +11,16 @@ class BuildExamplesCommand extends PackageLoopingCommand {
   BuildExamplesCommand(super.packagesDir);
 
   @override
-  String get description => 'Builds all example apps.\n\n'
-      'This command requires "flutter-tizen" to be in your path.';
+  final String name = 'build-examples';
 
   @override
-  String get name => 'build-examples';
+  final String description = 'Builds all example apps.\n\n'
+      'This command requires "flutter-tizen" to be in your path.';
 
   @override
   Future<PackageResult> runForPackage(RepositoryPackage package) async {
     final List<String> errors = <String>[];
+
     bool builtSomething = false;
     for (final RepositoryPackage example in package.getExamples()) {
       int exitCode = await processRunner.runAndStream(

--- a/tools/lib/src/integration_test_command.dart
+++ b/tools/lib/src/integration_test_command.dart
@@ -86,12 +86,12 @@ class IntegrationTestCommand extends PackageLoopingCommand {
   Recipe? _recipe;
 
   @override
-  String get description =>
-      'Runs integration tests for plugin example apps.\n\n'
-      'This command requires "flutter-tizen" to be in your path.';
+  final String name = 'integration-test';
 
   @override
-  String get name => 'integration-test';
+  final String description =
+      'Runs integration tests for plugin example apps.\n\n'
+      'This command requires "flutter-tizen" to be in your path.';
 
   @override
   Future<void> initializeRun() async {

--- a/tools/lib/src/publish_command.dart
+++ b/tools/lib/src/publish_command.dart
@@ -73,10 +73,10 @@ class PublishCommand extends PackageLoopingCommand {
   static const String _pubCredentialName = 'PUB_CREDENTIALS';
 
   @override
-  String get name => 'publish';
+  final String name = 'publish';
 
   @override
-  String get description => 'Attempts to publish the given packages to pub.\n'
+  final String description = 'Attempts to publish the given packages to pub.\n'
       'If running this on CI, an environment variable named $_pubCredentialName must be set to a String that represents the pub credential JSON.\n'
       'WARNING: Do not check in the content of pub credential JSON, it should only come from secure sources.';
 

--- a/tools/lib/src/publish_command.dart
+++ b/tools/lib/src/publish_command.dart
@@ -256,13 +256,14 @@ Safe to ignore if the package is deleted in this commit.
   }
 
   void _ensureValidPubCredential() {
-    final String credentialsPath = _credentialsPath;
+    final String credentialsPath =
+        _getCredentialsPath(platform: platform, path: path);
     final File credentialFile = packagesDir.fileSystem.file(credentialsPath);
     if (credentialFile.existsSync() &&
         credentialFile.readAsStringSync().isNotEmpty) {
       return;
     }
-    final String? credential = io.Platform.environment[_pubCredentialName];
+    final String? credential = platform.environment[_pubCredentialName];
     if (credential == null) {
       printError('''
 No pub credential available. Please check if `$credentialsPath` is valid.
@@ -270,37 +271,37 @@ If running this command on CI, you can set the pub credential content in the $_p
 ''');
       throw ToolExit(1);
     }
+    credentialFile.createSync(recursive: true);
     credentialFile.openSync(mode: FileMode.writeOnlyAppend)
       ..writeStringSync(credential)
       ..closeSync();
   }
 }
 
-final String _credentialsPath = () {
-  String? cacheDir;
-  final String? pubCache = io.Platform.environment['PUB_CACHE'];
-  if (pubCache != null) {
-    cacheDir = pubCache;
-  } else if (io.Platform.isWindows) {
-    final String? appData = io.Platform.environment['APPDATA'];
-    if (appData == null) {
-      printError('"APPDATA" environment variable is not set.');
-    } else {
-      cacheDir = p.join(appData, 'Pub', 'Cache');
-    }
-  } else {
-    final String? home = io.Platform.environment['HOME'];
+/// The path in which pub expects to find its credentials file.
+String _getCredentialsPath({
+  required Platform platform,
+  required p.Context path,
+}) {
+  // See https://github.com/dart-lang/pub/blob/master/doc/cache_layout.md#layout
+  String? configDir;
+  String? configHome = platform.environment['XDG_CONFIG_HOME'];
+  if (configHome == null) {
+    final String? home = platform.environment['HOME'];
     if (home == null) {
       printError('"HOME" environment variable is not set.');
     } else {
-      cacheDir = p.join(home, '.pub-cache');
+      configHome = path.join(home, '.config');
     }
   }
+  if (configHome != null) {
+    configDir = path.join(configHome, 'dart');
+  }
 
-  if (cacheDir == null) {
-    printError('Unable to determine pub cache location');
+  if (configDir == null) {
+    printError('Unable to determine pub con location');
     throw ToolExit(1);
   }
 
-  return p.join(cacheDir, 'credentials.json');
-}();
+  return path.join(configDir, 'pub-credentials.json');
+}

--- a/tools/pubspec.yaml
+++ b/tools/pubspec.yaml
@@ -1,10 +1,10 @@
 name: flutter_tizen_plugin_tools
 description: Productivity utils for flutter-tizen/plugins.
 repository: https://github.com/flutter-tizen/plugins/tree/master/tools
-publish_to: none
+publish_to: "none"
 
 environment:
-  sdk: ">=2.17.0 <3.0.0"
+  sdk: ">=2.18.0 <4.0.0"
 
 dependencies:
   args: ^2.1.0


### PR DESCRIPTION
The pub cache location has changed in Dart 3.0.

This change should land as soon as possible to fix our [broken CI](https://github.com/flutter-tizen/plugins/actions/runs/5091477987).

Reference: https://github.com/flutter/packages/commit/5b7d732939860d38aeb6d255aa23713788c9833d