### PR TITLE
[sqflite] Remove deprecated WillPopScope

### DIFF
--- a/packages/sqflite/example/lib/manual_test_page.dart
+++ b/packages/sqflite/example/lib/manual_test_page.dart
@@ -56,10 +56,6 @@ class _ManualTestPageState extends State<ManualTestPage> {
   late List<SqfMenuItem> items;
   late List<ItemWidget> itemWidgets;
 
-  Future<bool> pop() async {
-    return true;
-  }
-
   Future<void> _addAndQuery({int? msDelay, bool? noSynchronized}) async {
     // await databaseFactory.debugSetLogLevel(sqfliteLogLevelVerbose);
     var db = await _openDatabase();
@@ -219,11 +215,8 @@ class _ManualTestPageState extends State<ManualTestPage> {
       appBar: AppBar(
         title: const Text('Manual tests'),
       ),
-      body: WillPopScope(
-        onWillPop: pop,
-        child: ListView(
-          children: itemWidgets,
-        ),
+      body: ListView(
+        children: itemWidgets,
       ),
     );
   }


### PR DESCRIPTION
Fix analyze error in CI. This patch is taken from here.
https://github.com/tekartik/sqflite/commit/c0defa9f622757fb135b006d10242f925b22fdc1

issue : https://github.com/flutter-tizen/plugins/actions/runs/6886746651/job/18732875305?pr=625#step:4:826