### PR TITLE
[video_player_avplay] Fix state check in SetVolume

### DIFF
--- a/packages/video_player_avplay/CHANGELOG.md
+++ b/packages/video_player_avplay/CHANGELOG.md
@@ -1,3 +1,7 @@
+## NEXT
+
+* Fix state check in SetVolume.
+
 ## 0.3.2
 
 * [VVC] Add VVC decoder, disable parse for mp4/vvc, create a new vvc decoder to try decode

--- a/packages/video_player_avplay/lib/video_player.dart
+++ b/packages/video_player_avplay/lib/video_player.dart
@@ -428,8 +428,11 @@ class VideoPlayerController extends ValueNotifier<VideoPlayerValue> {
           );
           initializingCompleter.complete(null);
           _applyLooping();
-          _applyVolume();
+          // NOTE(jsuya): The plusplayer's SetVolume() work when player is
+          // paused or played, so it changes the order of _applyPlayPause()
+          // and _applyVolume().
           _applyPlayPause();
+          _applyVolume();
           _durationTimer?.cancel();
           _durationTimer = _createDurationTimer();
           break;

--- a/packages/video_player_avplay/tizen/src/plus_player.cc
+++ b/packages/video_player_avplay/tizen/src/plus_player.cc
@@ -267,8 +267,7 @@ bool PlusPlayer::SetLooping(bool is_looping) {
 bool PlusPlayer::SetVolume(double volume) {
   LOG_INFO("[PlusPlayer] Volume: %f", volume);
 
-  if (GetState(player_) != plusplayer::State::kPlaying ||
-      GetState(player_) != plusplayer::State::kPaused) {
+  if (GetState(player_) < plusplayer::State::kPlaying) {
     LOG_ERROR("[PlusPlayer] Player is in invalid state");
     return false;
   }


### PR DESCRIPTION
SetVolume()'s state check returns fail even when the state is kPaused.
And _applyVolume called in VideoPlayerController's initialize() is called when the state is kReady, so modify the state check.