### PR TITLE
Change the minimum Tizen version to 5.5

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,14 +18,14 @@ jobs:
             --run-on-changed-packages \
             --base-sha=$(git rev-parse HEAD^))
           if [[ ! -z $CHANGED_PACKAGES ]]; then
-              echo $CHANGED_PACKAGES
-              echo "HAS_CHANGED_PACKAGES=true" >> $GITHUB_ENV
+            echo $CHANGED_PACKAGES
+            echo "HAS_CHANGED_PACKAGES=true" >> $GITHUB_ENV
           fi
       - name: Install Tizen Studio
         if: ${{ env.HAS_CHANGED_PACKAGES == 'true' }}
         run: |
           sudo apt install -y libncurses5 python2.7 libpython2.7 gettext
-          curl http://download.tizen.org/sdk/Installer/tizen-studio_5.0/web-cli_Tizen_Studio_5.0_ubuntu-64.bin -o install.bin
+          curl http://download.tizen.org/sdk/Installer/tizen-studio_5.1/web-cli_Tizen_Studio_5.1_ubuntu-64.bin -o install.bin
           chmod a+x install.bin
           ./install.bin --accept-license $HOME/tizen-studio
           rm install.bin
@@ -33,11 +33,10 @@ jobs:
         if: ${{ env.HAS_CHANGED_PACKAGES == 'true' }}
         run: |
           $HOME/tizen-studio/package-manager/package-manager-cli.bin install \
-          NativeToolchain-Gcc-9.2 \
-          WEARABLE-4.0-NativeAppDevelopment \
-          WEARABLE-5.5-NativeAppDevelopment \
-          WEARABLE-6.0-NativeAppDevelopment \
-          WEARABLE-6.5-NativeAppDevelopment
+            NativeToolchain-Gcc-9.2 \
+            WEARABLE-5.5-NativeAppDevelopment-CLI \
+            WEARABLE-6.0-NativeAppDevelopment-CLI \
+            WEARABLE-6.5-NativeAppDevelopment-CLI
       - name: Create a Tizen certificate profile
         if: ${{ env.HAS_CHANGED_PACKAGES == 'true' }}
         run: |

--- a/README.md
+++ b/README.md
@@ -57,41 +57,41 @@ The _"non-endorsed"_ status means that the plugin is not endorsed by the origina
 
 | Package name | API level | Watch | Watch<br>emulator | TV | TV<br>emulator | Remarks |
 |-|:-:|:-:|:-:|:-:|:-:|-|
-| [**audioplayers_tizen**](packages/audioplayers) | 4.0 | ✔️ | ✔️ | ✔️ | ✔️ |
-| [**battery_plus_tizen**](packages/battery_plus) | 4.0 | ✔️ | ✔️ | ❌ | ❌ | No battery |
-| [**camera_tizen**](packages/camera) | 4.0 | ❌ | ❌ | ❌ | ❌ | No camera |
-| [**connectivity_plus_tizen**](packages/connectivity_plus) | 4.0 | ✔️ | ⚠️ | ✔️ | ✔️ | Returns incorrect connection status |
-| [**device_info_plus_tizen**](packages/device_info_plus) | 4.0 | ✔️ | ✔️ | ✔️ | ✔️ |
-| [**firebase_core**](packages/firebase_core) | 4.0 | ✔️ | ✔️ | ✔️ | ✔️ |
-| [**flutter_app_badger_tizen**](packages/flutter_app_badger) | 4.0 | ✔️ | ✔️ | ❌ | ❌ | API not supported |
-| [**flutter_secure_storage_tizen**](packages/flutter_secure_storage) | 4.0 | ✔️ | ✔️ | ✔️ | ✔️ |
-| [**flutter_tts_tizen**](packages/flutter_tts) | 4.0 | ✔️ | ✔️ | ✔️ | ✔️ |
+| [**audioplayers_tizen**](packages/audioplayers) | 5.5 | ✔️ | ✔️ | ✔️ | ✔️ |
+| [**battery_plus_tizen**](packages/battery_plus) | 5.5 | ✔️ | ✔️ | ❌ | ❌ | No battery |
+| [**camera_tizen**](packages/camera) | 5.5 | ❌ | ❌ | ❌ | ❌ | No camera |
+| [**connectivity_plus_tizen**](packages/connectivity_plus) | 5.5 | ✔️ | ⚠️ | ✔️ | ✔️ | Returns incorrect connection status |
+| [**device_info_plus_tizen**](packages/device_info_plus) | 5.5 | ✔️ | ✔️ | ✔️ | ✔️ |
+| [**firebase_core**](packages/firebase_core) | 5.5 | ✔️ | ✔️ | ✔️ | ✔️ |
+| [**flutter_app_badger_tizen**](packages/flutter_app_badger) | 5.5 | ✔️ | ✔️ | ❌ | ❌ | API not supported |
+| [**flutter_secure_storage_tizen**](packages/flutter_secure_storage) | 5.5 | ✔️ | ✔️ | ✔️ | ✔️ |
+| [**flutter_tts_tizen**](packages/flutter_tts) | 5.5 | ✔️ | ✔️ | ✔️ | ✔️ |
 | [**flutter_webrtc_tizen**](packages/flutter_webrtc) | 6.0 | ❌ | ❌ | ✔️ | ❌ | No camera |
-| [**geolocator_tizen**](packages/geolocator) | 4.0 | ✔️ | ✔️ | ❌ | ❌ | Not applicable for TV |
+| [**geolocator_tizen**](packages/geolocator) | 5.5 | ✔️ | ✔️ | ❌ | ❌ | Not applicable for TV |
 | [**google_maps_flutter_tizen**](packages/google_maps_flutter) | 5.5 | ✔️ | ✔️ | ✔️ | ✔️ |
-| [**google_sign_in_tizen**](packages/google_sign_in) | 4.0 | ✔️ | ✔️ | ✔️ | ✔️ |
+| [**google_sign_in_tizen**](packages/google_sign_in) | 5.5 | ✔️ | ✔️ | ✔️ | ✔️ |
 | [**image_picker_tizen**](packages/image_picker) | 5.5 | ⚠️ | ❌ | ❌ | ❌ | No camera,<br>No file manager app |
-| [**integration_test_tizen**](packages/integration_test) | 4.0 | ✔️ | ✔️ | ✔️ | ✔️ |
-| [**messageport_tizen**](packages/messageport) | 4.0 | ✔️ | ✔️ | ✔️ | ✔️ |
-| [**network_info_plus_tizen**](packages/network_info_plus) | 4.0 | ✔️ | ❌ | ✔️ | ❌ | API not supported on emulator |
-| [**package_info_plus_tizen**](packages/package_info_plus) | 4.0 | ✔️ | ✔️ | ✔️ | ✔️ |
-| [**path_provider_tizen**](packages/path_provider) | 4.0 | ✔️ | ✔️ | ✔️ | ✔️ |
-| [**permission_handler_tizen**](packages/permission_handler) | 4.0 | ✔️ | ✔️ | ⚠️ | ⚠️ | Not applicable for TV |
-| [**sensors_plus_tizen**](packages/sensors_plus) | 4.0 | ✔️ | ✔️ | ❌ | ❌ | No sensor hardware |
-| [**shared_preferences_tizen**](packages/shared_preferences) | 4.0 | ✔️ | ✔️ | ✔️ | ✔️ |
-| [**sqflite_tizen**](packages/sqflite) | 4.0 | ✔️ | ✔️ | ✔️ | ✔️ |
-| [**tizen_app_control**](packages/tizen_app_control) | 4.0 | ✔️ | ✔️ | ✔️ | ✔️ |
-| [**tizen_app_manager**](packages/tizen_app_manager) | 4.0 | ✔️ | ✔️ | ✔️ | ✔️ |
-| [**tizen_audio_manager**](packages/tizen_audio_manager) | 4.0 | ✔️ | ✔️ | ✔️ | ✔️ |
-| [**tizen_bundle**](packages/tizen_bundle) | 4.0 | ✔️ | ✔️ | ✔️ | ✔️ |
-| [**tizen_log**](packages/tizen_log) | 4.0 | ✔️ | ✔️ | ❌ | ❌ | Not applicable for TV |
-| [**tizen_notification**](packages/tizen_notification) | 4.0 | ❌ | ✔️ | ✔️ | ✔️ | API not supported |
-| [**tizen_package_manager**](packages/tizen_package_manager) | 4.0 | ✔️ | ✔️ | ✔️ | ✔️ |
+| [**integration_test_tizen**](packages/integration_test) | 5.5 | ✔️ | ✔️ | ✔️ | ✔️ |
+| [**messageport_tizen**](packages/messageport) | 5.5 | ✔️ | ✔️ | ✔️ | ✔️ |
+| [**network_info_plus_tizen**](packages/network_info_plus) | 5.5 | ✔️ | ❌ | ✔️ | ❌ | API not supported on emulator |
+| [**package_info_plus_tizen**](packages/package_info_plus) | 5.5 | ✔️ | ✔️ | ✔️ | ✔️ |
+| [**path_provider_tizen**](packages/path_provider) | 5.5 | ✔️ | ✔️ | ✔️ | ✔️ |
+| [**permission_handler_tizen**](packages/permission_handler) | 5.5 | ✔️ | ✔️ | ⚠️ | ⚠️ | Not applicable for TV |
+| [**sensors_plus_tizen**](packages/sensors_plus) | 5.5 | ✔️ | ✔️ | ❌ | ❌ | No sensor hardware |
+| [**shared_preferences_tizen**](packages/shared_preferences) | 5.5 | ✔️ | ✔️ | ✔️ | ✔️ |
+| [**sqflite_tizen**](packages/sqflite) | 5.5 | ✔️ | ✔️ | ✔️ | ✔️ |
+| [**tizen_app_control**](packages/tizen_app_control) | 5.5 | ✔️ | ✔️ | ✔️ | ✔️ |
+| [**tizen_app_manager**](packages/tizen_app_manager) | 5.5 | ✔️ | ✔️ | ✔️ | ✔️ |
+| [**tizen_audio_manager**](packages/tizen_audio_manager) | 5.5 | ✔️ | ✔️ | ✔️ | ✔️ |
+| [**tizen_bundle**](packages/tizen_bundle) | 5.5 | ✔️ | ✔️ | ✔️ | ✔️ |
+| [**tizen_log**](packages/tizen_log) | 5.5 | ✔️ | ✔️ | ❌ | ❌ | Not applicable for TV |
+| [**tizen_notification**](packages/tizen_notification) | 5.5 | ❌ | ✔️ | ✔️ | ✔️ | API not supported |
+| [**tizen_package_manager**](packages/tizen_package_manager) | 5.5 | ✔️ | ✔️ | ✔️ | ✔️ |
 | [**tizen_rpc_port**](packages/tizen_rpc_port) | 6.5 | ✔️ | ✔️ | ✔️ | ✔️ |
-| [**url_launcher_tizen**](packages/url_launcher) | 4.0 | ✔️ | ❌ | ✔️ | ❌ | No browser app |
-| [**video_player_tizen**](packages/video_player) | 4.0 | ✔️ | ✔️ | ✔️ | ❌ | TV emulator issue |
-| [**video_player_videohole**](packages/video_player_videohole) | 4.0 | ❌ | ❌ | ✔️ | ❌ | Only for TV devices |
-| [**wakelock_tizen**](packages/wakelock) | 4.0 | ✔️ | ✔️ | ❌ | ❌ | Cannot override system settings |
-| [**wearable_rotary**](packages/wearable_rotary) | 4.0 | ✔️ | ✔️ | ❌ | ❌ | Not applicable for TV |
+| [**url_launcher_tizen**](packages/url_launcher) | 5.5 | ✔️ | ❌ | ✔️ | ❌ | No browser app |
+| [**video_player_tizen**](packages/video_player) | 5.5 | ✔️ | ✔️ | ✔️ | ❌ | TV emulator issue |
+| [**video_player_videohole**](packages/video_player_videohole) | 5.5 | ❌ | ❌ | ✔️ | ❌ | Only for TV devices |
+| [**wakelock_tizen**](packages/wakelock) | 5.5 | ✔️ | ✔️ | ❌ | ❌ | Cannot override system settings |
+| [**wearable_rotary**](packages/wearable_rotary) | 5.5 | ✔️ | ✔️ | ❌ | ❌ | Not applicable for TV |
 | [**webview_flutter_lwe**](packages/webview_flutter_lwe) | 5.5 | ✔️ | ✔️ | ✔️ | ✔️ | Not for production use |
 | [**webview_flutter_tizen**](packages/webview_flutter) | 5.5 | ❌ | ❌ | ✔️ | ✔️ | API not supported |

--- a/packages/audioplayers/example/tizen/tizen-manifest.xml
+++ b/packages/audioplayers/example/tizen/tizen-manifest.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest package="org.tizen.audioplayers_tizen_example" version="1.0.0" api-version="4.0" xmlns="http://tizen.org/ns/packages">
+<manifest package="org.tizen.audioplayers_tizen_example" version="1.0.0" api-version="5.5" xmlns="http://tizen.org/ns/packages">
     <profile name="common"/>
     <ui-application appid="org.tizen.audioplayers_tizen_example" exec="Runner.dll" type="dotnet" multiple="false" taskmanage="true" nodisplay="false">
         <label>audioplayers_tizen_example</label>

--- a/packages/audioplayers/tizen/project_def.prop
+++ b/packages/audioplayers/tizen/project_def.prop
@@ -3,7 +3,7 @@
 
 APPNAME = audioplayers_tizen_plugin
 type = staticLib
-profile = common-4.0
+profile = common-5.5
 
 # Source files
 USER_SRCS += src/*.cc

--- a/packages/battery_plus/README.md
+++ b/packages/battery_plus/README.md
@@ -31,4 +31,4 @@ For detailed usage, see https://pub.dev/packages/battery_plus#usage.
 
 ## Supported devices
 
-- Galaxy Watch series (running Tizen 4.0 or later)
+- Galaxy Watch series (running Tizen 5.5)

--- a/packages/battery_plus/example/tizen/tizen-manifest.xml
+++ b/packages/battery_plus/example/tizen/tizen-manifest.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest package="org.tizen.battery_plus_example" version="1.0.0" api-version="4.0" xmlns="http://tizen.org/ns/packages">
+<manifest package="org.tizen.battery_plus_example" version="1.0.0" api-version="5.5" xmlns="http://tizen.org/ns/packages">
     <profile name="wearable"/>
     <ui-application appid="org.tizen.battery_plus_example" exec="Runner.dll" type="dotnet" multiple="false" taskmanage="true" nodisplay="false">
         <label>battery_plus_tizen_example</label>

--- a/packages/battery_plus/tizen/project_def.prop
+++ b/packages/battery_plus/tizen/project_def.prop
@@ -3,7 +3,7 @@
 
 APPNAME = battery_plus_tizen_plugin
 type = staticLib
-profile = common-4.0
+profile = common-5.5
 
 # Source files
 USER_SRCS += src/*.cc

--- a/packages/camera/example/tizen/tizen-manifest.xml
+++ b/packages/camera/example/tizen/tizen-manifest.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest package="org.tizen.camera_plugin_example" version="1.0.0" api-version="4.0" xmlns="http://tizen.org/ns/packages">
+<manifest package="org.tizen.camera_plugin_example" version="1.0.0" api-version="5.5" xmlns="http://tizen.org/ns/packages">
     <profile name="common"/>
     <ui-application appid="org.tizen.camera_plugin_example" exec="Runner.dll" type="dotnet" multiple="false" taskmanage="true" nodisplay="false">
         <label>camera_plugin_example</label>

--- a/packages/camera/tizen/project_def.prop
+++ b/packages/camera/tizen/project_def.prop
@@ -3,7 +3,7 @@
 
 APPNAME = camera_plugin
 type = staticLib
-profile = common-4.0
+profile = common-5.5
 
 # Source files
 USER_SRCS += src/*.cc

--- a/packages/connectivity_plus/example/tizen/tizen-manifest.xml
+++ b/packages/connectivity_plus/example/tizen/tizen-manifest.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest package="org.tizen.connectivity_plus_tizen_example" version="1.0.0" api-version="4.0" xmlns="http://tizen.org/ns/packages">
+<manifest package="org.tizen.connectivity_plus_tizen_example" version="1.0.0" api-version="5.5" xmlns="http://tizen.org/ns/packages">
     <profile name="common"/>
     <ui-application appid="org.tizen.connectivity_plus_tizen_example" exec="Runner.dll" type="dotnet" multiple="false" taskmanage="true" nodisplay="false">
         <label>connectivity_plus_tizen_example</label>

--- a/packages/connectivity_plus/tizen/project_def.prop
+++ b/packages/connectivity_plus/tizen/project_def.prop
@@ -3,7 +3,7 @@
 
 APPNAME = connectivity_plus_tizen_plugin
 type = staticLib
-profile = common-4.0
+profile = common-5.5
 
 # Source files
 USER_SRCS += src/*.cc

--- a/packages/device_info_plus/example/tizen/tizen-manifest.xml
+++ b/packages/device_info_plus/example/tizen/tizen-manifest.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest package="org.tizen.device_info_plus_tizen_example" version="1.0.0" api-version="4.0" xmlns="http://tizen.org/ns/packages">
+<manifest package="org.tizen.device_info_plus_tizen_example" version="1.0.0" api-version="5.5" xmlns="http://tizen.org/ns/packages">
     <profile name="common"/>
     <ui-application appid="org.tizen.device_info_plus_tizen_example" exec="Runner.dll" type="dotnet" multiple="false" taskmanage="true" nodisplay="false">
         <label>device_info_plus_tizen_example</label>

--- a/packages/device_info_plus/tizen/project_def.prop
+++ b/packages/device_info_plus/tizen/project_def.prop
@@ -3,7 +3,7 @@
 
 APPNAME = device_info_plus_tizen_plugin
 type = staticLib
-profile = common-4.0
+profile = common-5.5
 
 # Source files
 USER_SRCS += src/*.cc

--- a/packages/firebase_core/example/tizen/tizen-manifest.xml
+++ b/packages/firebase_core/example/tizen/tizen-manifest.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest package="org.tizen.firebase_core_tizen_example" version="1.0.0" api-version="4.0" xmlns="http://tizen.org/ns/packages">
+<manifest package="org.tizen.firebase_core_tizen_example" version="1.0.0" api-version="5.5" xmlns="http://tizen.org/ns/packages">
     <profile name="common"/>
     <ui-application appid="org.tizen.firebase_core_tizen_example" exec="Runner.dll" type="dotnet" multiple="false" nodisplay="false" taskmanage="true">
         <label>firebase_core_tizen_example</label>

--- a/packages/flutter_app_badger/README.md
+++ b/packages/flutter_app_badger/README.md
@@ -34,7 +34,7 @@ To use this plugin, you need to declare privileges in `tizen-manifest.xml` of yo
 
 ## Supported devices
 
-- Galaxy Watch series (running Tizen 4.0 or later)
+- Galaxy Watch series (running Tizen 5.5)
 
 ## Notes
 

--- a/packages/flutter_app_badger/example/tizen/tizen-manifest.xml
+++ b/packages/flutter_app_badger/example/tizen/tizen-manifest.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest package="org.tizen.flutter_app_badger_tizen_example" version="1.0.0" api-version="4.0" xmlns="http://tizen.org/ns/packages">
+<manifest package="org.tizen.flutter_app_badger_tizen_example" version="1.0.0" api-version="5.5" xmlns="http://tizen.org/ns/packages">
     <profile name="common"/>
     <ui-application appid="org.tizen.flutter_app_badger_tizen_example" exec="Runner.dll" type="dotnet" multiple="false" nodisplay="false" taskmanage="true">
         <label>flutter_app_badger_tizen_example</label>

--- a/packages/flutter_app_badger/tizen/project_def.prop
+++ b/packages/flutter_app_badger/tizen/project_def.prop
@@ -3,7 +3,7 @@
 
 APPNAME = flutter_app_badger_tizen_plugin
 type = staticLib
-profile = common-4.0
+profile = common-5.5
 
 # Source files
 USER_SRCS += src/*.cc

--- a/packages/flutter_secure_storage/example/tizen/tizen-manifest.xml
+++ b/packages/flutter_secure_storage/example/tizen/tizen-manifest.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest package="org.tizen.flutter_secure_storage_tizen_example" version="1.0.0" api-version="4.0" xmlns="http://tizen.org/ns/packages">
+<manifest package="org.tizen.flutter_secure_storage_tizen_example" version="1.0.0" api-version="5.5" xmlns="http://tizen.org/ns/packages">
     <profile name="common" />
     <ui-application appid="org.tizen.flutter_secure_storage_tizen_example" exec="Runner.dll" type="dotnet" multiple="false" nodisplay="false" taskmanage="true">
         <label>flutter_secure_storage_tizen_example</label>

--- a/packages/flutter_secure_storage/tizen/project_def.prop
+++ b/packages/flutter_secure_storage/tizen/project_def.prop
@@ -3,7 +3,7 @@
 
 APPNAME = flutter_secure_storage_tizen_plugin
 type = staticLib
-profile = common-4.0
+profile = common-5.5
 
 # Source files
 USER_SRCS += src/*.cc

--- a/packages/flutter_tts/example/tizen/tizen-manifest.xml
+++ b/packages/flutter_tts/example/tizen/tizen-manifest.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest package="org.tizen.flutter_tts_tizen_example" version="1.0.0" api-version="4.0" xmlns="http://tizen.org/ns/packages">
+<manifest package="org.tizen.flutter_tts_tizen_example" version="1.0.0" api-version="5.5" xmlns="http://tizen.org/ns/packages">
     <profile name="common"/>
     <ui-application appid="org.tizen.flutter_tts_tizen_example" exec="Runner.dll" type="dotnet" multiple="false" taskmanage="true" nodisplay="false">
         <label>flutter_tts_tizen_example</label>

--- a/packages/flutter_tts/tizen/project_def.prop
+++ b/packages/flutter_tts/tizen/project_def.prop
@@ -3,7 +3,7 @@
 
 APPNAME = flutter_tts_tizen_plugin
 type = staticLib
-profile = common-4.0
+profile = common-5.5
 
 # Source files
 USER_SRCS += src/*.cc

--- a/packages/geolocator/README.md
+++ b/packages/geolocator/README.md
@@ -36,7 +36,7 @@ To use this plugin, you need to declare privileges in `tizen-manifest.xml` of yo
 
 ## Supported devices
 
-- Galaxy Watch series (running Tizen 4.0 or later)
+- Galaxy Watch series (running Tizen 5.5)
 
 ## Supported APIs
 

--- a/packages/geolocator/example/tizen/tizen-manifest.xml
+++ b/packages/geolocator/example/tizen/tizen-manifest.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest package="org.tizen.geolocator_example" version="1.0.0" api-version="4.0" xmlns="http://tizen.org/ns/packages">
+<manifest package="org.tizen.geolocator_example" version="1.0.0" api-version="5.5" xmlns="http://tizen.org/ns/packages">
     <profile name="wearable"/>
     <ui-application appid="org.tizen.geolocator_example" exec="Runner.dll" type="dotnet" multiple="false" nodisplay="false" taskmanage="true">
         <label>geolocator_example</label>

--- a/packages/geolocator/tizen/project_def.prop
+++ b/packages/geolocator/tizen/project_def.prop
@@ -3,7 +3,7 @@
 
 APPNAME = geolocator_tizen_plugin
 type = staticLib
-profile = common-4.0
+profile = common-5.5
 
 # Source files
 USER_SRCS += src/*.cc

--- a/packages/google_sign_in/example/tizen/tizen-manifest.xml
+++ b/packages/google_sign_in/example/tizen/tizen-manifest.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest package="org.tizen.google_sign_in_tizen_example" version="1.0.0" api-version="4.0" xmlns="http://tizen.org/ns/packages">
+<manifest package="org.tizen.google_sign_in_tizen_example" version="1.0.0" api-version="5.5" xmlns="http://tizen.org/ns/packages">
     <profile name="common"/>
     <ui-application appid="org.tizen.google_sign_in_tizen_example" exec="Runner.dll" type="dotnet" multiple="false" nodisplay="false" taskmanage="true">
         <label>google_sign_in_tizen_example</label>

--- a/packages/integration_test/example/tizen/tizen-manifest.xml
+++ b/packages/integration_test/example/tizen/tizen-manifest.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest package="org.tizen.integration_test_example" version="1.0.0" api-version="4.0" xmlns="http://tizen.org/ns/packages">
+<manifest package="org.tizen.integration_test_example" version="1.0.0" api-version="5.5" xmlns="http://tizen.org/ns/packages">
     <profile name="common"/>
     <ui-application appid="org.tizen.integration_test_example" exec="Runner.dll" type="dotnet" multiple="false" taskmanage="true" nodisplay="false">
         <label>integration_test_example</label>

--- a/packages/integration_test/tizen/project_def.prop
+++ b/packages/integration_test/tizen/project_def.prop
@@ -3,7 +3,7 @@
 
 APPNAME = integration_test_plugin
 type = staticLib
-profile = common-4.0
+profile = common-5.5
 
 # Source files
 USER_SRCS += src/*.cc

--- a/packages/messageport/example/tizen/tizen-manifest.xml
+++ b/packages/messageport/example/tizen/tizen-manifest.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest package="org.tizen.messageport_tizen_example" version="1.0.0" api-version="4.0" xmlns="http://tizen.org/ns/packages">
+<manifest package="org.tizen.messageport_tizen_example" version="1.0.0" api-version="5.5" xmlns="http://tizen.org/ns/packages">
     <profile name="common"/>
     <ui-application appid="org.tizen.messageport_tizen_example" exec="Runner.dll" type="dotnet" multiple="false" taskmanage="true" nodisplay="false">
         <label>MessagePort Tizen Example</label>

--- a/packages/messageport/tizen/project_def.prop
+++ b/packages/messageport/tizen/project_def.prop
@@ -3,7 +3,7 @@
 
 APPNAME = messageport_tizen_plugin
 type = staticLib
-profile = common-4.0
+profile = common-5.5
 
 # Source files
 USER_SRCS += src/*.cc

--- a/packages/network_info_plus/example/tizen/tizen-manifest.xml
+++ b/packages/network_info_plus/example/tizen/tizen-manifest.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest package="org.tizen.network_info_plus_tizen_example" version="1.0.0" api-version="4.0" xmlns="http://tizen.org/ns/packages">
+<manifest package="org.tizen.network_info_plus_tizen_example" version="1.0.0" api-version="5.5" xmlns="http://tizen.org/ns/packages">
     <profile name="common"/>
     <ui-application appid="org.tizen.network_info_plus_tizen_example" exec="Runner.dll" type="dotnet" multiple="false" taskmanage="true" nodisplay="false">
         <label>network_info_plus_tizen_example</label>

--- a/packages/network_info_plus/tizen/project_def.prop
+++ b/packages/network_info_plus/tizen/project_def.prop
@@ -3,7 +3,7 @@
 
 APPNAME = network_info_plus_tizen_plugin
 type = staticLib
-profile = common-4.0
+profile = common-5.5
 
 # Source files
 USER_SRCS += src/*.cc

--- a/packages/package_info_plus/example/tizen/tizen-manifest.xml
+++ b/packages/package_info_plus/example/tizen/tizen-manifest.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest package="org.tizen.package_info_plus_tizen_example" version="1.2.3" api-version="4.0" xmlns="http://tizen.org/ns/packages">
+<manifest package="org.tizen.package_info_plus_tizen_example" version="1.2.3" api-version="5.5" xmlns="http://tizen.org/ns/packages">
     <profile name="common"/>
     <ui-application appid="org.tizen.package_info_plus_tizen_example" exec="Runner.dll" type="dotnet" multiple="false" taskmanage="true" nodisplay="false">
         <label>package_info_plus_tizen_example</label>

--- a/packages/package_info_plus/tizen/project_def.prop
+++ b/packages/package_info_plus/tizen/project_def.prop
@@ -3,7 +3,7 @@
 
 APPNAME = package_info_plus_tizen_plugin
 type = staticLib
-profile = common-4.0
+profile = common-5.5
 
 # Source files
 USER_SRCS += src/*.cc

--- a/packages/path_provider/example/tizen/tizen-manifest.xml
+++ b/packages/path_provider/example/tizen/tizen-manifest.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest package="org.tizen.path_provider_tizen_example" version="1.0.0" api-version="4.0" xmlns="http://tizen.org/ns/packages">
+<manifest package="org.tizen.path_provider_tizen_example" version="1.0.0" api-version="5.5" xmlns="http://tizen.org/ns/packages">
     <profile name="common"/>
     <ui-application appid="org.tizen.path_provider_tizen_example" exec="Runner.dll" type="dotnet" multiple="false" taskmanage="true" nodisplay="false">
         <label>path_provider_tizen_example</label>

--- a/packages/permission_handler/README.md
+++ b/packages/permission_handler/README.md
@@ -56,7 +56,7 @@ On Tizen, your app can use some security-sensitive features (such as bluetooth) 
 
 ## Supported devices
 
-- Galaxy Watch series (running Tizen 4.0 or later)
+- Galaxy Watch series (running Tizen 5.5)
 
 On TV devices, you don't need to explicitly request permissions since they are already granted to apps by default.
 

--- a/packages/permission_handler/example/tizen/tizen-manifest.xml
+++ b/packages/permission_handler/example/tizen/tizen-manifest.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest package="org.tizen.permission_handler_tizen_example" version="1.0.0" api-version="4.0" xmlns="http://tizen.org/ns/packages">
+<manifest package="org.tizen.permission_handler_tizen_example" version="1.0.0" api-version="5.5" xmlns="http://tizen.org/ns/packages">
     <profile name="wearable"/>
     <ui-application appid="org.tizen.permission_handler_tizen_example" exec="Runner.dll" type="dotnet" multiple="false" taskmanage="true" nodisplay="false">
         <label>permission_handler_tizen_example</label>

--- a/packages/permission_handler/tizen/project_def.prop
+++ b/packages/permission_handler/tizen/project_def.prop
@@ -3,7 +3,7 @@
 
 APPNAME = permission_handler_tizen_plugin
 type = staticLib
-profile = common-4.0
+profile = common-5.5
 
 # Source files
 USER_SRCS += src/*.cc

--- a/packages/sensors_plus/README.md
+++ b/packages/sensors_plus/README.md
@@ -24,7 +24,7 @@ For detailed usage, see https://pub.dev/packages/sensors_plus#usage.
 
 ## Supported devices
 
-- Galaxy Watch series (running Tizen 4.0 or later)
+- Galaxy Watch series (running Tizen 5.5)
 
 ## Supported APIs
 

--- a/packages/sensors_plus/example/tizen/tizen-manifest.xml
+++ b/packages/sensors_plus/example/tizen/tizen-manifest.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest package="org.tizen.sensors_plus_example" version="1.0.0" api-version="4.0" xmlns="http://tizen.org/ns/packages">
+<manifest package="org.tizen.sensors_plus_example" version="1.0.0" api-version="5.5" xmlns="http://tizen.org/ns/packages">
     <profile name="wearable"/>
     <ui-application appid="org.tizen.sensors_plus_example" exec="Runner.dll" type="dotnet" multiple="false" taskmanage="true" nodisplay="false">
         <label>sensors_plus_example</label>

--- a/packages/sensors_plus/tizen/project_def.prop
+++ b/packages/sensors_plus/tizen/project_def.prop
@@ -3,7 +3,7 @@
 
 APPNAME = sensors_plus_plugin
 type = staticLib
-profile = common-4.0
+profile = common-5.5
 
 # Source files
 USER_SRCS += src/*.cc

--- a/packages/shared_preferences/example/tizen/tizen-manifest.xml
+++ b/packages/shared_preferences/example/tizen/tizen-manifest.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest package="org.tizen.shared_preferences_tizen_example" version="1.0.0" api-version="4.0" xmlns="http://tizen.org/ns/packages">
+<manifest package="org.tizen.shared_preferences_tizen_example" version="1.0.0" api-version="5.5" xmlns="http://tizen.org/ns/packages">
     <profile name="common"/>
     <ui-application appid="org.tizen.shared_preferences_tizen_example" exec="Runner.dll" type="dotnet" multiple="false" taskmanage="true" nodisplay="false">
         <label>shared_preferences_tizen_example</label>

--- a/packages/sqflite/example/tizen/tizen-manifest.xml
+++ b/packages/sqflite/example/tizen/tizen-manifest.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest package="org.tizen.sqflite_example" version="1.0.0" api-version="4.0" xmlns="http://tizen.org/ns/packages">
+<manifest package="org.tizen.sqflite_example" version="1.0.0" api-version="5.5" xmlns="http://tizen.org/ns/packages">
     <profile name="wearable"/>
     <ui-application appid="org.tizen.sqflite_example" exec="Runner.dll" type="dotnet" multiple="false" nodisplay="false" taskmanage="true">
         <label>sqflite_example</label>

--- a/packages/sqflite/tizen/project_def.prop
+++ b/packages/sqflite/tizen/project_def.prop
@@ -3,7 +3,7 @@
 
 APPNAME = sqflite_plugin
 type = staticLib
-profile = common-4.0
+profile = common-5.5
 
 # Source files
 USER_SRCS += src/*.cc

--- a/packages/tizen_app_control/example/tizen/service/project_def.prop
+++ b/packages/tizen_app_control/example/tizen/service/project_def.prop
@@ -3,7 +3,7 @@
 
 APPNAME = runner_service
 type = app
-profile = common-4.0
+profile = common-5.5
 
 # Source files
 USER_SRCS += src/runner.cc

--- a/packages/tizen_app_control/example/tizen/service/tizen-manifest.xml
+++ b/packages/tizen_app_control/example/tizen/service/tizen-manifest.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest package="org.tizen.tizen_app_control_example" version="1.0.0" api-version="4.0" xmlns="http://tizen.org/ns/packages">
+<manifest package="org.tizen.tizen_app_control_example" version="1.0.0" api-version="5.5" xmlns="http://tizen.org/ns/packages">
     <profile name="wearable"/>
     <service-application appid="org.tizen.tizen_app_control_example_service" exec="runner_service" type="capp" multiple="false" nodisplay="true" taskmanage="false" auto-restart="false">
         <label>tizen_app_control_example</label>

--- a/packages/tizen_app_control/example/tizen/ui/project_def.prop
+++ b/packages/tizen_app_control/example/tizen/ui/project_def.prop
@@ -3,7 +3,7 @@
 
 APPNAME = runner
 type = app
-profile = common-4.0
+profile = common-5.5
 
 # Source files
 USER_SRCS += src/runner.cc

--- a/packages/tizen_app_control/example/tizen/ui/tizen-manifest.xml
+++ b/packages/tizen_app_control/example/tizen/ui/tizen-manifest.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest package="org.tizen.tizen_app_control_example" version="1.0.0" api-version="4.0" xmlns="http://tizen.org/ns/packages">
+<manifest package="org.tizen.tizen_app_control_example" version="1.0.0" api-version="5.5" xmlns="http://tizen.org/ns/packages">
     <profile name="wearable"/>
     <ui-application appid="org.tizen.tizen_app_control_example" exec="runner" type="capp" multiple="false" nodisplay="false" taskmanage="true" hw-acceleration="on">
         <label>tizen_app_control_example</label>

--- a/packages/tizen_app_manager/example/tizen/tizen-manifest.xml
+++ b/packages/tizen_app_manager/example/tizen/tizen-manifest.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest package="org.tizen.tizen_app_manager_example" version="1.0.0" api-version="4.0" xmlns="http://tizen.org/ns/packages">
+<manifest package="org.tizen.tizen_app_manager_example" version="1.0.0" api-version="5.5" xmlns="http://tizen.org/ns/packages">
     <profile name="common"/>
     <ui-application appid="org.tizen.tizen_app_manager_example" exec="Runner.dll" type="dotnet" multiple="false" nodisplay="false" taskmanage="true">
         <label>tizen_app_manager_example</label>

--- a/packages/tizen_app_manager/tizen/project_def.prop
+++ b/packages/tizen_app_manager/tizen/project_def.prop
@@ -3,7 +3,7 @@
 
 APPNAME = tizen_app_manager_plugin
 type = staticLib
-profile = common-4.0
+profile = common-5.5
 
 # Source files
 USER_SRCS += src/*.cc

--- a/packages/tizen_audio_manager/example/tizen/tizen-manifest.xml
+++ b/packages/tizen_audio_manager/example/tizen/tizen-manifest.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest package="org.tizen.tizen_audio_manager_example" version="1.0.0" api-version="4.0" xmlns="http://tizen.org/ns/packages">
+<manifest package="org.tizen.tizen_audio_manager_example" version="1.0.0" api-version="5.5" xmlns="http://tizen.org/ns/packages">
     <profile name="common"/>
     <ui-application appid="org.tizen.tizen_audio_manager_example" exec="Runner.dll" type="dotnet" multiple="false" nodisplay="false" taskmanage="true">
         <label>tizen_audio_manager_example</label>

--- a/packages/tizen_audio_manager/tizen/project_def.prop
+++ b/packages/tizen_audio_manager/tizen/project_def.prop
@@ -3,7 +3,7 @@
 
 APPNAME = tizen_audio_manager_plugin
 type = staticLib
-profile = common-4.0
+profile = common-5.5
 
 # Source files
 USER_SRCS += src/*.cc

--- a/packages/tizen_bundle/example/tizen/tizen-manifest.xml
+++ b/packages/tizen_bundle/example/tizen/tizen-manifest.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest package="org.tizen.tizen_bundle_example" version="1.0.0" api-version="4.0" xmlns="http://tizen.org/ns/packages">
+<manifest package="org.tizen.tizen_bundle_example" version="1.0.0" api-version="5.5" xmlns="http://tizen.org/ns/packages">
     <profile name="common"/>
     <ui-application appid="org.tizen.tizen_bundle_example" exec="Runner.dll" type="dotnet" multiple="false" nodisplay="false" taskmanage="true">
         <label>tizen_bundle_example</label>

--- a/packages/tizen_log/README.md
+++ b/packages/tizen_log/README.md
@@ -59,4 +59,4 @@ $ sdb dlog TEST  # Replace TEST with your log tag.
 
 ## Supported devices
 
-- Galaxy Watch series (running Tizen 4.0 or later)
+- Galaxy Watch series (running Tizen 5.5)

--- a/packages/tizen_log/example/tizen/tizen-manifest.xml
+++ b/packages/tizen_log/example/tizen/tizen-manifest.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest package="org.tizen.tizen_log_example" version="1.0.0" api-version="4.0" xmlns="http://tizen.org/ns/packages">
+<manifest package="org.tizen.tizen_log_example" version="1.0.0" api-version="5.5" xmlns="http://tizen.org/ns/packages">
     <profile name="common"/>
     <ui-application appid="org.tizen.tizen_log_example" exec="Runner.dll" type="dotnet" multiple="false" nodisplay="false" taskmanage="true">
         <label>tizen_log_example</label>

--- a/packages/tizen_notification/example/tizen/tizen-manifest.xml
+++ b/packages/tizen_notification/example/tizen/tizen-manifest.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest package="org.tizen.tizen_notification_example" version="1.0.0" api-version="4.0" xmlns="http://tizen.org/ns/packages">
+<manifest package="org.tizen.tizen_notification_example" version="1.0.0" api-version="5.5" xmlns="http://tizen.org/ns/packages">
     <profile name="common"/>
     <ui-application appid="org.tizen.tizen_notification_example" exec="Runner.dll" type="dotnet" multiple="false" nodisplay="false" taskmanage="true">
         <label>tizen_notification_example</label>

--- a/packages/tizen_notification/tizen/project_def.prop
+++ b/packages/tizen_notification/tizen/project_def.prop
@@ -3,7 +3,7 @@
 
 APPNAME = tizen_notification_plugin
 type = staticLib
-profile = common-4.0
+profile = common-5.5
 
 # Source files
 USER_SRCS += src/*.cc

--- a/packages/tizen_package_manager/example/tizen/tizen-manifest.xml
+++ b/packages/tizen_package_manager/example/tizen/tizen-manifest.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest package="org.tizen.tizen_package_manager_example" version="1.0.0" api-version="4.0" xmlns="http://tizen.org/ns/packages">
+<manifest package="org.tizen.tizen_package_manager_example" version="1.0.0" api-version="5.5" xmlns="http://tizen.org/ns/packages">
     <profile name="common"/>
     <ui-application appid="org.tizen.tizen_package_manager_example" exec="Runner.dll" type="dotnet" multiple="false" nodisplay="false" taskmanage="true">
         <label>tizen_package_manager_example</label>

--- a/packages/tizen_package_manager/tizen/project_def.prop
+++ b/packages/tizen_package_manager/tizen/project_def.prop
@@ -3,7 +3,7 @@
 
 APPNAME = tizen_package_manager_plugin
 type = staticLib
-profile = common-4.0
+profile = common-5.5
 
 # Source files
 USER_SRCS += src/*.cc

--- a/packages/url_launcher/example/tizen/tizen-manifest.xml
+++ b/packages/url_launcher/example/tizen/tizen-manifest.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest package="org.tizen.url_launcher_example" version="1.0.0" api-version="4.0" xmlns="http://tizen.org/ns/packages">
+<manifest package="org.tizen.url_launcher_example" version="1.0.0" api-version="5.5" xmlns="http://tizen.org/ns/packages">
     <profile name="common"/>
     <ui-application appid="org.tizen.url_launcher_example" exec="Runner.dll" type="dotnet" multiple="false" taskmanage="true" nodisplay="false">
         <label>url_launcher_example</label>

--- a/packages/video_player/README.md
+++ b/packages/video_player/README.md
@@ -6,7 +6,7 @@ The Tizen implementation of [`video_player`](https://pub.dev/packages/video_play
 
 ## Supported devices
 
-This plugin is **NOT** supported on TV emulators. This plugin is supported on Galaxy Watch devices and Smart TVs running Tizen 4.0 or above.
+This plugin is **NOT** supported on TV emulators. This plugin is supported on Galaxy Watch devices and Smart TVs running Tizen 5.5 or above.
 
 ## Usage
 

--- a/packages/video_player/example/tizen/tizen-manifest.xml
+++ b/packages/video_player/example/tizen/tizen-manifest.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest package="org.tizen.video_player_tizen_example" version="1.0.0" api-version="4.0" xmlns="http://tizen.org/ns/packages">
+<manifest package="org.tizen.video_player_tizen_example" version="1.0.0" api-version="5.5" xmlns="http://tizen.org/ns/packages">
     <profile name="common"/>
     <ui-application appid="org.tizen.video_player_tizen_example" exec="Runner.dll" type="dotnet" multiple="false" taskmanage="true" nodisplay="false">
         <label>video_player_tizen_example</label>

--- a/packages/video_player/tizen/project_def.prop
+++ b/packages/video_player/tizen/project_def.prop
@@ -3,7 +3,7 @@
 
 APPNAME = video_player_tizen_plugin
 type = staticLib
-profile = common-4.0
+profile = common-5.5
 
 # Source files
 USER_SRCS += src/*.cc

--- a/packages/video_player_videohole/example/tizen/tizen-manifest.xml
+++ b/packages/video_player_videohole/example/tizen/tizen-manifest.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest package="org.tizen.video_player_videohole_example" version="1.0.0" api-version="4.0" xmlns="http://tizen.org/ns/packages">
+<manifest package="org.tizen.video_player_videohole_example" version="1.0.0" api-version="5.5" xmlns="http://tizen.org/ns/packages">
     <profile name="tv"/>
     <ui-application appid="org.tizen.video_player_videohole_example" exec="Runner.dll" type="dotnet" multiple="false" taskmanage="true" nodisplay="false">
         <label>video_player_videohole_example</label>

--- a/packages/video_player_videohole/tizen/project_def.prop
+++ b/packages/video_player_videohole/tizen/project_def.prop
@@ -3,7 +3,7 @@
 
 APPNAME = video_player_tizen_plugin
 type = staticLib
-profile = common-4.0
+profile = common-5.5
 
 # Source files
 USER_SRCS += src/*.cc

--- a/packages/wakelock/README.md
+++ b/packages/wakelock/README.md
@@ -34,4 +34,4 @@ To use the wakelock plugin in a Tizen application, the display privilege must be
 
 ## Supported devices
 
-- Galaxy Watch series (running Tizen 4.0 or later)
+- Galaxy Watch series (running Tizen 5.5)

--- a/packages/wakelock/example/tizen/tizen-manifest.xml
+++ b/packages/wakelock/example/tizen/tizen-manifest.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest package="org.tizen.wakelock_tizen_example" version="1.0.0" api-version="4.0" xmlns="http://tizen.org/ns/packages">
+<manifest package="org.tizen.wakelock_tizen_example" version="1.0.0" api-version="5.5" xmlns="http://tizen.org/ns/packages">
     <profile name="wearable"/>
     <ui-application appid="org.tizen.wakelock_tizen_example" exec="Runner.dll" type="dotnet" multiple="false" taskmanage="true" nodisplay="false">
         <label>wakelock_tizen_example</label>

--- a/packages/wakelock/tizen/project_def.prop
+++ b/packages/wakelock/tizen/project_def.prop
@@ -3,7 +3,7 @@
 
 APPNAME = wakelock_tizen_plugin
 type = staticLib
-profile = common-4.0
+profile = common-5.5
 
 # Source files
 USER_SRCS += src/*.cc

--- a/packages/wearable_rotary/README.md
+++ b/packages/wearable_rotary/README.md
@@ -59,4 +59,4 @@ ListView(controller: RotaryScrollController());
 ## Supported devices
 
 - Wear OS devices with rotary input (Galaxy Watch 4, Pixel Watch, etc.)
-- Galaxy Watch series (running Tizen 4.0 or later)
+- Galaxy Watch series (running Tizen 5.5)

--- a/packages/wearable_rotary/example/tizen/tizen-manifest.xml
+++ b/packages/wearable_rotary/example/tizen/tizen-manifest.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest package="org.tizen.wearable_rotary_example" version="1.0.0" api-version="4.0" xmlns="http://tizen.org/ns/packages">
+<manifest package="org.tizen.wearable_rotary_example" version="1.0.0" api-version="5.5" xmlns="http://tizen.org/ns/packages">
     <profile name="wearable"/>
     <ui-application appid="org.tizen.wearable_rotary_example" exec="Runner.dll" type="dotnet" multiple="false" taskmanage="true" nodisplay="false">
         <label>wearable_rotary_example</label>

--- a/packages/wearable_rotary/tizen/project_def.prop
+++ b/packages/wearable_rotary/tizen/project_def.prop
@@ -3,7 +3,7 @@
 
 APPNAME = wearable_rotary_plugin
 type = staticLib
-profile = common-4.0
+profile = common-5.5
 
 # Source files
 USER_SRCS += src/*.cc

--- a/tools/lib/src/integration_test_command.dart
+++ b/tools/lib/src/integration_test_command.dart
@@ -52,7 +52,7 @@ class IntegrationTestCommand extends PackageLoopingCommand {
           'plugins:\n'
           '  a: [wearable-5.5, tv-6.0]\n'
           '  b: [mobile-6.0]\n'
-          '  c: [wearable-4.0]\n'
+          '  c: [wearable-5.5]\n'
           '  d: [] # explicitly excluded\n',
       valueHelp: 'recipe.yaml',
     );

--- a/tools/test_data/foo/example/tizen/tizen-manifest.xml
+++ b/tools/test_data/foo/example/tizen/tizen-manifest.xml
@@ -1,13 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest package="com.example.foo_example" version="1.0.0" api-version="4.0" xmlns="http://tizen.org/ns/packages">
+<manifest package="com.example.foo_example" version="1.0.0" api-version="5.5" xmlns="http://tizen.org/ns/packages">
     <profile name="wearable"/>
     <ui-application appid="com.example.foo_example" exec="Runner.dll" type="dotnet" multiple="false" nodisplay="false" taskmanage="true">
         <label>foo_example</label>
         <icon>ic_launcher.png</icon>
         <metadata key="http://tizen.org/metadata/prefer_dotnet_aot" value="true"/>
     </ui-application>
-    <tv-info api-version="8.8.0">
-        <infolink>T-INFOLINK2021-1000</infolink>
-    </tv-info>
     <feature name="http://tizen.org/feature/screen.size.all"/>
 </manifest>

--- a/tools/test_data/foo/tizen/project_def.prop
+++ b/tools/test_data/foo/tizen/project_def.prop
@@ -3,7 +3,7 @@
 
 APPNAME = foo_plugin
 type = staticLib
-profile = common-4.0
+profile = common-5.5
 
 # Source files
 USER_SRCS += src/*.cc
@@ -13,10 +13,6 @@ USER_DEFS =
 USER_UNDEFS =
 USER_CPP_DEFS = FLUTTER_PLUGIN_IMPL
 USER_CPP_UNDEFS =
-
-# Compiler flags
-USER_CFLAGS_MISC =
-USER_CPPFLAGS_MISC =
 
 # User includes
 USER_INC_DIRS = inc src


### PR DESCRIPTION
Part of https://github.com/flutter-tizen/flutter-tizen/issues/481.

The app manifests should be updated because the default rootstrap has been changed to wearable-5.5 in https://github.com/flutter-tizen/flutter-tizen/pull/502. (It is assumed that the user has only the wearable-5.5 rootstrap installed when trying to run the example apps.)

I also updated all other references to "Tizen 4.0" to avoid any possible confusion.