### PR TITLE
[webview_flutter_tizen] Add tizenEnginePolicy extension api temporary

### DIFF
--- a/packages/webview_flutter/CHANGELOG.md
+++ b/packages/webview_flutter/CHANGELOG.md
@@ -1,8 +1,9 @@
-## NEXT
+## 0.9.1
 
 * Add ewk_set_version_policy() call.
 * Fix new lint warnings.
 * Update minimum Flutter and Dart version to 3.13 and 3.1.
+* Add WebViewController.tizenEnginePolicy extension API temporary.
 
 ## 0.9.0
 

--- a/packages/webview_flutter/README.md
+++ b/packages/webview_flutter/README.md
@@ -23,7 +23,7 @@ This package is not an _endorsed_ implementation of `webview_flutter`. Therefore
 ```yaml
 dependencies:
   webview_flutter: ^4.4.2
-  webview_flutter_tizen: ^0.9.0
+  webview_flutter_tizen: ^0.9.1
 ```
 
 ## Example
@@ -63,7 +63,7 @@ This plugin is only supported on Tizen TV devices running Tizen 5.5 or later.
 
 ## Note
 
-To play Youtube, make app's background color to transparent.
+- To play Youtube, make app's background color to transparent.
 
 ```diff
 --- a/packages/webview_flutter/example/lib/main.dart
@@ -75,4 +75,13 @@ To play Youtube, make app's background color to transparent.
 +       backgroundColor: Colors.transparent,
        appBar: AppBar(
          title: const Text('Flutter WebView example'),
+```
+
+- In Tizen 6.0, there were some devices that failed to create the web view. In this case, the creation failure is resolved by using the Upgrade Web Engine (UWE) internally. If you set the `WebViewController.tizenEnginePolicy` extension API to `true` before creating the `WebviewWidget`, the webview will internally search for another version of the engine. However, this API can be changed(or removed) at any time and is not officially guaranteed to work.
+
+```dart
+import 'package:webview_flutter_tizen/webview_flutter_tizen.dart';
+
+WebViewController _controller;
+_controller.tizenEnginePolicy = true;
 ```

--- a/packages/webview_flutter/lib/src/tizen_webview.dart
+++ b/packages/webview_flutter/lib/src/tizen_webview.dart
@@ -60,12 +60,13 @@ class TizenWebView {
   }
 
   /// Called when [TizenView] is created. Invokes the requested method call before [TizenWebView] is created.
-  void onCreate(int viewId) {
+  void onCreate(int viewId, bool enginePolicy) {
     _isCreated = true;
     _viewId = viewId;
     _tizenWebViewChannel =
         MethodChannel(kTizenWebViewChannelName + viewId.toString());
     _tizenWebViewChannel.setMethodCallHandler(_onMethodCall);
+    _invokeChannelMethod<void>('setEnginePolicy', enginePolicy);
 
     _callPendingMethodCalls();
   }

--- a/packages/webview_flutter/lib/src/tizen_webview_controller.dart
+++ b/packages/webview_flutter/lib/src/tizen_webview_controller.dart
@@ -8,6 +8,7 @@ import 'dart:async';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_tizen/widgets.dart';
+import 'package:webview_flutter/webview_flutter.dart';
 import 'package:webview_flutter_platform_interface/webview_flutter_platform_interface.dart';
 
 import 'tizen_webview.dart';
@@ -19,6 +20,16 @@ const String kTizenNavigationDelegateChannelName =
 /// The channel name of [TizenWebViewController].
 const String kTizenWebViewControllerChannelName =
     'plugins.flutter.io/tizen_webview_controller_';
+
+/// The extension of WebViewController class for the Tizen.
+extension TizenWebViewControllerExtension on WebViewController {
+  /// Set to engine policy.
+  set tizenEnginePolicy(bool enginePolicy) {
+    final TizenWebViewController controller =
+        platform as TizenWebViewController;
+    controller._enginePolicy = enginePolicy;
+  }
+}
 
 /// An implementation of [PlatformWebViewController] using the Tizen WebView API.
 class TizenWebViewController extends PlatformWebViewController {
@@ -33,6 +44,8 @@ class TizenWebViewController extends PlatformWebViewController {
   void Function(JavaScriptConsoleMessage consoleMessage)? _onConsoleLogCallback;
 
   late final MethodChannel _webviewControllerChannel;
+
+  bool _enginePolicy = false;
 
   /// Called when [TizenView] is created.
   void createWebviewControllerChannel(int viewId) {
@@ -74,7 +87,7 @@ class TizenWebViewController extends PlatformWebViewController {
 
   /// Called when [TizenView] is created.
   void onCreate(int viewId) {
-    _webview.onCreate(viewId);
+    _webview.onCreate(viewId, _enginePolicy);
     if (_webview.hasNavigationDelegate) {
       _tizenNavigationDelegate.createNavigationDelegateChannel(viewId);
     }

--- a/packages/webview_flutter/pubspec.yaml
+++ b/packages/webview_flutter/pubspec.yaml
@@ -2,7 +2,7 @@ name: webview_flutter_tizen
 description: Tizen implementation of the webview_flutter plugin.
 homepage: https://github.com/flutter-tizen/plugins
 repository: https://github.com/flutter-tizen/plugins/tree/master/packages/webview_flutter
-version: 0.9.0
+version: 0.9.1
 
 environment:
   sdk: ">=3.1.0 <4.0.0"

--- a/packages/webview_flutter/tizen/src/webview.h
+++ b/packages/webview_flutter/tizen/src/webview.h
@@ -67,7 +67,7 @@ class WebView : public PlatformView {
   std::string GetWebViewControllerChannelName();
   std::string GetNavigationDelegateChannelName();
 
-  void InitWebView();
+  bool InitWebView();
 
   static void OnFrameRendered(void* data, Evas_Object* obj, void* event_info);
   static void OnLoadStarted(void* data, Evas_Object* obj, void* event_info);
@@ -84,6 +84,7 @@ class WebView : public PlatformView {
 
   Evas_Object* webview_instance_ = nullptr;
   flutter::TextureRegistrar* texture_registrar_;
+  bool engine_policy_ = false;
   double width_ = 0.0;
   double height_ = 0.0;
   double left_ = 0.0;


### PR DESCRIPTION
There was a case where the ewk engine failed to load on some devices using Tizen 6.0.
As a result, ewk init failed and an engine instance could not be created. We have not found an exact cause for this.
Calling ewk_set_version_policy(1) will solve the problem,
but using UWE(upgrade web engine) in 3rd party application is not recommended.
(The webview works may not be guaranteed to normally.)
Therefore, add a temporary API and have user application call it. 
This API may be deleted in the future depending on whether tizen version 6.0 is supported.

related issue: https://github.com/flutter-tizen/plugins/issues/647