### PR TITLE
[video_player_avplay] Fix can not resume issue when re-launch app

### DIFF
--- a/packages/video_player_avplay/tizen/src/media_player.cc
+++ b/packages/video_player_avplay/tizen/src/media_player.cc
@@ -680,9 +680,6 @@ void MediaPlayer::OnPlayCompleted(void *user_data) {
 void MediaPlayer::OnInterrupted(player_interrupted_code_e code,
                                 void *user_data) {
   LOG_ERROR("[MediaPlayer] Interrupt code: %d.", code);
-
-  MediaPlayer *self = static_cast<MediaPlayer *>(user_data);
-  self->SendError("Interrupted error", "Media player has been interrupted.");
 }
 
 void MediaPlayer::OnError(int error_code, void *user_data) {


### PR DESCRIPTION
Do not need send error message when receive OnInterrupted callback, because MM player can recover on its own.