### PR TITLE
[image_picker] Fix video_player dependency in example

### DIFF
--- a/packages/image_picker/CHANGELOG.md
+++ b/packages/image_picker/CHANGELOG.md
@@ -3,7 +3,6 @@
 * Increase the minimum Flutter version to 3.3.
 * Update example app pubspec.
 
-
 ## 2.2.0
 
 * Switch to an internal method channel implementation.

--- a/packages/image_picker/CHANGELOG.md
+++ b/packages/image_picker/CHANGELOG.md
@@ -1,6 +1,8 @@
 ## NEXT
 
 * Increase the minimum Flutter version to 3.3.
+* Update example app pubspec.
+
 
 ## 2.2.0
 

--- a/packages/image_picker/example/pubspec.yaml
+++ b/packages/image_picker/example/pubspec.yaml
@@ -12,7 +12,7 @@ dependencies:
   image_picker: ^0.8.6
   image_picker_tizen:
     path: ../
-  video_player: ^2.1.4
+  video_player: ">=2.1.4 <2.7.0"
 
 dev_dependencies:
   flutter_driver:


### PR DESCRIPTION
- Fix `video_player` dependency in example to `>=2.1.4 <2.7.0`
- `VideoPlayerController.network` is deprecated since version 2.7.0 in video_player plugin. ([link](https://pub.dev/packages/video_player/changelog))