### PR TITLE
Sync with analysis_options.yaml in flutter/packages

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -1,16 +1,22 @@
-# This file is a copy of analysis_options.yaml from flutter/packages repo
-# as of 2023-03-07.
+# Specify analysis options.
+#
+# This file is a copy of analysis_options.yaml from flutter repo
+# as of 2023-12-18, but with some modifications marked with
+# "DIFFERENT FROM FLUTTER/FLUTTER" below. The file is expected to
+# be kept in sync with the master file from the flutter repo.
 
 analyzer:
   language:
     strict-casts: true
+    strict-inference: true
     strict-raw-types: true
   errors:
-    # allow self-reference to deprecated members (we do this because otherwise we have
-    # to annotate every member in every test, assert, etc, when we deprecate something)
+    # allow deprecated members (we do this because otherwise we have to annotate
+    # every member in every test, assert, etc, when we or the Dart SDK deprecates
+    # something (https://github.com/flutter/flutter/issues/143312)
+    deprecated_member_use: ignore
     deprecated_member_use_from_same_package: ignore
-    # Turned off until null-safe rollout is complete.
-    unnecessary_null_comparison: ignore
+    unnecessary_null_comparison: ignore # Temporarily ingnored from flutter-tizen.
   exclude: # DIFFERENT FROM FLUTTER/FLUTTER
     # Ignore generated files
     - '**/*.g.dart'
@@ -19,11 +25,10 @@ analyzer:
 linter:
   rules:
     # This list is derived from the list of all available lints located at
-    # https://github.com/dart-lang/linter/blob/master/example/all.yaml
+    # https://github.com/dart-lang/linter/blob/main/example/all.yaml
     - always_declare_return_types
     - always_put_control_body_on_new_line
     # - always_put_required_named_parameters_first # we prefer having parameters in the same order as fields https://github.com/flutter/flutter/issues/10219
-    - always_require_non_null_named_parameters
     - always_specify_types
     # - always_use_package_imports # we do this commonly
     - annotate_overrides
@@ -31,7 +36,7 @@ linter:
     - avoid_bool_literals_in_conditional_expressions
     # - avoid_catches_without_on_clauses # blocked on https://github.com/dart-lang/linter/issues/3023
     # - avoid_catching_errors # blocked on https://github.com/dart-lang/linter/issues/3023
-    - avoid_classes_with_only_static_members
+    # - avoid_classes_with_only_static_members # we do this commonly for `abstract final class`es
     - avoid_double_and_int_checks
     - avoid_dynamic_calls
     - avoid_empty_else
@@ -40,7 +45,7 @@ linter:
     - avoid_field_initializers_in_const_classes
     # - avoid_final_parameters # incompatible with prefer_final_parameters
     - avoid_function_literals_in_foreach_calls
-    - avoid_implementing_value_types
+    # - avoid_implementing_value_types # see https://github.com/dart-lang/linter/issues/4558
     - avoid_init_to_null
     - avoid_js_rounded_ints
     # - avoid_multiple_declarations_per_line # seems to be a stylistic choice we don't subscribe to
@@ -52,8 +57,6 @@ linter:
     - avoid_relative_lib_imports
     - avoid_renaming_method_parameters
     - avoid_return_types_on_setters
-    - avoid_returning_null
-    - avoid_returning_null_for_future
     - avoid_returning_null_for_void
     # - avoid_returning_this # there are enough valid reasons to return `this` that this lint ends up with too many false positives
     - avoid_setters_without_getters
@@ -74,17 +77,20 @@ linter:
     # - cascade_invocations # doesn't match the typical style of this repo
     - cast_nullable_to_non_nullable
     # - close_sinks # not reliable enough
-    # - combinators_ordering # DIFFERENT FROM FLUTTER/FLUTTER: This isn't available on stable yet.
+    - collection_methods_unrelated_type
+    - combinators_ordering
     # - comment_references # blocked on https://github.com/dart-lang/linter/issues/1142
     - conditional_uri_does_not_exist
     # - constant_identifier_names # needs an opt-out https://github.com/dart-lang/linter/issues/204
     - control_flow_in_finally
     - curly_braces_in_flow_control_structures
+    # - dangling_library_doc_comments # Temporarily ingnored from flutter-tizen.
     - depend_on_referenced_packages
     - deprecated_consistency
+    # - deprecated_member_use_from_same_package # we allow self-references to deprecated members
     # - diagnostic_describe_all_properties # enabled only at the framework level (packages/flutter/lib)
     - directives_ordering
-    # - discarded_futures # not yet tested
+    # - discarded_futures # too many false positives, similar to unawaited_futures
     # - do_not_use_environment # there are appropriate times to use the environment, especially in our tests and build logic
     - empty_catches
     - empty_constructor_bodies
@@ -95,23 +101,29 @@ linter:
     - flutter_style_todos
     - hash_and_equals
     - implementation_imports
-    - iterable_contains_unrelated_type
+    - implicit_call_tearoffs
+    - implicit_reopen
+    - invalid_case_patterns
     # - join_return_with_assignment # not required by flutter style
     - leading_newlines_in_multiline_strings
+    - library_annotations
     - library_names
     - library_prefixes
     - library_private_types_in_public_api
     # - lines_longer_than_80_chars # not required by flutter style
-    - list_remove_unrelated_type
-    # - literal_only_boolean_expressions # too many false positives: https://github.com/dart-lang/linter/issues/453
+    - literal_only_boolean_expressions
+    # - matching_super_parameters # blocked on https://github.com/dart-lang/language/issues/2509
     - missing_whitespace_between_adjacent_strings
     - no_adjacent_strings_in_list
     - no_default_cases
     - no_duplicate_case_values
     - no_leading_underscores_for_library_prefixes
     - no_leading_underscores_for_local_identifiers
+    # - no_literal_bool_comparisons # Temporarily ingnored from flutter-tizen.
     - no_logic_in_create_state
     - no_runtimeType_toString # DIFFERENT FROM FLUTTER/FLUTTER
+    - no_self_assignments
+    - no_wildcard_variable_uses
     - non_constant_identifier_names
     - noop_primitive_operations
     - null_check_on_nullable_type_parameter
@@ -136,12 +148,11 @@ linter:
     # - prefer_constructors_over_static_methods # far too many false positives
     - prefer_contains
     # - prefer_double_quotes # opposite of prefer_single_quotes
-    - prefer_equal_for_default_values
     # - prefer_expression_function_bodies # conflicts with https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#consider-using--for-short-functions-and-methods
     - prefer_final_fields
     - prefer_final_in_for_each
     - prefer_final_locals
-    # - prefer_final_parameters # we should enable this one day when it can be auto-fixed (https://github.com/dart-lang/linter/issues/3104), see also parameter_assignments
+    # - prefer_final_parameters # adds too much verbosity
     - prefer_for_elements_to_map_fromIterable
     - prefer_foreach
     - prefer_function_declarations_over_variables
@@ -156,7 +167,7 @@ linter:
     - prefer_is_not_empty
     - prefer_is_not_operator
     - prefer_iterable_whereType
-    # - prefer_mixin # Has false positives, see https://github.com/dart-lang/linter/issues/3018
+    - prefer_mixin
     # - prefer_null_aware_method_calls # "call()" is confusing to people new to the language since it's not documented anywhere
     - prefer_null_aware_operators
     - prefer_relative_imports
@@ -167,10 +178,10 @@ linter:
     - provide_deprecation_message
     - public_member_api_docs # DIFFERENT FROM FLUTTER/FLUTTER
     - recursive_getters
-    # - require_trailing_commas # blocked on https://github.com/dart-lang/sdk/issues/47441
+    # - require_trailing_commas # would be nice, but requires a lot of manual work: 10,000+ code locations would need to be reformatted by hand after bulk fix is applied
     - secure_pubspec_urls
     - sized_box_for_whitespace
-    # - sized_box_shrink_expand # not yet tested
+    - sized_box_shrink_expand
     - slash_for_doc_comments
     - sort_child_properties_last
     - sort_constructors_first
@@ -181,15 +192,18 @@ linter:
     - tighten_type_of_initializing_formals
     # - type_annotate_public_apis # subset of always_specify_types
     - type_init_formals
-    # - unawaited_futures # too many false positives, especially with the way AnimationController works
+    - type_literal_in_constant_pattern
+    # - unawaited_futures # DIFFERENT FROM FLUTTER/FLUTTER: It's disabled there for "too many false positives"; that's not an issue here, and missing awaits have caused production issues in plugins. # Temporarily ingnored from flutter-tizen.
     - unnecessary_await_in_return
     - unnecessary_brace_in_string_interps
+    - unnecessary_breaks
     - unnecessary_const
     - unnecessary_constructor_name
     # - unnecessary_final # conflicts with prefer_final_locals
     - unnecessary_getters_setters
     # - unnecessary_lambdas # has false positives: https://github.com/dart-lang/linter/issues/498
     - unnecessary_late
+    # - unnecessary_library_directive # Temporarily ingnored from flutter-tizen.
     - unnecessary_new
     - unnecessary_null_aware_assignments
     - unnecessary_null_aware_operator_on_extension_on_nullable
@@ -204,12 +218,13 @@ linter:
     - unnecessary_string_interpolations
     - unnecessary_this
     - unnecessary_to_list_in_spreads
+    - unreachable_from_main
     - unrelated_type_equality_checks
     - unsafe_html
     - use_build_context_synchronously
-    # - use_colored_box # not yet tested
-    # - use_decorated_box # not yet tested
-    # - use_enums # not yet tested
+    # - use_colored_box # Temporarily ingnored from flutter-tizen.
+    # - use_decorated_box # leads to bugs: DecoratedBox and Container are not equivalent (Container inserts extra padding)
+    # - use_enums # Temporarily ingnored from flutter-tizen.
     - use_full_hex_values_for_flutter_colors
     - use_function_type_syntax_for_parameters
     - use_if_null_to_convert_nulls_to_bools
@@ -221,6 +236,7 @@ linter:
     - use_rethrow_when_possible
     - use_setters_to_change_properties
     # - use_string_buffers # has false positives: https://github.com/dart-lang/sdk/issues/34182
+    # - use_string_in_part_of_directives # Temporarily ingnored from flutter-tizen.
     - use_super_parameters
     - use_test_throws_matchers
     # - use_to_and_as_if_applicable # has false positives, so we prefer to catch this by code-review

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -1,9 +1,5 @@
-# Specify analysis options.
-#
-# This file is a copy of analysis_options.yaml from flutter repo
-# as of 2023-12-18, but with some modifications marked with
-# "DIFFERENT FROM FLUTTER/FLUTTER" below. The file is expected to
-# be kept in sync with the master file from the flutter repo.
+# This file is a copy of analysis_options.yaml from flutter/packages repo
+# as of 2024-03-07.
 
 analyzer:
   language:

--- a/packages/messageport/example/integration_test/messageport_test.dart
+++ b/packages/messageport/example/integration_test/messageport_test.dart
@@ -26,7 +26,7 @@ void main() {
 
   testWidgets('Create remote port', (WidgetTester tester) async {
     final LocalPort localPort = await LocalPort.create(kTestPort);
-    localPort.register((dynamic message, [RemotePort? remotePort]) => () {});
+    localPort.register((dynamic message, [RemotePort? remotePort]) {});
 
     final RemotePort remotePort =
         await RemotePort.connect(kTestAppId, kTestPort);
@@ -40,7 +40,7 @@ void main() {
       (WidgetTester tester) async {
     final LocalPort localPort =
         await LocalPort.create(kTestPort, trusted: false);
-    localPort.register((dynamic message, [RemotePort? remotePort]) => () {});
+    localPort.register((dynamic message, [RemotePort? remotePort]) {});
 
     await expectLater(
       () => RemotePort.connect(kTestAppId, kTestPort),
@@ -52,7 +52,7 @@ void main() {
 
   testWidgets('Check for remote', (WidgetTester tester) async {
     final LocalPort localPort = await LocalPort.create(kTestPort);
-    localPort.register((dynamic message, [RemotePort? remotePort]) => () {});
+    localPort.register((dynamic message, [RemotePort? remotePort]) {});
 
     final RemotePort remotePort =
         await RemotePort.connect(kTestAppId, kTestPort);

--- a/packages/messageport/example/integration_test/messageport_test.dart
+++ b/packages/messageport/example/integration_test/messageport_test.dart
@@ -26,7 +26,7 @@ void main() {
 
   testWidgets('Create remote port', (WidgetTester tester) async {
     final LocalPort localPort = await LocalPort.create(kTestPort);
-    localPort.register((dynamic message, [RemotePort? remotePort]) => null);
+    localPort.register((dynamic message, [RemotePort? remotePort]) => () {});
 
     final RemotePort remotePort =
         await RemotePort.connect(kTestAppId, kTestPort);
@@ -40,7 +40,7 @@ void main() {
       (WidgetTester tester) async {
     final LocalPort localPort =
         await LocalPort.create(kTestPort, trusted: false);
-    localPort.register((dynamic message, [RemotePort? remotePort]) => null);
+    localPort.register((dynamic message, [RemotePort? remotePort]) => () {});
 
     await expectLater(
       () => RemotePort.connect(kTestAppId, kTestPort),
@@ -52,7 +52,7 @@ void main() {
 
   testWidgets('Check for remote', (WidgetTester tester) async {
     final LocalPort localPort = await LocalPort.create(kTestPort);
-    localPort.register((dynamic message, [RemotePort? remotePort]) => null);
+    localPort.register((dynamic message, [RemotePort? remotePort]) => () {});
 
     final RemotePort remotePort =
         await RemotePort.connect(kTestAppId, kTestPort);

--- a/packages/messageport/lib/messageport_tizen.dart
+++ b/packages/messageport/lib/messageport_tizen.dart
@@ -11,7 +11,8 @@ MessagePortManager _manager = MessagePortManager();
 /// Called when a message is received on message port.
 ///
 /// This is used by [LocalPort.register].
-typedef OnMessageReceived = Function(dynamic message, [RemotePort? remotePort]);
+typedef OnMessageReceived = void Function(dynamic message,
+    [RemotePort? remotePort]);
 
 /// Local message port for receiving messages.
 class LocalPort {

--- a/packages/video_player_avplay/example/lib/main.dart
+++ b/packages/video_player_avplay/example/lib/main.dart
@@ -632,7 +632,7 @@ class _GetVideoTrackButton extends StatelessWidget {
             if (videotracks == null) {
               return;
             }
-            await showDialog(
+            await showDialog<void>(
                 context: context,
                 builder: (BuildContext context) {
                   return AlertDialog(
@@ -676,7 +676,7 @@ class _GetAudioTrackButton extends StatelessWidget {
             if (audioTracks == null) {
               return;
             }
-            await showDialog(
+            await showDialog<void>(
                 context: context,
                 builder: (BuildContext context) {
                   return AlertDialog(
@@ -720,7 +720,7 @@ class _GetTextTrackButton extends StatelessWidget {
             if (textTracks == null) {
               return;
             }
-            await showDialog(
+            await showDialog<void>(
                 context: context,
                 builder: (BuildContext context) {
                   return AlertDialog(

--- a/packages/video_player_videohole/example/lib/main.dart
+++ b/packages/video_player_videohole/example/lib/main.dart
@@ -567,7 +567,7 @@ class _GetVideoTrackButton extends StatelessWidget {
             if (videotracks == null) {
               return;
             }
-            await showDialog(
+            await showDialog<void>(
                 context: context,
                 builder: (BuildContext context) {
                   return AlertDialog(
@@ -611,7 +611,7 @@ class _GetAudioTrackButton extends StatelessWidget {
             if (audioTracks == null) {
               return;
             }
-            await showDialog(
+            await showDialog<void>(
                 context: context,
                 builder: (BuildContext context) {
                   return AlertDialog(
@@ -655,7 +655,7 @@ class _GetTextTrackButton extends StatelessWidget {
             if (textTracks == null) {
               return;
             }
-            await showDialog(
+            await showDialog<void>(
                 context: context,
                 builder: (BuildContext context) {
                   return AlertDialog(


### PR DESCRIPTION
Some packages require package upgrade rather than simple modification (ex: google_maps_flutter)
Therefore, the rules below are temporarily ignored.
Any necessary modifications can be applied in a later PR.

https://github.com/flutter/packages/pull/4060
- unnecessary_null_comparison

https://github.com/flutter/packages/pull/4067
- unawaited_futures

https://github.com/flutter/packages/pull/5717
- dangling_library_doc_comments
- no_literal_bool_comparisons
- unnecessary_library_directive
- use_colored_box
- use_enums
- use_string_in_part_of_directives