### PR TITLE
[video_player_avplay] Fix not display video issue when start play

### DIFF
--- a/packages/video_player_avplay/CHANGELOG.md
+++ b/packages/video_player_avplay/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.1.3
+
+* Fix issue of not display video when start play.
+
 ## 0.1.2
 
 * Replace surface id with resource id for fixing overlap issue.

--- a/packages/video_player_avplay/README.md
+++ b/packages/video_player_avplay/README.md
@@ -12,7 +12,7 @@ To use this package, add `video_player_avplay` as a dependency in your `pubspec.
 
 ```yaml
 dependencies:
-  video_player_avplay: ^0.1.2
+  video_player_avplay: ^0.1.3
 ```
 
 Then you can import `video_player_avplay` in your Dart code:

--- a/packages/video_player_avplay/lib/video_player.dart
+++ b/packages/video_player_avplay/lib/video_player.dart
@@ -578,7 +578,11 @@ class VideoPlayerController extends ValueNotifier<VideoPlayerValue> {
       // This ensures that the correct playback speed is always applied when
       // playing back. This is necessary because we do not set playback speed
       // when paused.
-      await _applyPlaybackSpeed();
+      //
+      // For Tizen, playback speed don't need to set when start play,
+      // otherwise player will restart buffer.
+      // The default value is 1.0.
+      // await _applyPlaybackSpeed();
     } else {
       _timer?.cancel();
       await _videoPlayerPlatform.pause(_playerId);

--- a/packages/video_player_avplay/lib/video_player.dart
+++ b/packages/video_player_avplay/lib/video_player.dart
@@ -575,10 +575,6 @@ class VideoPlayerController extends ValueNotifier<VideoPlayerValue> {
         },
       );
 
-      // This ensures that the correct playback speed is always applied when
-      // playing back. This is necessary because we do not set playback speed
-      // when paused.
-      //
       // For Tizen, playback speed don't need to set when start play,
       // otherwise player will restart buffer.
       // The default value is 1.0.

--- a/packages/video_player_avplay/lib/video_player.dart
+++ b/packages/video_player_avplay/lib/video_player.dart
@@ -574,11 +574,6 @@ class VideoPlayerController extends ValueNotifier<VideoPlayerValue> {
           _updatePosition(newPosition);
         },
       );
-
-      // For Tizen, playback speed don't need to set when start play,
-      // otherwise player will restart buffer.
-      // The default value is 1.0.
-      // await _applyPlaybackSpeed();
     } else {
       _timer?.cancel();
       await _videoPlayerPlatform.pause(_playerId);
@@ -594,13 +589,6 @@ class VideoPlayerController extends ValueNotifier<VideoPlayerValue> {
 
   Future<void> _applyPlaybackSpeed() async {
     if (_isDisposedOrNotInitialized) {
-      return;
-    }
-
-    // Setting the playback speed on iOS will trigger the video to play. We
-    // prevent this from happening by not applying the playback speed until
-    // the video is manually played from Flutter.
-    if (!value.isPlaying) {
       return;
     }
 

--- a/packages/video_player_avplay/pubspec.yaml
+++ b/packages/video_player_avplay/pubspec.yaml
@@ -2,7 +2,7 @@ name: video_player_avplay
 description: Flutter plugin for displaying inline video on Tizen TV devices.
 homepage: https://github.com/flutter-tizen/plugins
 repository: https://github.com/flutter-tizen/plugins/tree/master/packages/video_player_avplay
-version: 0.1.2
+version: 0.1.3
 
 environment:
   sdk: ">=2.18.0 <4.0.0"

--- a/packages/video_player_avplay/tizen/src/plus_player.cc
+++ b/packages/video_player_avplay/tizen/src/plus_player.cc
@@ -618,6 +618,10 @@ void PlusPlayer::OnPrepareDone(bool ret, void *user_data) {
   LOG_INFO("[PlusPlayer] Prepare done, result: %d.", ret);
   PlusPlayer *self = reinterpret_cast<PlusPlayer *>(user_data);
 
+  if (!SetDisplayVisible(self->player_, true)) {
+    LOG_ERROR("[PlusPlayer] Fail to set display visible.");
+  }
+
   if (!self->is_initialized_ && ret) {
     self->SendInitialized();
   }


### PR DESCRIPTION
Issue: there is no video and audio after start play.
1. player should call `SetDisplayVisible` to display one fram after prepare is done.
2. plusplayer don't need to set playback speed when start play, otherwise it will clear buffer and restart buffer.
3. plusplayer can set playback speed when player is pause. Remove code:
```
if (!value.isPlaying) {
       return;
    }
```