### PR TITLE
[device_info_plus] Add TizenDeviceInfo.data property

### DIFF
--- a/packages/device_info_plus/CHANGELOG.md
+++ b/packages/device_info_plus/CHANGELOG.md
@@ -1,6 +1,9 @@
-## NEXT
+## 1.2.0
 
+* Add `TizenDeviceInfo.data` which represents the device info as a map.
+* Disambiguate the method channel name.
 * Increase the minimum Flutter version to 3.3.
+* Update the example app and integration_test.
 
 ## 1.1.0
 

--- a/packages/device_info_plus/README.md
+++ b/packages/device_info_plus/README.md
@@ -10,7 +10,7 @@ Add `device_info_plus_tizen` as a dependency in your `pubspec.yaml` file.
 
 ```yaml
 dependencies:
-  device_info_plus_tizen: ^1.1.0
+  device_info_plus_tizen: ^1.2.0
 ```
 
 Then you can import `device_info_plus_tizen` in your Dart code.
@@ -24,9 +24,9 @@ TizenDeviceInfo tizenInfo = await deviceInfo.tizenInfo;
 String modelName = tizenInfo.modelName;
 ```
 
-## Available values
+## Supported properties
 
-| Value | Feature or system key |
+| Property | Feature or system key |
 |-|-|
 | `modelName` | `http://tizen.org/system/model_name` |
 | `cpuArch` | `http://tizen.org/feature/platform.core.cpu.arch` |
@@ -47,4 +47,4 @@ String modelName = tizenInfo.modelName;
 | `platformProcessor` | `http://tizen.org/system/platform.processor` |
 | `tizenId` | `http://tizen.org/system/tizenid` |
 
-For description on each feature or system key in the list, see https://docs.tizen.org/application/native/guides/device/system.
+For a description of each feature or system key in the list, see https://docs.tizen.org/application/native/guides/device/system.

--- a/packages/device_info_plus/example/integration_test/device_info_plus_test.dart
+++ b/packages/device_info_plus/example/integration_test/device_info_plus_test.dart
@@ -2,6 +2,8 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+import 'dart:io';
+
 import 'package:flutter_test/flutter_test.dart';
 import 'package:device_info_plus_tizen/device_info_plus_tizen.dart';
 import 'package:integration_test/integration_test.dart';
@@ -19,4 +21,26 @@ void main() {
   testWidgets('Can get non-null device model', (WidgetTester tester) async {
     expect(tizenInfo.modelName, isNotNull);
   });
+
+  testWidgets('Check all Tizen info values are available',
+      (WidgetTester tester) async {
+    expect(tizenInfo.modelName, isNotNull);
+    expect(tizenInfo.cpuArch, isNotNull);
+    expect(tizenInfo.nativeApiVersion, isNotNull);
+    expect(tizenInfo.platformVersion, isNotNull);
+    expect(tizenInfo.webApiVersion, isNotNull);
+    expect(tizenInfo.profile, isNotNull);
+    expect(tizenInfo.buildDate, isNotNull);
+    expect(tizenInfo.buildId, isNotNull);
+    expect(tizenInfo.buildString, isNotNull);
+    expect(tizenInfo.buildTime, isNotNull);
+    expect(tizenInfo.buildType, isNotNull);
+    expect(tizenInfo.buildVariant, isNotNull);
+    expect(tizenInfo.buildRelease, isNotNull);
+    expect(tizenInfo.deviceType, isNotNull);
+    expect(tizenInfo.manufacturer, isNotNull);
+    expect(tizenInfo.platformName, isNotNull);
+    expect(tizenInfo.platformProcessor, isNotNull);
+    expect(tizenInfo.tizenId, isNotNull);
+  }, skip: !Platform.isLinux);
 }

--- a/packages/device_info_plus/example/lib/main.dart
+++ b/packages/device_info_plus/example/lib/main.dart
@@ -23,7 +23,7 @@ class MyApp extends StatefulWidget {
   const MyApp({Key? key}) : super(key: key);
 
   @override
-  _MyAppState createState() => _MyAppState();
+  State<MyApp> createState() => _MyAppState();
 }
 
 class _MyAppState extends State<MyApp> {
@@ -80,15 +80,22 @@ class _MyAppState extends State<MyApp> {
   @override
   Widget build(BuildContext context) {
     return MaterialApp(
+      theme: ThemeData(
+        useMaterial3: true,
+        colorSchemeSeed: const Color(0x9f4376f8),
+      ),
       home: Scaffold(
-        appBar: AppBar(title: const Text('Tizen Device Info')),
+        appBar: AppBar(
+          title: const Text('Tizen Device Info'),
+          elevation: 4,
+        ),
         body: ListView(
           children: _deviceData.keys.map(
             (String property) {
               return Row(
                 children: <Widget>[
                   Container(
-                    padding: const EdgeInsets.all(10.0),
+                    padding: const EdgeInsets.all(10),
                     child: Text(
                       property,
                       style: const TextStyle(
@@ -97,14 +104,15 @@ class _MyAppState extends State<MyApp> {
                     ),
                   ),
                   Expanded(
-                      child: Container(
-                    padding: const EdgeInsets.fromLTRB(0.0, 10.0, 0.0, 10.0),
-                    child: Text(
-                      '${_deviceData[property]}',
-                      maxLines: 10,
-                      overflow: TextOverflow.ellipsis,
+                    child: Container(
+                      padding: const EdgeInsets.symmetric(vertical: 10),
+                      child: Text(
+                        '${_deviceData[property]}',
+                        maxLines: 10,
+                        overflow: TextOverflow.ellipsis,
+                      ),
                     ),
-                  )),
+                  ),
                 ],
               );
             },

--- a/packages/device_info_plus/example/pubspec.yaml
+++ b/packages/device_info_plus/example/pubspec.yaml
@@ -21,7 +21,6 @@ dev_dependencies:
     sdk: flutter
   integration_test_tizen:
     path: ../../integration_test/
-  flutter_lints: ^1.0.4
 
 flutter:
   uses-material-design: true

--- a/packages/device_info_plus/lib/device_info_plus_tizen.dart
+++ b/packages/device_info_plus/lib/device_info_plus_tizen.dart
@@ -86,7 +86,7 @@ class TizenDeviceInfo {
   /// http://tizen.org/system/tizenid
   final String? tizenId;
 
-  /// Deserializes from the message received from [_kChannel].
+  /// Creates a [TizenDeviceInfo] from the [map].
   static TizenDeviceInfo fromMap(Map<String, dynamic> map) {
     return TizenDeviceInfo(
       modelName: map['modelName'],
@@ -109,12 +109,33 @@ class TizenDeviceInfo {
       tizenId: map['tizenId'],
     );
   }
+
+  /// Device information data.
+  Map<String, dynamic> get data => {
+        'modelName': modelName,
+        'cpuArch': cpuArch,
+        'nativeApiVersion': nativeApiVersion,
+        'platformVersion': platformVersion,
+        'webApiVersion': webApiVersion,
+        'profile': profile,
+        'buildDate': buildDate,
+        'buildId': buildId,
+        'buildString': buildString,
+        'buildTime': buildTime,
+        'buildType': buildType,
+        'buildVariant': buildVariant,
+        'buildRelease': buildRelease,
+        'deviceType': deviceType,
+        'manufacturer': manufacturer,
+        'platformName': platformName,
+        'platformProcessor': platformProcessor,
+        'tizenId': tizenId,
+      };
 }
 
 class _MethodChannelDeviceInfo {
   /// The method channel used to interact with the native platform.
-  MethodChannel channel =
-      const MethodChannel('dev.fluttercommunity.plus/device_info');
+  MethodChannel channel = const MethodChannel('tizen/device_info_plus');
 
   /// Method channel for Tizen devices.
   Future<TizenDeviceInfo> tizenInfo() async {

--- a/packages/device_info_plus/lib/device_info_plus_tizen.dart
+++ b/packages/device_info_plus/lib/device_info_plus_tizen.dart
@@ -10,8 +10,8 @@ import 'package:flutter/services.dart';
 ///
 /// See: https://docs.tizen.org/application/native/guides/device/system
 class TizenDeviceInfo {
-  /// Tizen device info class.
-  TizenDeviceInfo({
+  TizenDeviceInfo._({
+    required this.data,
     required this.modelName,
     required this.cpuArch,
     required this.nativeApiVersion,
@@ -31,6 +31,9 @@ class TizenDeviceInfo {
     required this.platformProcessor,
     required this.tizenId,
   });
+
+  /// Device information data.
+  final Map<String, dynamic> data;
 
   /// http://tizen.org/system/model_name
   final String? modelName;
@@ -88,7 +91,8 @@ class TizenDeviceInfo {
 
   /// Creates a [TizenDeviceInfo] from the [map].
   static TizenDeviceInfo fromMap(Map<String, dynamic> map) {
-    return TizenDeviceInfo(
+    return TizenDeviceInfo._(
+      data: map,
       modelName: map['modelName'],
       cpuArch: map['cpuArch'],
       nativeApiVersion: map['nativeApiVersion'],
@@ -110,27 +114,10 @@ class TizenDeviceInfo {
     );
   }
 
-  /// Device information data.
-  Map<String, dynamic> get data => {
-        'modelName': modelName,
-        'cpuArch': cpuArch,
-        'nativeApiVersion': nativeApiVersion,
-        'platformVersion': platformVersion,
-        'webApiVersion': webApiVersion,
-        'profile': profile,
-        'buildDate': buildDate,
-        'buildId': buildId,
-        'buildString': buildString,
-        'buildTime': buildTime,
-        'buildType': buildType,
-        'buildVariant': buildVariant,
-        'buildRelease': buildRelease,
-        'deviceType': deviceType,
-        'manufacturer': manufacturer,
-        'platformName': platformName,
-        'platformProcessor': platformProcessor,
-        'tizenId': tizenId,
-      };
+  @override
+  String toString() {
+    return 'TizenDeviceInfo{data: $data}';
+  }
 }
 
 class _MethodChannelDeviceInfo {

--- a/packages/device_info_plus/pubspec.yaml
+++ b/packages/device_info_plus/pubspec.yaml
@@ -1,9 +1,9 @@
 name: device_info_plus_tizen
 description: Flutter plugin providing detailed information about Tizen device
-  (make, model, etc.).
+  (make, model, etc.) the app is running on.
 homepage: https://github.com/flutter-tizen/plugins
 repository: https://github.com/flutter-tizen/plugins/tree/master/packages/device_info_plus
-version: 1.1.0
+version: 1.2.0
 
 environment:
   sdk: ">=2.18.0 <4.0.0"
@@ -21,4 +21,4 @@ dependencies:
     sdk: flutter
 
 dev_dependencies:
-  flutter_lints: ^1.0.4
+  flutter_lints: ^2.0.1

--- a/packages/device_info_plus/tizen/src/device_info_plus_tizen_plugin.cc
+++ b/packages/device_info_plus/tizen/src/device_info_plus_tizen_plugin.cc
@@ -22,7 +22,7 @@ class DeviceInfoPlusTizenPlugin : public flutter::Plugin {
   static void RegisterWithRegistrar(flutter::PluginRegistrar *registrar) {
     auto channel =
         std::make_unique<flutter::MethodChannel<flutter::EncodableValue>>(
-            registrar->messenger(), "dev.fluttercommunity.plus/device_info",
+            registrar->messenger(), "tizen/device_info_plus",
             &flutter::StandardMethodCodec::GetInstance());
 
     auto plugin = std::make_unique<DeviceInfoPlusTizenPlugin>();


### PR DESCRIPTION
- Add `TizenDeviceInfo.data` which represents the device info as a map. ([source](https://github.com/fluttercommunity/plus_plugins/blob/a246de0323c454b0a89dfa0fc1ba6e7aa58ef477/packages/device_info_plus/device_info_plus_platform_interface/lib/model/base_device_info.dart#L7))
- Disambiguate the method channel name to avoid a possible conflict with the original device_info_plus.
