### PR TITLE
[video_player_avplay] Add get streaming property interface and Update SetStreamingProperty interface

### DIFF
--- a/packages/video_player_avplay/CHANGELOG.md
+++ b/packages/video_player_avplay/CHANGELOG.md
@@ -1,6 +1,7 @@
-## NEXT
+## 0.4.0
 
 * Minor refactor.
+* Add getStreamingProperty interface.
 
 ## 0.3.3
 

--- a/packages/video_player_avplay/README.md
+++ b/packages/video_player_avplay/README.md
@@ -12,7 +12,7 @@ To use this package, add `video_player_avplay` as a dependency in your `pubspec.
 
 ```yaml
 dependencies:
-  video_player_avplay: ^0.3.3
+  video_player_avplay: ^0.4.0
 ```
 
 Then you can import `video_player_avplay` in your Dart code:

--- a/packages/video_player_avplay/lib/src/messages.g.dart
+++ b/packages/video_player_avplay/lib/src/messages.g.dart
@@ -364,6 +364,58 @@ class DurationMessage {
   }
 }
 
+class StreamingPropertyMessage {
+  StreamingPropertyMessage({
+    required this.playerId,
+    required this.streamingProperty,
+  });
+
+  int playerId;
+
+  String streamingProperty;
+
+  Object encode() {
+    return <Object?>[
+      playerId,
+      streamingProperty,
+    ];
+  }
+
+  static StreamingPropertyMessage decode(Object result) {
+    result as List<Object?>;
+    return StreamingPropertyMessage(
+      playerId: result[0]! as int,
+      streamingProperty: result[1]! as String,
+    );
+  }
+}
+
+class StreamingPropertyTypeMessage {
+  StreamingPropertyTypeMessage({
+    required this.playerId,
+    required this.streamingPropertyType,
+  });
+
+  int playerId;
+
+  String streamingPropertyType;
+
+  Object encode() {
+    return <Object?>[
+      playerId,
+      streamingPropertyType,
+    ];
+  }
+
+  static StreamingPropertyTypeMessage decode(Object result) {
+    result as List<Object?>;
+    return StreamingPropertyTypeMessage(
+      playerId: result[0]! as int,
+      streamingPropertyType: result[1]! as String,
+    );
+  }
+}
+
 class _VideoPlayerAvplayApiCodec extends StandardMessageCodec {
   const _VideoPlayerAvplayApiCodec();
   @override
@@ -395,14 +447,20 @@ class _VideoPlayerAvplayApiCodec extends StandardMessageCodec {
     } else if (value is SelectedTracksMessage) {
       buffer.putUint8(136);
       writeValue(buffer, value.encode());
-    } else if (value is TrackMessage) {
+    } else if (value is StreamingPropertyMessage) {
       buffer.putUint8(137);
       writeValue(buffer, value.encode());
-    } else if (value is TrackTypeMessage) {
+    } else if (value is StreamingPropertyTypeMessage) {
       buffer.putUint8(138);
       writeValue(buffer, value.encode());
-    } else if (value is VolumeMessage) {
+    } else if (value is TrackMessage) {
       buffer.putUint8(139);
+      writeValue(buffer, value.encode());
+    } else if (value is TrackTypeMessage) {
+      buffer.putUint8(140);
+      writeValue(buffer, value.encode());
+    } else if (value is VolumeMessage) {
+      buffer.putUint8(141);
       writeValue(buffer, value.encode());
     } else {
       super.writeValue(buffer, value);
@@ -431,10 +489,14 @@ class _VideoPlayerAvplayApiCodec extends StandardMessageCodec {
       case 136:
         return SelectedTracksMessage.decode(readValue(buffer)!);
       case 137:
-        return TrackMessage.decode(readValue(buffer)!);
+        return StreamingPropertyMessage.decode(readValue(buffer)!);
       case 138:
-        return TrackTypeMessage.decode(readValue(buffer)!);
+        return StreamingPropertyTypeMessage.decode(readValue(buffer)!);
       case 139:
+        return TrackMessage.decode(readValue(buffer)!);
+      case 140:
+        return TrackTypeMessage.decode(readValue(buffer)!);
+      case 141:
         return VolumeMessage.decode(readValue(buffer)!);
       default:
         return super.readValueOfType(type, buffer);
@@ -874,6 +936,35 @@ class VideoPlayerAvplayApi {
       );
     } else {
       return;
+    }
+  }
+
+  Future<StreamingPropertyMessage> getStreamingProperty(
+      StreamingPropertyTypeMessage arg_msg) async {
+    final BasicMessageChannel<Object?> channel = BasicMessageChannel<Object?>(
+        'dev.flutter.pigeon.video_player_avplay.VideoPlayerAvplayApi.getStreamingProperty',
+        codec,
+        binaryMessenger: _binaryMessenger);
+    final List<Object?>? replyList =
+        await channel.send(<Object?>[arg_msg]) as List<Object?>?;
+    if (replyList == null) {
+      throw PlatformException(
+        code: 'channel-error',
+        message: 'Unable to establish connection on channel.',
+      );
+    } else if (replyList.length > 1) {
+      throw PlatformException(
+        code: replyList[0]! as String,
+        message: replyList[1] as String?,
+        details: replyList[2],
+      );
+    } else if (replyList[0] == null) {
+      throw PlatformException(
+        code: 'null-error',
+        message: 'Host platform returned null value for non-null return value.',
+      );
+    } else {
+      return (replyList[0] as StreamingPropertyMessage?)!;
     }
   }
 }

--- a/packages/video_player_avplay/lib/src/video_player_tizen.dart
+++ b/packages/video_player_avplay/lib/src/video_player_tizen.dart
@@ -198,6 +198,15 @@ class VideoPlayerTizen extends VideoPlayerPlatform {
   }
 
   @override
+  Future<String> getStreamingProperty(
+      int playerId, StreamingPropertyType type) async {
+    final StreamingPropertyMessage streamingPropertyMessage =
+        await _api.getStreamingProperty(StreamingPropertyTypeMessage(
+            playerId: playerId, streamingPropertyType: _streamingPropertyType[type]!));
+    return streamingPropertyMessage.streamingProperty;
+  }
+
+  @override
   Stream<VideoEvent> videoEventsFor(int playerId) {
     return _eventChannelFor(playerId)
         .receiveBroadcastStream()
@@ -285,5 +294,23 @@ class VideoPlayerTizen extends VideoPlayerPlatform {
     1: AudioTrackChannelType.mono,
     2: AudioTrackChannelType.stereo,
     3: AudioTrackChannelType.surround,
+  };
+
+  static const Map<StreamingPropertyType, String> _streamingPropertyType =
+      <StreamingPropertyType, String>{
+    StreamingPropertyType.ADAPTIVE_INFO: 'ADAPTIVE_INFO',
+    StreamingPropertyType.AVAILABLE_BITRATE: 'AVAILABLE_BITRATE',
+    StreamingPropertyType.COOKIE: 'COOKIE',
+    StreamingPropertyType.CURRENT_BANDWIDTH: 'CURRENT_BANDWIDTH',
+    StreamingPropertyType.GET_LIVE_DURATION: 'GET_LIVE_DURATION',
+    StreamingPropertyType.IN_APP_MULTIVIEW: 'IN_APP_MULTIVIEW',
+    StreamingPropertyType.IS_LIVE: 'IS_LIVE',
+    StreamingPropertyType.LISTEN_SPARSE_TRACK: 'LISTEN_SPARSE_TRACK',
+    StreamingPropertyType.PORTRAIT_MODE: 'PORTRAIT_MODE',
+    StreamingPropertyType.PREBUFFER_MODE: 'PREBUFFER_MODE',
+    StreamingPropertyType.SET_MIXEDFRAME: 'SET_MIXEDFRAME',
+    StreamingPropertyType.SET_MODE_4K: 'SET_MODE_4K',
+    StreamingPropertyType.USER_AGENT: 'USER_AGENT',
+    StreamingPropertyType.USE_VIDEOMIXER: 'USE_VIDEOMIXER',
   };
 }

--- a/packages/video_player_avplay/lib/src/video_player_tizen.dart
+++ b/packages/video_player_avplay/lib/src/video_player_tizen.dart
@@ -202,7 +202,8 @@ class VideoPlayerTizen extends VideoPlayerPlatform {
       int playerId, StreamingPropertyType type) async {
     final StreamingPropertyMessage streamingPropertyMessage =
         await _api.getStreamingProperty(StreamingPropertyTypeMessage(
-            playerId: playerId, streamingPropertyType: _streamingPropertyType[type]!));
+            playerId: playerId,
+            streamingPropertyType: _streamingPropertyType[type]!));
     return streamingPropertyMessage.streamingProperty;
   }
 

--- a/packages/video_player_avplay/lib/src/video_player_tizen.dart
+++ b/packages/video_player_avplay/lib/src/video_player_tizen.dart
@@ -303,19 +303,19 @@ class VideoPlayerTizen extends VideoPlayerPlatform {
 
   static const Map<StreamingPropertyType, String> _streamingPropertyType =
       <StreamingPropertyType, String>{
-    StreamingPropertyType.ADAPTIVE_INFO: 'ADAPTIVE_INFO',
-    StreamingPropertyType.AVAILABLE_BITRATE: 'AVAILABLE_BITRATE',
-    StreamingPropertyType.COOKIE: 'COOKIE',
-    StreamingPropertyType.CURRENT_BANDWIDTH: 'CURRENT_BANDWIDTH',
-    StreamingPropertyType.GET_LIVE_DURATION: 'GET_LIVE_DURATION',
-    StreamingPropertyType.IN_APP_MULTIVIEW: 'IN_APP_MULTIVIEW',
-    StreamingPropertyType.IS_LIVE: 'IS_LIVE',
-    StreamingPropertyType.LISTEN_SPARSE_TRACK: 'LISTEN_SPARSE_TRACK',
-    StreamingPropertyType.PORTRAIT_MODE: 'PORTRAIT_MODE',
-    StreamingPropertyType.PREBUFFER_MODE: 'PREBUFFER_MODE',
-    StreamingPropertyType.SET_MIXEDFRAME: 'SET_MIXEDFRAME',
-    StreamingPropertyType.SET_MODE_4K: 'SET_MODE_4K',
-    StreamingPropertyType.USER_AGENT: 'USER_AGENT',
-    StreamingPropertyType.USE_VIDEOMIXER: 'USE_VIDEOMIXER',
+    StreamingPropertyType.adaptiveInfo: 'ADAPTIVE_INFO',
+    StreamingPropertyType.availableBitrate: 'AVAILABLE_BITRATE',
+    StreamingPropertyType.cookie: 'COOKIE',
+    StreamingPropertyType.currentBandwidth: 'CURRENT_BANDWIDTH',
+    StreamingPropertyType.getLiveDuration: 'GET_LIVE_DURATION',
+    StreamingPropertyType.inAppMultiView: 'IN_APP_MULTIVIEW',
+    StreamingPropertyType.isLive: 'IS_LIVE',
+    StreamingPropertyType.listenSparseTrack: 'LISTEN_SPARSE_TRACK',
+    StreamingPropertyType.portraitMode: 'PORTRAIT_MODE',
+    StreamingPropertyType.prebufferMode: 'PREBUFFER_MODE',
+    StreamingPropertyType.setMixedFrame: 'SET_MIXEDFRAME',
+    StreamingPropertyType.setMode4K: 'SET_MODE_4K',
+    StreamingPropertyType.userAgent: 'USER_AGENT',
+    StreamingPropertyType.useVideoMixer: 'USE_VIDEOMIXER',
   };
 }

--- a/packages/video_player_avplay/lib/src/video_player_tizen.dart
+++ b/packages/video_player_avplay/lib/src/video_player_tizen.dart
@@ -3,8 +3,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'dart:async';
-
 import 'package:flutter/services.dart';
 import 'package:flutter/widgets.dart';
 
@@ -42,7 +40,13 @@ class VideoPlayerTizen extends VideoPlayerPlatform {
         message.httpHeaders = dataSource.httpHeaders;
         message.drmConfigs = dataSource.drmConfigs?.toMap();
         message.playerOptions = dataSource.playerOptions;
-        message.streamingProperty = dataSource.streamingProperty;
+        message.streamingProperty = dataSource.streamingProperty == null
+            ? null
+            : <String, String>{
+                for (final MapEntry<StreamingPropertyType, String> entry
+                    in dataSource.streamingProperty!.entries)
+                  _streamingPropertyType[entry.key]!: entry.value
+              };
         break;
       case DataSourceType.file:
         message.uri = dataSource.uri;

--- a/packages/video_player_avplay/lib/video_player.dart
+++ b/packages/video_player_avplay/lib/video_player.dart
@@ -714,6 +714,14 @@ class VideoPlayerController extends ValueNotifier<VideoPlayerValue> {
     await _applyVolume();
   }
 
+  /// Retrieves a specific property value obtained by the streaming engine (Smooth Streaming, HLS, DASH, or Widevine).
+  Future<String> getStreamingProperty(StreamingPropertyType type) async {
+    if (_isDisposedOrNotInitialized) {
+      return '';
+    }
+    return _videoPlayerPlatform.getStreamingProperty(_playerId, type);
+  }
+
   /// Sets the playback speed of [this].
   ///
   /// [speed] indicates a speed value with different platforms accepting

--- a/packages/video_player_avplay/lib/video_player.dart
+++ b/packages/video_player_avplay/lib/video_player.dart
@@ -315,7 +315,7 @@ class VideoPlayerController extends ValueNotifier<VideoPlayerValue> {
   /// Sets specific feature values for HTTP, MMS, or specific streaming engine (Smooth Streaming, HLS, DASH, DivX Plus Streaming, or Widevine).
   /// The available streaming properties depend on the streaming protocol or engine.
   /// Only for [VideoPlayerController.network].
-  final Map<String, String>? streamingProperty;
+  final Map<StreamingPropertyType, String>? streamingProperty;
 
   /// **Android only**. Will override the platform's generic file format
   /// detection with whatever is set here.

--- a/packages/video_player_avplay/lib/video_player_platform_interface.dart
+++ b/packages/video_player_avplay/lib/video_player_platform_interface.dart
@@ -132,6 +132,13 @@ abstract class VideoPlayerPlatform extends PlatformInterface {
     throw UnimplementedError('getDuration() has not been implemented.');
   }
 
+  /// Retrieves a specific property value obtained by the streaming engine (Smooth Streaming, HLS, DASH, or Widevine).
+  Future<String> getStreamingProperty(
+      int playerId, StreamingPropertyType type) {
+    throw UnimplementedError(
+        'getStreamingProperty() has not been implemented.');
+  }
+
   /// Returns a widget displaying the video with a given playerId.
   Widget buildView(int playerId) {
     throw UnimplementedError('buildView() has not been implemented.');
@@ -251,6 +258,73 @@ enum VideoFormat {
 
   /// Any format other than the other ones defined in this enum.
   other,
+}
+
+/// The file format of the given video.
+enum StreamingPropertyType {
+  /// HTTP request cookie used to establish the session with the HTTP server.
+  COOKIE,
+
+  /// HTTP user agent, used in the HTTP request header.
+  USER_AGENT,
+
+  /// Property to initiate prebuffering mode. The second parameter indicates start-time for prebuffered content, in milliseconds.
+  PREBUFFER_MODE,
+
+  /// Sets a custom streaming URL with various streaming parameters, such as "BITRATES", "STARTBITRATE", or "SKIPBITRATE".
+  /// String containing custom attributes for adaptive streaming playback.
+  /// "STARTBITRATE=" Valid values are "LOWEST", "HIGHEST", and "AVERAGE". You can also define a specific bandwidth for the start of playback.
+  /// "BITRATES=" Use '~' to define a bandwidth range (5000 ~ 20000). You can also define a specific bandwidth for playback.
+  /// "SKIPBITRATE=" Defines the bandwidth to use after a skip operation.
+  /// "STARTFRAGMENT=" For live content playback, defines the start fragment number.
+  /// "FIXED_MAX_RESOLUTION=max_widthXmax_height". Only if the given media URI such as mpd in MPEG-DASH or m3u8 in HLS through open()
+  ///  method doesn't describe entire required video resolutions,application should use this attribute to complete the resolution information for the player.
+
+  ADAPTIVE_INFO,
+
+  /// Forces the player to use the 4K UHD decoder. Its parameter can be the string "TRUE" or "FALSE".
+  /// In the case of adaptive streaming which requires stream-change for different video resolution during the playback,
+  /// Only if the given media URI such as mpd in MPEG-DASH or m3u8 in HLS through open() method doesn't describe entire required video resolutions,
+  /// pass TRUE with this property in IDLE state.
+
+  SET_MODE_4K,
+
+  /// For the Smooth Streaming case, configures the player to listen for a "Sparse name" configured through "propertyParam" . The sparse track name is a string.
+
+  LISTEN_SPARSE_TRACK,
+
+  /// Whether the stream is LIVE or VOD. Applicable to all streaming types.
+
+  IS_LIVE,
+
+  /// String listing the available bit-rates for the currently-playing stream.
+
+  AVAILABLE_BITRATE,
+
+  /// String describing the duration of live content.
+
+  GET_LIVE_DURATION,
+
+  /// String describing the current streaming bandwidth.
+
+  CURRENT_BANDWIDTH,
+
+  /// Property used for enabling/initializing video mixer feature on B2B product only. It should be set before
+  /// setting SET_MIXEDFRAME property on the player.
+
+  USE_VIDEOMIXER,
+
+  /// : Property to set the position of mixed frame. setDisplayRect with required position on corresponding
+  ///  player instance to be called before setting this property.
+
+  SET_MIXEDFRAME,
+
+  /// Property to force the playback the video in potrait mode on B2B proudct only.
+
+  PORTRAIT_MODE,
+
+  /// Property to select the Scaler type, By Default MAIN Scaler selected.
+  IN_APP_MULTIVIEW,
 }
 
 /// Event emitted from the platform implementation.

--- a/packages/video_player_avplay/lib/video_player_platform_interface.dart
+++ b/packages/video_player_avplay/lib/video_player_platform_interface.dart
@@ -260,7 +260,7 @@ enum VideoFormat {
   other,
 }
 
-/// The file format of the given video.
+/// The streaming property type.
 enum StreamingPropertyType {
   /// HTTP request cookie used to establish the session with the HTTP server.
   COOKIE,
@@ -314,7 +314,7 @@ enum StreamingPropertyType {
 
   USE_VIDEOMIXER,
 
-  /// : Property to set the position of mixed frame. setDisplayRect with required position on corresponding
+  /// Property to set the position of mixed frame. setDisplayRect with required position on corresponding
   ///  player instance to be called before setting this property.
 
   SET_MIXEDFRAME,

--- a/packages/video_player_avplay/lib/video_player_platform_interface.dart
+++ b/packages/video_player_avplay/lib/video_player_platform_interface.dart
@@ -263,13 +263,13 @@ enum VideoFormat {
 /// The streaming property type.
 enum StreamingPropertyType {
   /// HTTP request cookie used to establish the session with the HTTP server.
-  COOKIE,
+  cookie,
 
   /// HTTP user agent, used in the HTTP request header.
-  USER_AGENT,
+  userAgent,
 
   /// Property to initiate prebuffering mode. The second parameter indicates start-time for prebuffered content, in milliseconds.
-  PREBUFFER_MODE,
+  prebufferMode,
 
   /// Sets a custom streaming URL with various streaming parameters, such as "BITRATES", "STARTBITRATE", or "SKIPBITRATE".
   /// String containing custom attributes for adaptive streaming playback.
@@ -279,52 +279,42 @@ enum StreamingPropertyType {
   /// "STARTFRAGMENT=" For live content playback, defines the start fragment number.
   /// "FIXED_MAX_RESOLUTION=max_widthXmax_height". Only if the given media URI such as mpd in MPEG-DASH or m3u8 in HLS through open()
   ///  method doesn't describe entire required video resolutions,application should use this attribute to complete the resolution information for the player.
-
-  ADAPTIVE_INFO,
+  adaptiveInfo,
 
   /// Forces the player to use the 4K UHD decoder. Its parameter can be the string "TRUE" or "FALSE".
   /// In the case of adaptive streaming which requires stream-change for different video resolution during the playback,
   /// Only if the given media URI such as mpd in MPEG-DASH or m3u8 in HLS through open() method doesn't describe entire required video resolutions,
   /// pass TRUE with this property in IDLE state.
-
-  SET_MODE_4K,
+  setMode4K,
 
   /// For the Smooth Streaming case, configures the player to listen for a "Sparse name" configured through "propertyParam" . The sparse track name is a string.
-
-  LISTEN_SPARSE_TRACK,
+  listenSparseTrack,
 
   /// Whether the stream is LIVE or VOD. Applicable to all streaming types.
-
-  IS_LIVE,
+  isLive,
 
   /// String listing the available bit-rates for the currently-playing stream.
-
-  AVAILABLE_BITRATE,
+  availableBitrate,
 
   /// String describing the duration of live content.
-
-  GET_LIVE_DURATION,
+  getLiveDuration,
 
   /// String describing the current streaming bandwidth.
-
-  CURRENT_BANDWIDTH,
+  currentBandwidth,
 
   /// Property used for enabling/initializing video mixer feature on B2B product only. It should be set before
   /// setting SET_MIXEDFRAME property on the player.
-
-  USE_VIDEOMIXER,
+  useVideoMixer,
 
   /// Property to set the position of mixed frame. setDisplayRect with required position on corresponding
   ///  player instance to be called before setting this property.
-
-  SET_MIXEDFRAME,
+  setMixedFrame,
 
   /// Property to force the playback the video in potrait mode on B2B proudct only.
-
-  PORTRAIT_MODE,
+  portraitMode,
 
   /// Property to select the Scaler type, By Default MAIN Scaler selected.
-  IN_APP_MULTIVIEW,
+  inAppMultiView,
 }
 
 /// Event emitted from the platform implementation.

--- a/packages/video_player_avplay/lib/video_player_platform_interface.dart
+++ b/packages/video_player_avplay/lib/video_player_platform_interface.dart
@@ -224,7 +224,7 @@ class DataSource {
   Map<String, dynamic>? playerOptions;
 
   /// Sets specific feature values for HTTP, MMS, or specific streaming engine
-  Map<String, String>? streamingProperty;
+  Map<StreamingPropertyType, String>? streamingProperty;
 }
 
 /// The way in which the video was originally loaded.

--- a/packages/video_player_avplay/pigeons/messages.dart
+++ b/packages/video_player_avplay/pigeons/messages.dart
@@ -89,6 +89,18 @@ class DurationMessage {
   List<int?>? durationRange;
 }
 
+class StreamingPropertyMessage {
+  StreamingPropertyMessage(this.playerId, this.streamingProperty);
+  int playerId;
+  String streamingProperty;
+}
+
+class StreamingPropertyTypeMessage {
+  StreamingPropertyTypeMessage(this.playerId, this.streamingPropertyType);
+  int playerId;
+  String streamingPropertyType;
+}
+
 @HostApi()
 abstract class VideoPlayerAvplayApi {
   void initialize();
@@ -109,4 +121,6 @@ abstract class VideoPlayerAvplayApi {
   void pause(PlayerMessage msg);
   void setMixWithOthers(MixWithOthersMessage msg);
   void setDisplayGeometry(GeometryMessage msg);
+  StreamingPropertyMessage getStreamingProperty(
+      StreamingPropertyTypeMessage msg);
 }

--- a/packages/video_player_avplay/pubspec.yaml
+++ b/packages/video_player_avplay/pubspec.yaml
@@ -2,7 +2,7 @@ name: video_player_avplay
 description: Flutter plugin for displaying inline video on Tizen TV devices.
 homepage: https://github.com/flutter-tizen/plugins
 repository: https://github.com/flutter-tizen/plugins/tree/master/packages/video_player_avplay
-version: 0.3.3
+version: 0.4.0
 
 environment:
   sdk: ">=2.18.0 <4.0.0"

--- a/packages/video_player_avplay/tizen/src/media_player.cc
+++ b/packages/video_player_avplay/tizen/src/media_player.cc
@@ -86,8 +86,8 @@ int64_t MediaPlayer::Create(const std::string &uri,
     return -1;
   }
 
-  std::string cookie = flutter_common::GetValue(create_message.http_headers(),
-                                                "Cookie", std::string());
+  std::string cookie = flutter_common::GetValue(
+      create_message.streaming_property(), "COOKIE", std::string());
   if (!cookie.empty()) {
     int ret =
         player_set_streaming_cookie(player_, cookie.c_str(), cookie.size());
@@ -97,7 +97,7 @@ int64_t MediaPlayer::Create(const std::string &uri,
     }
   }
   std::string user_agent = flutter_common::GetValue(
-      create_message.http_headers(), "User-Agent", std::string());
+      create_message.streaming_property(), "USER_AGENT", std::string());
   if (!user_agent.empty()) {
     int ret = player_set_streaming_user_agent(player_, user_agent.c_str(),
                                               user_agent.size());

--- a/packages/video_player_avplay/tizen/src/messages.h
+++ b/packages/video_player_avplay/tizen/src/messages.h
@@ -365,6 +365,52 @@ class DurationMessage {
   std::optional<flutter::EncodableList> duration_range_;
 };
 
+// Generated class from Pigeon that represents data sent in messages.
+class StreamingPropertyMessage {
+ public:
+  // Constructs an object setting all fields.
+  explicit StreamingPropertyMessage(int64_t player_id,
+                                    const std::string& streaming_property);
+
+  int64_t player_id() const;
+  void set_player_id(int64_t value_arg);
+
+  const std::string& streaming_property() const;
+  void set_streaming_property(std::string_view value_arg);
+
+ private:
+  static StreamingPropertyMessage FromEncodableList(
+      const flutter::EncodableList& list);
+  flutter::EncodableList ToEncodableList() const;
+  friend class VideoPlayerAvplayApi;
+  friend class VideoPlayerAvplayApiCodecSerializer;
+  int64_t player_id_;
+  std::string streaming_property_;
+};
+
+// Generated class from Pigeon that represents data sent in messages.
+class StreamingPropertyTypeMessage {
+ public:
+  // Constructs an object setting all fields.
+  explicit StreamingPropertyTypeMessage(
+      int64_t player_id, const std::string& streaming_property_type);
+
+  int64_t player_id() const;
+  void set_player_id(int64_t value_arg);
+
+  const std::string& streaming_property_type() const;
+  void set_streaming_property_type(std::string_view value_arg);
+
+ private:
+  static StreamingPropertyTypeMessage FromEncodableList(
+      const flutter::EncodableList& list);
+  flutter::EncodableList ToEncodableList() const;
+  friend class VideoPlayerAvplayApi;
+  friend class VideoPlayerAvplayApiCodecSerializer;
+  int64_t player_id_;
+  std::string streaming_property_type_;
+};
+
 class VideoPlayerAvplayApiCodecSerializer
     : public flutter::StandardCodecSerializer {
  public:
@@ -411,6 +457,8 @@ class VideoPlayerAvplayApi {
       const MixWithOthersMessage& msg) = 0;
   virtual std::optional<FlutterError> SetDisplayGeometry(
       const GeometryMessage& msg) = 0;
+  virtual ErrorOr<StreamingPropertyMessage> GetStreamingProperty(
+      const StreamingPropertyTypeMessage& msg) = 0;
 
   // The codec used by VideoPlayerAvplayApi.
   static const flutter::StandardMessageCodec& GetCodec();

--- a/packages/video_player_avplay/tizen/src/plus_player.cc
+++ b/packages/video_player_avplay/tizen/src/plus_player.cc
@@ -334,7 +334,7 @@ bool PlusPlayer::IsLive() {
 
 std::pair<int64_t, int64_t> PlusPlayer::GetLiveDuration() {
   std::string live_duration_str =
-      GetStreamingProperty(player_, "GET_LIVE_DURATION");
+      ::GetStreamingProperty(player_, "GET_LIVE_DURATION");
   if (live_duration_str.empty()) {
     LOG_ERROR("[PlusPlayer] Player fail to get live duration.");
     return std::make_pair(0, 0);
@@ -575,6 +575,20 @@ bool PlusPlayer::SetDrm(const std::string &uri, int drm_type,
     }
   }
   return true;
+}
+
+std::string PlusPlayer::GetStreamingProperty(
+    const std::string &streaming_property_type) {
+  if (!player_) {
+    LOG_ERROR("[PlusPlayer] Player not created.");
+    return "";
+  }
+  plusplayer::State state = GetState(player_);
+  if (state == plusplayer::State::kNone || state == plusplayer::State::kIdle) {
+    LOG_ERROR("[PIE]:Player is in invalid state[%d]", state);
+    return "";
+  }
+  return ::GetStreamingProperty(player_, streaming_property_type);
 }
 
 bool PlusPlayer::OnLicenseAcquired(int *drm_handle, unsigned int length,

--- a/packages/video_player_avplay/tizen/src/plus_player.cc
+++ b/packages/video_player_avplay/tizen/src/plus_player.cc
@@ -87,20 +87,12 @@ int64_t PlusPlayer::Create(const std::string &uri,
     return -1;
   }
 
-  std::string cookie = flutter_common::GetValue(create_message.http_headers(),
-                                                "Cookie", std::string());
-  if (!cookie.empty()) {
-    SetStreamingProperty(player_, "COOKIE", cookie);
-  }
-  std::string user_agent = flutter_common::GetValue(
-      create_message.http_headers(), "User-Agent", std::string());
-  if (!user_agent.empty()) {
-    SetStreamingProperty(player_, "USER_AGENT", user_agent);
-  }
-  std::string adaptive_info = flutter_common::GetValue(
-      create_message.streaming_property(), "ADAPTIVE_INFO", std::string());
-  if (!adaptive_info.empty()) {
-    SetStreamingProperty(player_, "ADAPTIVE_INFO", adaptive_info);
+  if (create_message.streaming_property() != nullptr &&
+      !create_message.streaming_property()->empty()) {
+    for (const auto &[key, value] : *create_message.streaming_property()) {
+      SetStreamingProperty(player_, std::get<std::string>(key),
+                           std::get<std::string>(value));
+    }
   }
 
   if (!Open(player_, uri)) {
@@ -585,7 +577,7 @@ std::string PlusPlayer::GetStreamingProperty(
   }
   plusplayer::State state = GetState(player_);
   if (state == plusplayer::State::kNone || state == plusplayer::State::kIdle) {
-    LOG_ERROR("[PIE]:Player is in invalid state[%d]", state);
+    LOG_ERROR("[PlusPlayer]:Player is in invalid state[%d]", state);
     return "";
   }
   return ::GetStreamingProperty(player_, streaming_property_type);

--- a/packages/video_player_avplay/tizen/src/plus_player.h
+++ b/packages/video_player_avplay/tizen/src/plus_player.h
@@ -41,6 +41,7 @@ class PlusPlayer : public VideoPlayer {
   bool IsReady() override;
   flutter::EncodableList GetTrackInfo(std::string track_type) override;
   bool SetTrackSelection(int32_t track_id, std::string track_type) override;
+  std::string GetStreamingProperty(const std::string& streaming_property_type) override;
 
  private:
   bool IsLive();

--- a/packages/video_player_avplay/tizen/src/plus_player.h
+++ b/packages/video_player_avplay/tizen/src/plus_player.h
@@ -41,7 +41,8 @@ class PlusPlayer : public VideoPlayer {
   bool IsReady() override;
   flutter::EncodableList GetTrackInfo(std::string track_type) override;
   bool SetTrackSelection(int32_t track_id, std::string track_type) override;
-  std::string GetStreamingProperty(const std::string& streaming_property_type) override;
+  std::string GetStreamingProperty(
+      const std::string &streaming_property_type) override;
 
  private:
   bool IsLive();

--- a/packages/video_player_avplay/tizen/src/video_player.h
+++ b/packages/video_player_avplay/tizen/src/video_player.h
@@ -48,7 +48,10 @@ class VideoPlayer {
   virtual bool IsReady() = 0;
   virtual flutter::EncodableList GetTrackInfo(std::string track_type) = 0;
   virtual bool SetTrackSelection(int32_t track_id, std::string track_type) = 0;
-  virtual std::string GetStreamingProperty(const std::string& streaming_property_type){ return "";};
+  virtual std::string GetStreamingProperty(
+      const std::string &streaming_property_type) {
+    return "";
+  };
 
  protected:
   virtual void GetVideoSize(int32_t *width, int32_t *height) = 0;

--- a/packages/video_player_avplay/tizen/src/video_player.h
+++ b/packages/video_player_avplay/tizen/src/video_player.h
@@ -48,6 +48,7 @@ class VideoPlayer {
   virtual bool IsReady() = 0;
   virtual flutter::EncodableList GetTrackInfo(std::string track_type) = 0;
   virtual bool SetTrackSelection(int32_t track_id, std::string track_type) = 0;
+  virtual std::string GetStreamingProperty(const std::string& streaming_property_type){ return "";};
 
  protected:
   virtual void GetVideoSize(int32_t *width, int32_t *height) = 0;

--- a/packages/video_player_avplay/tizen/src/video_player_tizen_plugin.cc
+++ b/packages/video_player_avplay/tizen/src/video_player_tizen_plugin.cc
@@ -55,6 +55,8 @@ class VideoPlayerTizenPlugin : public flutter::Plugin,
       const MixWithOthersMessage &msg) override;
   std::optional<FlutterError> SetDisplayGeometry(
       const GeometryMessage &msg) override;
+  ErrorOr<StreamingPropertyMessage> GetStreamingProperty(
+      const StreamingPropertyTypeMessage &msg) override;
 
   static VideoPlayer *FindPlayerById(int64_t player_id) {
     auto iter = players_.find(player_id);
@@ -297,6 +299,18 @@ std::optional<FlutterError> VideoPlayerTizenPlugin::SetDisplayGeometry(
   }
   player->SetDisplayRoi(msg.x(), msg.y(), msg.width(), msg.height());
   return std::nullopt;
+}
+
+ErrorOr<StreamingPropertyMessage> VideoPlayerTizenPlugin::GetStreamingProperty(
+    const StreamingPropertyTypeMessage &msg) {
+  VideoPlayer *player = FindPlayerById(msg.player_id());
+  if (!player) {
+    return FlutterError("Invalid argument", "Player not found");
+  }
+  StreamingPropertyMessage result(
+      msg.player_id(),
+      player->GetStreamingProperty(msg.streaming_property_type()));
+  return result;
 }
 
 std::optional<FlutterError> VideoPlayerTizenPlugin::SetMixWithOthers(


### PR DESCRIPTION
## GetStreamingProperty Interface
```dart  
/// Retrieves a specific property value obtained by the streaming engine (Smooth Streaming, HLS, DASH, or Widevine).
  Future<String> getStreamingProperty(StreamingPropertyType type)
  ````
## SetStreamingProperty interface
```dart 
    _controller = VideoPlayerController.network(
        'https://bitdash-a.akamaihd.net/content/sintel/hls/playlist.m3u8',
        streamingProperty: <StreamingPropertyType, String>{
          StreamingPropertyType.setMode4K: 'true',
          StreamingPropertyType.prebufferMode: '50000'
        });
``` 
## StreamingPropertyType 
```dart
/// The streaming property type.
enum StreamingPropertyType {
  /// HTTP request cookie used to establish the session with the HTTP server.
  cookie,

  /// HTTP user agent, used in the HTTP request header.
  userAgent,

  /// Property to initiate prebuffering mode. The second parameter indicates start-time for prebuffered content, in milliseconds.
  prebufferMode,

  /// Sets a custom streaming URL with various streaming parameters, such as "BITRATES", "STARTBITRATE", or "SKIPBITRATE".
  /// String containing custom attributes for adaptive streaming playback.
  /// "STARTBITRATE=" Valid values are "LOWEST", "HIGHEST", and "AVERAGE". You can also define a specific bandwidth for the start of playback.
  /// "BITRATES=" Use '~' to define a bandwidth range (5000 ~ 20000). You can also define a specific bandwidth for playback.
  /// "SKIPBITRATE=" Defines the bandwidth to use after a skip operation.
  /// "STARTFRAGMENT=" For live content playback, defines the start fragment number.
  /// "FIXED_MAX_RESOLUTION=max_widthXmax_height". Only if the given media URI such as mpd in MPEG-DASH or m3u8 in HLS through open()
  ///  method doesn't describe entire required video resolutions,application should use this attribute to complete the resolution information for the player.
  adaptiveInfo,

  /// Forces the player to use the 4K UHD decoder. Its parameter can be the string "TRUE" or "FALSE".
  /// In the case of adaptive streaming which requires stream-change for different video resolution during the playback,
  /// Only if the given media URI such as mpd in MPEG-DASH or m3u8 in HLS through open() method doesn't describe entire required video resolutions,
  /// pass TRUE with this property in IDLE state.
  setMode4K,

  /// For the Smooth Streaming case, configures the player to listen for a "Sparse name" configured through "propertyParam" . The sparse track name is a string.
  listenSparseTrack,

  /// Whether the stream is LIVE or VOD. Applicable to all streaming types.
  isLive,

  /// String listing the available bit-rates for the currently-playing stream.
  availableBitrate,

  /// String describing the duration of live content.
  getLiveDuration,

  /// String describing the current streaming bandwidth.
  currentBandwidth,

  /// Property used for enabling/initializing video mixer feature on B2B product only. It should be set before
  /// setting SET_MIXEDFRAME property on the player.
  useVideoMixer,

  /// Property to set the position of mixed frame. setDisplayRect with required position on corresponding
  ///  player instance to be called before setting this property.
  setMixedFrame,

  /// Property to force the playback the video in potrait mode on B2B proudct only.
  portraitMode,

  /// Property to select the Scaler type, By Default MAIN Scaler selected.
  inAppMultiView,
}
```
