### PR TITLE
[shared_preferences] Update to support shared_preferences 2.2.0

### DIFF
--- a/packages/shared_preferences/CHANGELOG.md
+++ b/packages/shared_preferences/CHANGELOG.md
@@ -1,6 +1,9 @@
-## NEXT
+## 2.1.1
 
 * Increase the minimum Flutter version to 3.3.
+* Update shared_preferences to 2.2.0.
+* Update shared_preferences_interface to 2.3.0.
+* Update integration_test.
 
 ## 2.1.0
 

--- a/packages/shared_preferences/CHANGELOG.md
+++ b/packages/shared_preferences/CHANGELOG.md
@@ -3,6 +3,7 @@
 * Increase the minimum Flutter version to 3.3.
 * Update shared_preferences to 2.2.0.
 * Update shared_preferences_interface to 2.3.0.
+* Add `clearWithParameters` and `getAllWithParameters`.
 * Update integration_test.
 
 ## 2.1.0

--- a/packages/shared_preferences/CHANGELOG.md
+++ b/packages/shared_preferences/CHANGELOG.md
@@ -4,6 +4,8 @@
 * Update shared_preferences to 2.2.0.
 * Update shared_preferences_interface to 2.3.0.
 * Add `clearWithParameters` and `getAllWithParameters`.
+* Update `clear` to use `clearWithParameters`
+* Update `getAll` to use `getAllWithParameters`
 * Update integration_test.
 
 ## 2.1.0

--- a/packages/shared_preferences/CHANGELOG.md
+++ b/packages/shared_preferences/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 2.1.1
+## 2.2.0
 
 * Increase the minimum Flutter version to 3.3.
 * Update shared_preferences to 2.2.0.

--- a/packages/shared_preferences/README.md
+++ b/packages/shared_preferences/README.md
@@ -10,8 +10,8 @@ This package is not an _endorsed_ implementation of `shared_preferences`. Theref
 
 ```yaml
 dependencies:
-  shared_preferences: ^2.0.9
-  shared_preferences_tizen: ^2.1.0
+  shared_preferences: ^2.2.0
+  shared_preferences_tizen: ^2.1.1
 ```
 
 Then you can import `shared_preferences` in your Dart code:

--- a/packages/shared_preferences/README.md
+++ b/packages/shared_preferences/README.md
@@ -11,7 +11,7 @@ This package is not an _endorsed_ implementation of `shared_preferences`. Theref
 ```yaml
 dependencies:
   shared_preferences: ^2.2.0
-  shared_preferences_tizen: ^2.1.1
+  shared_preferences_tizen: ^2.2.0
 ```
 
 Then you can import `shared_preferences` in your Dart code:

--- a/packages/shared_preferences/example/pubspec.yaml
+++ b/packages/shared_preferences/example/pubspec.yaml
@@ -9,7 +9,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  shared_preferences: ^2.0.9
+  shared_preferences: ^2.2.0
   shared_preferences_tizen:
     path: ../
 

--- a/packages/shared_preferences/lib/shared_preferences_tizen.dart
+++ b/packages/shared_preferences/lib/shared_preferences_tizen.dart
@@ -94,7 +94,7 @@ class SharedPreferencesPlugin extends SharedPreferencesStorePlatform {
         failed |= !(await remove(key));
       }
     }
-    return failed;
+    return !failed;
   }
 
   @override

--- a/packages/shared_preferences/lib/shared_preferences_tizen.dart
+++ b/packages/shared_preferences/lib/shared_preferences_tizen.dart
@@ -87,14 +87,16 @@ class SharedPreferencesPlugin extends SharedPreferencesStorePlatform {
   Future<bool> clearWithParameters(ClearParameters parameters) async {
     final PreferencesFilter filter = parameters.filter;
     final List<String> keys = List<String>.of(_preferences.keys);
-    bool failed = false;
+
     for (final String key in keys) {
       if (key.startsWith(filter.prefix) &&
           (filter.allowList == null || filter.allowList!.contains(key))) {
-        failed |= !(await remove(key));
+        if (!(await remove(key))) {
+          return false;
+        }
       }
     }
-    return !failed;
+    return true;
   }
 
   @override

--- a/packages/shared_preferences/lib/shared_preferences_tizen.dart
+++ b/packages/shared_preferences/lib/shared_preferences_tizen.dart
@@ -17,6 +17,8 @@ class SharedPreferencesPlugin extends SharedPreferencesStorePlatform {
     SharedPreferencesStorePlatform.instance = SharedPreferencesPlugin();
   }
 
+  static const String _defaultPrefix = 'flutter.';
+
   static Map<String, Object>? _cachedPreferences;
   static const String _separator = '␞';
 
@@ -78,9 +80,9 @@ class SharedPreferencesPlugin extends SharedPreferencesStorePlatform {
 
   @override
   Future<bool> clear() async {
-    _preferences.clear();
-
-    return tizen.preference_remove_all() == 0;
+    return clearWithParameters(ClearParameters(
+      filter: PreferencesFilter(prefix: _defaultPrefix),
+    ));
   }
 
   @override
@@ -100,7 +102,11 @@ class SharedPreferencesPlugin extends SharedPreferencesStorePlatform {
   }
 
   @override
-  Future<Map<String, Object>> getAll() async => _preferences;
+  Future<Map<String, Object>> getAll() async {
+    return getAllWithParameters(
+      GetAllParameters(filter: PreferencesFilter(prefix: _defaultPrefix)),
+    );
+  }
 
   @override
   Future<Map<String, Object>> getAllWithParameters(

--- a/packages/shared_preferences/pubspec.yaml
+++ b/packages/shared_preferences/pubspec.yaml
@@ -18,5 +18,5 @@ dependencies:
   ffi: ^2.0.1
   flutter:
     sdk: flutter
-  shared_preferences_platform_interface: ^2.0.0
+  shared_preferences_platform_interface: ^2.3.0
   tizen_interop: ^0.2.0

--- a/packages/shared_preferences/pubspec.yaml
+++ b/packages/shared_preferences/pubspec.yaml
@@ -2,7 +2,7 @@ name: shared_preferences_tizen
 description: Tizen implementation of the shared_preferences plugin.
 homepage: https://github.com/flutter-tizen/plugins
 repository: https://github.com/flutter-tizen/plugins/tree/master/packages/shared_preferences
-version: 2.1.0
+version: 2.2.0
 
 environment:
   sdk: ">=2.18.0 <4.0.0"


### PR DESCRIPTION
- Update shared_preferences to 2.2.0.
- Update shared_preferences_platform_interface to 2.3.0.
- Implement `clearWithParameters` and `getAllWithParameters`
- Update integration_test.
