### PR TITLE
Remove API level info from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,43 +55,43 @@ The _"non-endorsed"_ status means that the plugin is not endorsed by the origina
 
 ## Device limitations
 
-| Package name | API level | Watch | Watch<br>emulator | TV | TV<br>emulator | Remarks |
-|-|:-:|:-:|:-:|:-:|:-:|-|
-| [**audioplayers_tizen**](packages/audioplayers) | 5.5 | ✔️ | ✔️ | ✔️ | ✔️ |
-| [**battery_plus_tizen**](packages/battery_plus) | 5.5 | ✔️ | ✔️ | ❌ | ❌ | No battery |
-| [**camera_tizen**](packages/camera) | 5.5 | ❌ | ❌ | ❌ | ❌ | No camera |
-| [**connectivity_plus_tizen**](packages/connectivity_plus) | 5.5 | ✔️ | ⚠️ | ✔️ | ✔️ | Returns incorrect connection status |
-| [**device_info_plus_tizen**](packages/device_info_plus) | 5.5 | ✔️ | ✔️ | ✔️ | ✔️ |
-| [**firebase_core**](packages/firebase_core) | 5.5 | ✔️ | ✔️ | ✔️ | ✔️ |
-| [**flutter_app_badger_tizen**](packages/flutter_app_badger) | 5.5 | ✔️ | ✔️ | ❌ | ❌ | API not supported |
-| [**flutter_secure_storage_tizen**](packages/flutter_secure_storage) | 5.5 | ✔️ | ✔️ | ✔️ | ✔️ |
-| [**flutter_tts_tizen**](packages/flutter_tts) | 5.5 | ✔️ | ✔️ | ✔️ | ✔️ |
-| [**flutter_webrtc_tizen**](packages/flutter_webrtc) | 6.0 | ❌ | ❌ | ✔️ | ❌ | No camera |
-| [**geolocator_tizen**](packages/geolocator) | 5.5 | ✔️ | ✔️ | ❌ | ❌ | Not applicable for TV |
-| [**google_maps_flutter_tizen**](packages/google_maps_flutter) | 5.5 | ✔️ | ✔️ | ✔️ | ✔️ |
-| [**google_sign_in_tizen**](packages/google_sign_in) | 5.5 | ✔️ | ✔️ | ✔️ | ✔️ |
-| [**image_picker_tizen**](packages/image_picker) | 5.5 | ⚠️ | ❌ | ❌ | ❌ | No camera,<br>No file manager app |
-| [**integration_test_tizen**](packages/integration_test) | 5.5 | ✔️ | ✔️ | ✔️ | ✔️ |
-| [**messageport_tizen**](packages/messageport) | 5.5 | ✔️ | ✔️ | ✔️ | ✔️ |
-| [**network_info_plus_tizen**](packages/network_info_plus) | 5.5 | ✔️ | ❌ | ✔️ | ❌ | API not supported on emulator |
-| [**package_info_plus_tizen**](packages/package_info_plus) | 5.5 | ✔️ | ✔️ | ✔️ | ✔️ |
-| [**path_provider_tizen**](packages/path_provider) | 5.5 | ✔️ | ✔️ | ✔️ | ✔️ |
-| [**permission_handler_tizen**](packages/permission_handler) | 5.5 | ✔️ | ✔️ | ⚠️ | ⚠️ | Not applicable for TV |
-| [**sensors_plus_tizen**](packages/sensors_plus) | 5.5 | ✔️ | ✔️ | ❌ | ❌ | No sensor hardware |
-| [**shared_preferences_tizen**](packages/shared_preferences) | 5.5 | ✔️ | ✔️ | ✔️ | ✔️ |
-| [**sqflite_tizen**](packages/sqflite) | 5.5 | ✔️ | ✔️ | ✔️ | ✔️ |
-| [**tizen_app_control**](packages/tizen_app_control) | 5.5 | ✔️ | ✔️ | ✔️ | ✔️ |
-| [**tizen_app_manager**](packages/tizen_app_manager) | 5.5 | ✔️ | ✔️ | ✔️ | ✔️ |
-| [**tizen_audio_manager**](packages/tizen_audio_manager) | 5.5 | ✔️ | ✔️ | ✔️ | ✔️ |
-| [**tizen_bundle**](packages/tizen_bundle) | 5.5 | ✔️ | ✔️ | ✔️ | ✔️ |
-| [**tizen_log**](packages/tizen_log) | 5.5 | ✔️ | ✔️ | ❌ | ❌ | Not applicable for TV |
-| [**tizen_notification**](packages/tizen_notification) | 5.5 | ❌ | ✔️ | ✔️ | ✔️ | API not supported |
-| [**tizen_package_manager**](packages/tizen_package_manager) | 5.5 | ✔️ | ✔️ | ✔️ | ✔️ |
-| [**tizen_rpc_port**](packages/tizen_rpc_port) | 6.5 | ✔️ | ✔️ | ✔️ | ✔️ |
-| [**url_launcher_tizen**](packages/url_launcher) | 5.5 | ✔️ | ❌ | ✔️ | ❌ | No browser app |
-| [**video_player_tizen**](packages/video_player) | 5.5 | ✔️ | ✔️ | ✔️ | ❌ | TV emulator issue |
-| [**video_player_videohole**](packages/video_player_videohole) | 5.5 | ❌ | ❌ | ✔️ | ❌ | Only for TV devices |
-| [**wakelock_tizen**](packages/wakelock) | 5.5 | ✔️ | ✔️ | ❌ | ❌ | Cannot override system settings |
-| [**wearable_rotary**](packages/wearable_rotary) | 5.5 | ✔️ | ✔️ | ❌ | ❌ | Not applicable for TV |
-| [**webview_flutter_lwe**](packages/webview_flutter_lwe) | 5.5 | ✔️ | ✔️ | ✔️ | ✔️ | Not for production use |
-| [**webview_flutter_tizen**](packages/webview_flutter) | 5.5 | ❌ | ❌ | ✔️ | ✔️ | API not supported |
+| Package name | Watch | Watch<br>emulator | TV | TV<br>emulator | Remarks |
+|-|:-:|:-:|:-:|:-:|-|
+| [**audioplayers_tizen**](packages/audioplayers) | ✔️ | ✔️ | ✔️ | ✔️ |
+| [**battery_plus_tizen**](packages/battery_plus) | ✔️ | ✔️ | ❌ | ❌ | No battery |
+| [**camera_tizen**](packages/camera) | ❌ | ❌ | ❌ | ❌ | No camera |
+| [**connectivity_plus_tizen**](packages/connectivity_plus) | ✔️ | ⚠️ | ✔️ | ✔️ | Returns incorrect connection status |
+| [**device_info_plus_tizen**](packages/device_info_plus) | ✔️ | ✔️ | ✔️ | ✔️ |
+| [**firebase_core**](packages/firebase_core) | ✔️ | ✔️ | ✔️ | ✔️ |
+| [**flutter_app_badger_tizen**](packages/flutter_app_badger) | ✔️ | ✔️ | ❌ | ❌ | API not supported |
+| [**flutter_secure_storage_tizen**](packages/flutter_secure_storage) | ✔️ | ✔️ | ✔️ | ✔️ |
+| [**flutter_tts_tizen**](packages/flutter_tts) | ✔️ | ✔️ | ✔️ | ✔️ |
+| [**flutter_webrtc_tizen**](packages/flutter_webrtc) | ❌ | ❌ | ✔️ | ❌ | No camera |
+| [**geolocator_tizen**](packages/geolocator) | ✔️ | ✔️ | ❌ | ❌ | Not applicable for TV |
+| [**google_maps_flutter_tizen**](packages/google_maps_flutter) | ✔️ | ✔️ | ✔️ | ✔️ |
+| [**google_sign_in_tizen**](packages/google_sign_in) | ✔️ | ✔️ | ✔️ | ✔️ |
+| [**image_picker_tizen**](packages/image_picker) | ⚠️ | ❌ | ❌ | ❌ | No camera,<br>No file manager app |
+| [**integration_test_tizen**](packages/integration_test) | ✔️ | ✔️ | ✔️ | ✔️ |
+| [**messageport_tizen**](packages/messageport) | ✔️ | ✔️ | ✔️ | ✔️ |
+| [**network_info_plus_tizen**](packages/network_info_plus) | ✔️ | ❌ | ✔️ | ❌ | API not supported on emulator |
+| [**package_info_plus_tizen**](packages/package_info_plus) | ✔️ | ✔️ | ✔️ | ✔️ |
+| [**path_provider_tizen**](packages/path_provider) | ✔️ | ✔️ | ✔️ | ✔️ |
+| [**permission_handler_tizen**](packages/permission_handler) | ✔️ | ✔️ | ⚠️ | ⚠️ | Not applicable for TV |
+| [**sensors_plus_tizen**](packages/sensors_plus) | ✔️ | ✔️ | ❌ | ❌ | No sensor hardware |
+| [**shared_preferences_tizen**](packages/shared_preferences) | ✔️ | ✔️ | ✔️ | ✔️ |
+| [**sqflite_tizen**](packages/sqflite) | ✔️ | ✔️ | ✔️ | ✔️ |
+| [**tizen_app_control**](packages/tizen_app_control) | ✔️ | ✔️ | ✔️ | ✔️ |
+| [**tizen_app_manager**](packages/tizen_app_manager) | ✔️ | ✔️ | ✔️ | ✔️ |
+| [**tizen_audio_manager**](packages/tizen_audio_manager) | ✔️ | ✔️ | ✔️ | ✔️ |
+| [**tizen_bundle**](packages/tizen_bundle) | ✔️ | ✔️ | ✔️ | ✔️ |
+| [**tizen_log**](packages/tizen_log) | ✔️ | ✔️ | ❌ | ❌ | Not applicable for TV |
+| [**tizen_notification**](packages/tizen_notification) | ❌ | ✔️ | ✔️ | ✔️ | API not supported |
+| [**tizen_package_manager**](packages/tizen_package_manager) | ✔️ | ✔️ | ✔️ | ✔️ |
+| [**tizen_rpc_port**](packages/tizen_rpc_port) | ✔️ | ✔️ | ✔️ | ✔️ |
+| [**url_launcher_tizen**](packages/url_launcher) | ✔️ | ❌ | ✔️ | ❌ | No browser app |
+| [**video_player_tizen**](packages/video_player) | ✔️ | ✔️ | ✔️ | ❌ | TV emulator issue |
+| [**video_player_videohole**](packages/video_player_videohole) | ❌ | ❌ | ✔️ | ⚠️ | See README for details |
+| [**wakelock_tizen**](packages/wakelock) | ✔️ | ✔️ | ❌ | ❌ | Cannot override system settings |
+| [**wearable_rotary**](packages/wearable_rotary) | ✔️ | ✔️ | ❌ | ❌ | Not applicable for TV |
+| [**webview_flutter_lwe**](packages/webview_flutter_lwe) | ✔️ | ✔️ | ✔️ | ✔️ | Not for production use |
+| [**webview_flutter_tizen**](packages/webview_flutter) | ❌ | ❌ | ✔️ | ✔️ | API not supported |

--- a/packages/flutter_webrtc/README.md
+++ b/packages/flutter_webrtc/README.md
@@ -56,3 +56,7 @@ dependencies:
 |   MediaRecorder    |       [WIP]        |
 |SFrame/FrameCryptor | :heavy_check_mark: |
 | Insertable Streams |       [WIP]        |
+
+## Supported devices
+
+This plugin is supported on Tizen devices running Tizen 6.0 or later.

--- a/packages/video_player_videohole/README.md
+++ b/packages/video_player_videohole/README.md
@@ -4,7 +4,7 @@
 
 A fork of the [`video_player`](https://pub.dev/packages/video_player) plugin to support playback of DRM streams (Widevine and PlayReady) on Tizen TV devices.
 
-This plugin is only supported on Tizen TV devices. If you are targeting other device types or don't plan to play DRM content in your app, use [`video_player`](https://pub.dev/packages/video_player) and [`video_player_tizen`](https://pub.dev/packages/video_player_tizen) instead.
+This plugin is only supported on Tizen TV devices. If you are targeting other types of devices or are not interested in playing DRM content in your app, use [`video_player`](https://pub.dev/packages/video_player) and [`video_player_tizen`](https://pub.dev/packages/video_player_tizen) instead.
 
 ## Usage
 
@@ -108,7 +108,7 @@ For detailed information on Tizen privileges, see [Tizen Docs: API Privileges](h
 
 ## Limitations
 
-This plugin is not supported on TV emulators.
+TV emulator support is experimental. DRM content playback is not supported on TV emulators.
 
 The following options are not currently supported.
 


### PR DESCRIPTION
Remove the API level column from the device limitations table as it doesn't add much useful information (there are now only two packages that require Tizen 6.0 or higher).

Also mark video_player_videohole as "[partially supported](https://github.com/flutter-tizen/plugins/issues/304#issuecomment-1592635340)" on TV emulator.