### PR TITLE
Resolve Flutter 3.19 analyze issues

### DIFF
--- a/packages/flutter_secure_storage/example/lib/main.dart
+++ b/packages/flutter_secure_storage/example/lib/main.dart
@@ -212,7 +212,7 @@ class ItemsWidgetState extends State<ItemsWidget> {
         if (!context.mounted) return;
         final key = await _displayTextInputDialog(context, item.key);
         final result = await _storage.containsKey(key: key);
-        if (!mounted) return;
+        if (!context.mounted) return;
         ScaffoldMessenger.of(context).showSnackBar(
           SnackBar(
             content: Text('Contains Key: $result, key checked: $key'),
@@ -225,7 +225,7 @@ class ItemsWidgetState extends State<ItemsWidget> {
         final key = await _displayTextInputDialog(context, item.key);
         final result =
             await _storage.read(key: key, aOptions: _getAndroidOptions());
-        if (!mounted) return;
+        if (!context.mounted) return;
         ScaffoldMessenger.of(context).showSnackBar(
           SnackBar(
             content: Text('value: $result'),

--- a/packages/in_app_purchase/example/lib/main.dart
+++ b/packages/in_app_purchase/example/lib/main.dart
@@ -234,8 +234,6 @@ class _MyAppState extends State<_MyApp> {
             trailing: TextButton(
               style: TextButton.styleFrom(
                 backgroundColor: Colors.green[800],
-                // ignore: deprecated_member_use
-                primary: Colors.white,
               ),
               onPressed: () {
                 final PurchaseParam purchaseParam = PurchaseParam(
@@ -278,8 +276,6 @@ class _MyAppState extends State<_MyApp> {
           TextButton(
             style: TextButton.styleFrom(
               backgroundColor: Theme.of(context).colorScheme.primary,
-              // ignore: deprecated_member_use
-              primary: Colors.white,
             ),
             onPressed: () => _inAppPurchase.restorePurchases(),
             child: const Text('Restore purchases'),

--- a/packages/sqflite/example/analysis_options.yaml
+++ b/packages/sqflite/example/analysis_options.yaml
@@ -76,7 +76,6 @@ linter:
     - prefer_initializing_formals
     - prefer_void_to_null
     #
-    - always_require_non_null_named_parameters
     - annotate_overrides
     - avoid_init_to_null
     - avoid_null_checks_in_equality_operators

--- a/packages/sqflite/example/lib/manual_test_page.dart
+++ b/packages/sqflite/example/lib/manual_test_page.dart
@@ -315,7 +315,7 @@ class _SimpleDbTestPageState extends State<SimpleDbTestPage> {
               final result =
                   firstIntValue(await db.query('test', columns: ['COUNT(*)']));
               // Temp for nnbd successfull lint
-              if (mounted) {
+              if (context.mounted) {
                 ScaffoldMessenger.of(context).showSnackBar(SnackBar(
                   content: Text('$result records'),
                   duration: const Duration(milliseconds: 700),


### PR DESCRIPTION
Fix analyzing issues when upgrade to 3.19 :
- 'always_require_non_null_named_parameters' was removed in Dart '3.3.0'
- Don't use 'BuildContext's across async gaps, guarded by an unrelated 'mounted' check.
- The named parameter 'primary' isn't defined.