### PR TITLE
Update minimum Flutter and Dart version to 3.13 and 3.1.

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -12,7 +12,6 @@ analyzer:
     # something (https://github.com/flutter/flutter/issues/143312)
     deprecated_member_use: ignore
     deprecated_member_use_from_same_package: ignore
-    unnecessary_null_comparison: ignore # Temporarily ingnored from flutter-tizen.
   exclude: # DIFFERENT FROM FLUTTER/FLUTTER
     # Ignore generated files
     - '**/*.g.dart'
@@ -80,7 +79,7 @@ linter:
     # - constant_identifier_names # needs an opt-out https://github.com/dart-lang/linter/issues/204
     - control_flow_in_finally
     - curly_braces_in_flow_control_structures
-    # - dangling_library_doc_comments # Temporarily ingnored from flutter-tizen.
+    - dangling_library_doc_comments
     - depend_on_referenced_packages
     - deprecated_consistency
     # - deprecated_member_use_from_same_package # we allow self-references to deprecated members
@@ -115,7 +114,7 @@ linter:
     - no_duplicate_case_values
     - no_leading_underscores_for_library_prefixes
     - no_leading_underscores_for_local_identifiers
-    # - no_literal_bool_comparisons # Temporarily ingnored from flutter-tizen.
+    - no_literal_bool_comparisons
     - no_logic_in_create_state
     - no_runtimeType_toString # DIFFERENT FROM FLUTTER/FLUTTER
     - no_self_assignments
@@ -189,7 +188,7 @@ linter:
     # - type_annotate_public_apis # subset of always_specify_types
     - type_init_formals
     - type_literal_in_constant_pattern
-    # - unawaited_futures # DIFFERENT FROM FLUTTER/FLUTTER: It's disabled there for "too many false positives"; that's not an issue here, and missing awaits have caused production issues in plugins. # Temporarily ingnored from flutter-tizen.
+    - unawaited_futures # DIFFERENT FROM FLUTTER/FLUTTER: It's disabled there for "too many false positives"; that's not an issue here, and missing awaits have caused production issues in plugins.
     - unnecessary_await_in_return
     - unnecessary_brace_in_string_interps
     - unnecessary_breaks
@@ -199,7 +198,7 @@ linter:
     - unnecessary_getters_setters
     # - unnecessary_lambdas # has false positives: https://github.com/dart-lang/linter/issues/498
     - unnecessary_late
-    # - unnecessary_library_directive # Temporarily ingnored from flutter-tizen.
+    - unnecessary_library_directive
     - unnecessary_new
     - unnecessary_null_aware_assignments
     - unnecessary_null_aware_operator_on_extension_on_nullable
@@ -218,9 +217,9 @@ linter:
     - unrelated_type_equality_checks
     - unsafe_html
     - use_build_context_synchronously
-    # - use_colored_box # Temporarily ingnored from flutter-tizen.
+    - use_colored_box
     # - use_decorated_box # leads to bugs: DecoratedBox and Container are not equivalent (Container inserts extra padding)
-    # - use_enums # Temporarily ingnored from flutter-tizen.
+    - use_enums
     - use_full_hex_values_for_flutter_colors
     - use_function_type_syntax_for_parameters
     - use_if_null_to_convert_nulls_to_bools
@@ -232,7 +231,7 @@ linter:
     - use_rethrow_when_possible
     - use_setters_to_change_properties
     # - use_string_buffers # has false positives: https://github.com/dart-lang/sdk/issues/34182
-    # - use_string_in_part_of_directives # Temporarily ingnored from flutter-tizen.
+    - use_string_in_part_of_directives
     - use_super_parameters
     - use_test_throws_matchers
     # - use_to_and_as_if_applicable # has false positives, so we prefer to catch this by code-review

--- a/packages/audioplayers/CHANGELOG.md
+++ b/packages/audioplayers/CHANGELOG.md
@@ -1,3 +1,7 @@
+## NEXT
+
+* Update minimum Flutter and Dart version to 3.13 and 3.1.
+
 ## 3.0.1
 
 * Update audioplayers to 5.1.0.

--- a/packages/audioplayers/example/pubspec.yaml
+++ b/packages/audioplayers/example/pubspec.yaml
@@ -3,8 +3,8 @@ description: Demonstrates how to use the audioplayers plugin.
 publish_to: "none"
 
 environment:
-  sdk: ">=2.18.0 <4.0.0"
-  flutter: ">=3.3.0"
+  sdk: ">=3.1.0 <4.0.0"
+  flutter: ">=3.13.0"
 
 dependencies:
   audioplayers: ^5.1.0

--- a/packages/audioplayers/pubspec.yaml
+++ b/packages/audioplayers/pubspec.yaml
@@ -5,8 +5,8 @@ repository: https://github.com/flutter-tizen/plugins/tree/master/packages/audiop
 version: 3.0.1
 
 environment:
-  sdk: ">=2.18.0 <4.0.0"
-  flutter: ">=3.3.0"
+  sdk: ">=3.1.0 <4.0.0"
+  flutter: ">=3.13.0"
 
 flutter:
   plugin:

--- a/packages/battery_plus/CHANGELOG.md
+++ b/packages/battery_plus/CHANGELOG.md
@@ -1,3 +1,7 @@
+## NEXT
+
+* Update minimum Flutter and Dart version to 3.13 and 3.1.
+
 ## 1.1.2
 
 * Update battery_plus to 4.0.1.

--- a/packages/battery_plus/example/pubspec.yaml
+++ b/packages/battery_plus/example/pubspec.yaml
@@ -3,8 +3,8 @@ description: Demonstrates how to use the battery_plus plugin.
 publish_to: "none"
 
 environment:
-  sdk: ">=2.18.0 <4.0.0"
-  flutter: ">=3.3.0"
+  sdk: ">=3.1.0 <4.0.0"
+  flutter: ">=3.13.0"
 
 dependencies:
   battery_plus: ^4.0.1

--- a/packages/battery_plus/pubspec.yaml
+++ b/packages/battery_plus/pubspec.yaml
@@ -5,8 +5,8 @@ repository: https://github.com/flutter-tizen/plugins/tree/master/packages/batter
 version: 1.1.2
 
 environment:
-  sdk: ">=2.18.0 <4.0.0"
-  flutter: ">=3.3.0"
+  sdk: ">=3.1.0 <4.0.0"
+  flutter: ">=3.13.0"
 
 flutter:
   plugin:

--- a/packages/camera/CHANGELOG.md
+++ b/packages/camera/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## NEXT
 
-* Increase the minimum Flutter version to 3.3.
+* Update minimum Flutter and Dart version to 3.13 and 3.1.
+* Fix new lint warnings.
 
 ## 0.3.4
 

--- a/packages/camera/example/lib/main.dart
+++ b/packages/camera/example/lib/main.dart
@@ -250,9 +250,7 @@ class _CameraExampleHomeState extends State<CameraExampleHome>
                         child: Center(
                           child: AspectRatio(
                               aspectRatio:
-                                  localVideoController.value.size != null
-                                      ? localVideoController.value.aspectRatio
-                                      : 1.0,
+                                  localVideoController.value.aspectRatio,
                               child: VideoPlayer(localVideoController)),
                         ),
                       ),
@@ -380,7 +378,7 @@ class _CameraExampleHomeState extends State<CameraExampleHome>
     return SizeTransition(
       sizeFactor: _exposureModeControlRowAnimation,
       child: ClipRect(
-        child: Container(
+        child: ColoredBox(
           color: Colors.grey.shade50,
           child: Column(
             children: <Widget>[
@@ -463,7 +461,7 @@ class _CameraExampleHomeState extends State<CameraExampleHome>
     return SizeTransition(
       sizeFactor: _focusModeControlRowAnimation,
       child: ClipRect(
-        child: Container(
+        child: ColoredBox(
           color: Colors.grey.shade50,
           child: Column(
             children: <Widget>[
@@ -680,30 +678,23 @@ class _CameraExampleHomeState extends State<CameraExampleHome>
       switch (e.code) {
         case 'CameraAccessDenied':
           showInSnackBar('You have denied camera access.');
-          break;
         case 'CameraAccessDeniedWithoutPrompt':
           // iOS only
           showInSnackBar('Please go to Settings app to enable camera access.');
-          break;
         case 'CameraAccessRestricted':
           // iOS only
           showInSnackBar('Camera access is restricted.');
-          break;
         case 'AudioAccessDenied':
           showInSnackBar('You have denied audio access.');
-          break;
         case 'AudioAccessDeniedWithoutPrompt':
           // iOS only
           showInSnackBar('Please go to Settings app to enable audio access.');
-          break;
         case 'AudioAccessRestricted':
           // iOS only
           showInSnackBar('Audio access is restricted.');
-          break;
         case 'cameraPermission':
           // Android & web only
           showInSnackBar('Unknown permission error.');
-          break;
         default:
           _showCameraException(e);
           break;
@@ -1001,7 +992,7 @@ class _CameraExampleHomeState extends State<CameraExampleHome>
         : VideoPlayerController.file(File(videoFile!.path));
 
     videoPlayerListener = () {
-      if (videoController != null && videoController!.value.size != null) {
+      if (videoController != null) {
         // Refreshing the state to update video player with the correct ratio.
         if (mounted) {
           setState(() {});

--- a/packages/camera/example/pubspec.yaml
+++ b/packages/camera/example/pubspec.yaml
@@ -3,8 +3,8 @@ description: Demonstrates how to use the camera plugin.
 publish_to: "none"
 
 environment:
-  sdk: ">=2.18.0 <4.0.0"
-  flutter: ">=3.3.0"
+  sdk: ">=3.1.0 <4.0.0"
+  flutter: ">=3.13.0"
 
 dependencies:
   camera: ^0.9.4

--- a/packages/camera/lib/camera_tizen.dart
+++ b/packages/camera/lib/camera_tizen.dart
@@ -536,7 +536,6 @@ class CameraTizen extends CameraPlatform {
         final Map<String, Object?> arguments = _getArgumentDictionary(call);
         _deviceEventStreamController.add(DeviceOrientationChangedEvent(
             deserializeDeviceOrientation(arguments['orientation']! as String)));
-        break;
       default:
         throw MissingPluginException();
     }
@@ -556,7 +555,6 @@ class CameraTizen extends CameraPlatform {
           deserializeFocusMode(arguments['focusMode']! as String),
           arguments['focusPointSupported']! as bool,
         ));
-        break;
       case 'resolution_changed':
         final Map<String, Object?> arguments = _getArgumentDictionary(call);
         _cameraEventStreamController.add(CameraResolutionChangedEvent(
@@ -564,12 +562,10 @@ class CameraTizen extends CameraPlatform {
           arguments['captureWidth']! as double,
           arguments['captureHeight']! as double,
         ));
-        break;
       case 'camera_closing':
         _cameraEventStreamController.add(CameraClosingEvent(
           cameraId,
         ));
-        break;
       case 'video_recorded':
         final Map<String, Object?> arguments = _getArgumentDictionary(call);
         _cameraEventStreamController.add(VideoRecordedEvent(
@@ -579,14 +575,12 @@ class CameraTizen extends CameraPlatform {
               ? Duration(milliseconds: arguments['maxVideoDuration']! as int)
               : null,
         ));
-        break;
       case 'error':
         final Map<String, Object?> arguments = _getArgumentDictionary(call);
         _cameraEventStreamController.add(CameraErrorEvent(
           cameraId,
           arguments['description']! as String,
         ));
-        break;
       default:
         throw MissingPluginException();
     }

--- a/packages/camera/pubspec.yaml
+++ b/packages/camera/pubspec.yaml
@@ -5,8 +5,8 @@ repository: https://github.com/flutter-tizen/plugins/tree/master/packages/camera
 version: 0.3.4
 
 environment:
-  sdk: ">=2.18.0 <4.0.0"
-  flutter: ">=3.3.0"
+  sdk: ">=3.1.0 <4.0.0"
+  flutter: ">=3.13.0"
 
 dependencies:
   camera_platform_interface: ^2.1.1

--- a/packages/connectivity_plus/CHANGELOG.md
+++ b/packages/connectivity_plus/CHANGELOG.md
@@ -1,3 +1,7 @@
+## NEXT
+
+* Update minimum Flutter and Dart version to 3.13 and 3.1.
+
 ## 1.1.4
 
 * Update connectivity_plus to 4.0.1.

--- a/packages/connectivity_plus/example/pubspec.yaml
+++ b/packages/connectivity_plus/example/pubspec.yaml
@@ -3,8 +3,8 @@ description: Demonstrates how to use the connectivity_plus_tizen plugin.
 publish_to: "none"
 
 environment:
-  sdk: ">=2.18.0 <4.0.0"
-  flutter: ">=3.3.0"
+  sdk: ">=3.1.0 <4.0.0"
+  flutter: ">=3.13.0"
 
 dependencies:
   connectivity_plus: ^4.0.1

--- a/packages/connectivity_plus/pubspec.yaml
+++ b/packages/connectivity_plus/pubspec.yaml
@@ -5,8 +5,8 @@ repository: https://github.com/flutter-tizen/plugins/tree/master/packages/connec
 version: 1.1.4
 
 environment:
-  sdk: ">=2.18.0 <4.0.0"
-  flutter: ">=3.3.0"
+  sdk: ">=3.1.0 <4.0.0"
+  flutter: ">=3.13.0"
 
 flutter:
   plugin:

--- a/packages/device_info_plus/CHANGELOG.md
+++ b/packages/device_info_plus/CHANGELOG.md
@@ -1,3 +1,7 @@
+## NEXT
+
+* Update minimum Flutter and Dart version to 3.13 and 3.1.
+
 ## 1.2.0
 
 * Add `TizenDeviceInfo.data` which represents the device info as a map.

--- a/packages/device_info_plus/example/pubspec.yaml
+++ b/packages/device_info_plus/example/pubspec.yaml
@@ -3,8 +3,8 @@ description: Demonstrates how to use the device_info_plus_tizen plugin.
 publish_to: "none"
 
 environment:
-  sdk: ">=2.18.0 <4.0.0"
-  flutter: ">=3.3.0"
+  sdk: ">=3.1.0 <4.0.0"
+  flutter: ">=3.13.0"
 
 dependencies:
   device_info_plus_tizen:

--- a/packages/device_info_plus/pubspec.yaml
+++ b/packages/device_info_plus/pubspec.yaml
@@ -6,8 +6,8 @@ repository: https://github.com/flutter-tizen/plugins/tree/master/packages/device
 version: 1.2.0
 
 environment:
-  sdk: ">=2.18.0 <4.0.0"
-  flutter: ">=3.3.0"
+  sdk: ">=3.1.0 <4.0.0"
+  flutter: ">=3.13.0"
 
 flutter:
   plugin:

--- a/packages/firebase_core/CHANGELOG.md
+++ b/packages/firebase_core/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## NEXT
 
-* Increase the minimum Flutter version to 3.3.
+* Update minimum Flutter and Dart version to 3.13 and 3.1.
+* Fix new lint warnings.
 
 ## 0.1.1
 

--- a/packages/firebase_core/example/pubspec.yaml
+++ b/packages/firebase_core/example/pubspec.yaml
@@ -3,8 +3,8 @@ description: An example application demonstrating calls to Firebase Core.
 publish_to: "none"
 
 environment:
-  sdk: ">=2.18.0 <4.0.0"
-  flutter: ">=3.3.0"
+  sdk: ">=3.1.0 <4.0.0"
+  flutter: ">=3.13.0"
 
 dependencies:
   firebase_core: ^2.4.0

--- a/packages/firebase_core/lib/firebase_app_tizen.dart
+++ b/packages/firebase_core/lib/firebase_app_tizen.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file.
 
-part of firebase_core_tizen;
+part of 'firebase_core_tizen.dart';
 
 /// A Dart only implementation of a Firebase app instance.
 class FirebaseApp extends FirebaseAppPlatform {

--- a/packages/firebase_core/pubspec.yaml
+++ b/packages/firebase_core/pubspec.yaml
@@ -5,8 +5,8 @@ repository: https://github.com/flutter-tizen/plugins/tree/master/packages/fireba
 version: 0.1.1
 
 environment:
-  sdk: ">=2.18.0 <4.0.0"
-  flutter: ">=3.3.0"
+  sdk: ">=3.1.0 <4.0.0"
+  flutter: ">=3.13.0"
 
 dependencies:
   firebase_core_dart: ^1.0.1

--- a/packages/flutter_app_badger/CHANGELOG.md
+++ b/packages/flutter_app_badger/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## NEXT
 
-* Increase the minimum Flutter version to 3.3.
+* Update minimum Flutter and Dart version to 3.13 and 3.1.
 
 ## 0.1.0
 

--- a/packages/flutter_app_badger/example/pubspec.yaml
+++ b/packages/flutter_app_badger/example/pubspec.yaml
@@ -3,8 +3,8 @@ description: Demonstrates how to use the flutter_app_badger_tizen plugin.
 publish_to: "none"
 
 environment:
-  sdk: ">=2.18.0 <4.0.0"
-  flutter: ">=3.3.0"
+  sdk: ">=3.1.0 <4.0.0"
+  flutter: ">=3.13.0"
 
 dependencies:
   flutter:

--- a/packages/flutter_app_badger/pubspec.yaml
+++ b/packages/flutter_app_badger/pubspec.yaml
@@ -5,8 +5,8 @@ repository: https://github.com/flutter-tizen/plugins/tree/master/packages/flutte
 version: 0.1.0
 
 environment:
-  sdk: ">=2.18.0 <4.0.0"
-  flutter: ">=3.3.0"
+  sdk: ">=3.1.0 <4.0.0"
+  flutter: ">=3.13.0"
 
 flutter:
   plugin:

--- a/packages/flutter_secure_storage/CHANGELOG.md
+++ b/packages/flutter_secure_storage/CHANGELOG.md
@@ -1,3 +1,8 @@
+## NEXT
+
+* Fix new lint warnings.
+* Update minimum Flutter and Dart version to 3.13 and 3.1.
+
 ## 0.1.1
 
 * Update flutter_secure_storage to 9.0.0.

--- a/packages/flutter_secure_storage/example/lib/main.dart
+++ b/packages/flutter_secure_storage/example/lib/main.dart
@@ -98,7 +98,6 @@ class ItemsWidgetState extends State<ItemsWidget> {
                 switch (action) {
                   case _Actions.deleteAll:
                     _deleteAll();
-                    break;
                 }
               },
               itemBuilder: (BuildContext context) => <PopupMenuEntry<_Actions>>[
@@ -191,7 +190,6 @@ class ItemsWidgetState extends State<ItemsWidget> {
         );
         _readAll();
 
-        break;
       case _ItemActions.edit:
         if (!context.mounted) return;
         final result = await showDialog<String>(
@@ -207,7 +205,6 @@ class ItemsWidgetState extends State<ItemsWidget> {
           );
           _readAll();
         }
-        break;
       case _ItemActions.containsKey:
         if (!context.mounted) return;
         final key = await _displayTextInputDialog(context, item.key);
@@ -219,7 +216,6 @@ class ItemsWidgetState extends State<ItemsWidget> {
             backgroundColor: result ? Colors.green : Colors.red,
           ),
         );
-        break;
       case _ItemActions.read:
         if (!context.mounted) return;
         final key = await _displayTextInputDialog(context, item.key);
@@ -231,7 +227,6 @@ class ItemsWidgetState extends State<ItemsWidget> {
             content: Text('value: $result'),
           ),
         );
-        break;
     }
   }
 

--- a/packages/flutter_secure_storage/example/pubspec.yaml
+++ b/packages/flutter_secure_storage/example/pubspec.yaml
@@ -3,8 +3,8 @@ description: Demonstrates how to use the flutter_secure_storage_tizen plugin.
 publish_to: "none"
 
 environment:
-  sdk: ">=2.18.0 <4.0.0"
-  flutter: ">=3.3.0"
+  sdk: ">=3.1.0 <4.0.0"
+  flutter: ">=3.13.0"
 
 dependencies:
   flutter:

--- a/packages/flutter_secure_storage/pubspec.yaml
+++ b/packages/flutter_secure_storage/pubspec.yaml
@@ -5,8 +5,8 @@ repository: https://github.com/flutter-tizen/plugins/tree/master/packages/flutte
 version: 0.1.1
 
 environment:
-  sdk: ">=2.18.0 <4.0.0"
-  flutter: ">=3.3.0"
+  sdk: ">=3.1.0 <4.0.0"
+  flutter: ">=3.13.0"
 
 flutter:
   plugin:

--- a/packages/flutter_tts/CHANGELOG.md
+++ b/packages/flutter_tts/CHANGELOG.md
@@ -1,3 +1,7 @@
+## NEXT
+
+* Update minimum Flutter and Dart version to 3.13 and 3.1.
+
 ## 1.4.0
 
 * Update flutter_tts to 3.6.3.

--- a/packages/flutter_tts/example/pubspec.yaml
+++ b/packages/flutter_tts/example/pubspec.yaml
@@ -3,8 +3,8 @@ description: Demonstrates how to use the flutter_tts_tizen plugin.
 publish_to: "none"
 
 environment:
-  sdk: ">=2.18.0 <4.0.0"
-  flutter: ">=3.3.0"
+  sdk: ">=3.1.0 <4.0.0"
+  flutter: ">=3.13.0"
 
 dependencies:
   flutter:

--- a/packages/flutter_tts/pubspec.yaml
+++ b/packages/flutter_tts/pubspec.yaml
@@ -5,8 +5,8 @@ repository: https://github.com/flutter-tizen/plugins/tree/master/packages/flutte
 version: 1.4.0
 
 environment:
-  sdk: ">=2.18.0 <4.0.0"
-  flutter: ">=3.3.0"
+  sdk: ">=3.1.0 <4.0.0"
+  flutter: ">=3.13.0"
 
 dependencies:
   flutter:

--- a/packages/flutter_webrtc/CHANGELOG.md
+++ b/packages/flutter_webrtc/CHANGELOG.md
@@ -1,3 +1,7 @@
+## NEXT
+
+* Update minimum Flutter and Dart version to 3.13 and 3.1.
+
 ## 0.1.3
 
 * Increase the minimum Flutter version to 3.3.

--- a/packages/flutter_webrtc/example/flutter_webrtc_demo/pubspec.yaml
+++ b/packages/flutter_webrtc/example/flutter_webrtc_demo/pubspec.yaml
@@ -3,8 +3,8 @@ description: A new Flutter application.
 publish_to: "none"
 
 environment:
-  sdk: ">=2.18.0 <4.0.0"
-  flutter: ">=3.3.0"
+  sdk: ">=3.1.0 <4.0.0"
+  flutter: ">=3.13.0"
 
 dependencies:
   cupertino_icons: ^1.0.3

--- a/packages/flutter_webrtc/example/flutter_webrtc_example/pubspec.yaml
+++ b/packages/flutter_webrtc/example/flutter_webrtc_example/pubspec.yaml
@@ -3,8 +3,8 @@ description: Demonstrates how to use the webrtc plugin.
 publish_to: "none"
 
 environment:
-  sdk: ">=2.18.0 <4.0.0"
-  flutter: ">=3.3.0"
+  sdk: ">=3.1.0 <4.0.0"
+  flutter: ">=3.13.0"
 
 dependencies:
   flutter:

--- a/packages/flutter_webrtc/pubspec.yaml
+++ b/packages/flutter_webrtc/pubspec.yaml
@@ -5,8 +5,8 @@ repository: https://github.com/flutter-tizen/plugins/tree/master/packages/flutte
 version: 0.1.3
 
 environment:
-  sdk: ">=2.18.0 <4.0.0"
-  flutter: ">=3.3.0"
+  sdk: ">=3.1.0 <4.0.0"
+  flutter: ">=3.13.0"
 
 flutter:
   plugin:

--- a/packages/geolocator/CHANGELOG.md
+++ b/packages/geolocator/CHANGELOG.md
@@ -1,3 +1,7 @@
+## NEXT
+
+* Update minimum Flutter and Dart version to 3.13 and 3.1.
+
 ## 1.0.6
 
 * Remove unnecessary `StreamHandlerError` implementation.

--- a/packages/geolocator/example/pubspec.yaml
+++ b/packages/geolocator/example/pubspec.yaml
@@ -3,8 +3,8 @@ description: Demonstrates how to use the geolocator_tizen plugin.
 publish_to: "none"
 
 environment:
-  sdk: ">=2.18.0 <4.0.0"
-  flutter: ">=3.3.0"
+  sdk: ">=3.1.0 <4.0.0"
+  flutter: ">=3.13.0"
 
 dependencies:
   baseflow_plugin_template: ^2.1.2

--- a/packages/geolocator/pubspec.yaml
+++ b/packages/geolocator/pubspec.yaml
@@ -5,8 +5,8 @@ repository: https://github.com/flutter-tizen/plugins/tree/master/packages/geoloc
 version: 1.0.6
 
 environment:
-  sdk: ">=2.18.0 <4.0.0"
-  flutter: ">=3.3.0"
+  sdk: ">=3.1.0 <4.0.0"
+  flutter: ">=3.13.0"
 
 flutter:
   plugin:

--- a/packages/google_maps_flutter/CHANGELOG.md
+++ b/packages/google_maps_flutter/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## NEXT
 
-* Increase the minimum Flutter version to 3.3.
+* Fix new lint warnings.
+* Update minimum Flutter and Dart version to 3.13 and 3.1.
 
 ## 0.1.5
 

--- a/packages/google_maps_flutter/example/pubspec.yaml
+++ b/packages/google_maps_flutter/example/pubspec.yaml
@@ -3,8 +3,8 @@ description: Demonstrates how to use the google_maps_flutter_tizen plugin.
 publish_to: "none"
 
 environment:
-  sdk: ">=2.18.0 <4.0.0"
-  flutter: ">=3.3.0"
+  sdk: ">=3.1.0 <4.0.0"
+  flutter: ">=3.13.0"
 
 dependencies:
   flutter:

--- a/packages/google_maps_flutter/lib/src/circle.dart
+++ b/packages/google_maps_flutter/lib/src/circle.dart
@@ -3,7 +3,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-part of google_maps_flutter_tizen;
+part of '../google_maps_flutter_tizen.dart';
 
 /// The `CircleController` class wraps a [GCircle] and its `onTap` behavior.
 class CircleController {

--- a/packages/google_maps_flutter/lib/src/circles.dart
+++ b/packages/google_maps_flutter/lib/src/circles.dart
@@ -3,7 +3,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-part of google_maps_flutter_tizen;
+part of '../google_maps_flutter_tizen.dart';
 
 /// This class manages all the [CircleController]s associated to a [GoogleMapController].
 class CirclesController extends GeometryController {

--- a/packages/google_maps_flutter/lib/src/convert.dart
+++ b/packages/google_maps_flutter/lib/src/convert.dart
@@ -5,7 +5,7 @@
 
 // ignore_for_file: avoid_dynamic_calls
 
-part of google_maps_flutter_tizen;
+part of '../google_maps_flutter_tizen.dart';
 
 // Indices in the plugin side don't match with the ones
 Map<int, String> _mapTypeToMapTypeId = <int, String>{
@@ -93,12 +93,9 @@ String _applyInitialPosition(
   CameraPosition initialPosition,
   String options,
 ) {
-  // Adjust the initial position, if passed...
-  if (initialPosition != null) {
-    options += ', zoom: ${initialPosition.zoom}';
-    options +=
-        ', center: {lat: ${initialPosition.target.latitude} ,lng: ${initialPosition.target.longitude}}';
-  }
+  options += ', zoom: ${initialPosition.zoom}';
+  options +=
+      ', center: {lat: ${initialPosition.target.latitude} ,lng: ${initialPosition.target.longitude}}';
   return options;
 }
 

--- a/packages/google_maps_flutter/lib/src/google_maps_controller.dart
+++ b/packages/google_maps_flutter/lib/src/google_maps_controller.dart
@@ -5,7 +5,7 @@
 
 // ignore_for_file: avoid_dynamic_calls
 
-part of google_maps_flutter_tizen;
+part of '../google_maps_flutter_tizen.dart';
 
 /// This class implements a Map Controller and its events
 class GoogleMapsController {
@@ -188,7 +188,7 @@ class GoogleMapsController {
     return JavascriptChannel(
         name: 'BoundChanged',
         onMessageReceived: (JavascriptMessage message) async {
-          if (_widget == null || _streamController == null) {
+          if (_widget == null) {
             return;
           }
           final LatLng center = await getCenter();
@@ -212,7 +212,7 @@ class GoogleMapsController {
     return JavascriptChannel(
         name: 'Idle',
         onMessageReceived: (JavascriptMessage message) async {
-          if (_widget == null || _streamController == null) {
+          if (_widget == null) {
             return;
           }
           _mapIsMoving = false;
@@ -224,7 +224,7 @@ class GoogleMapsController {
     return JavascriptChannel(
         name: 'Tilesloaded',
         onMessageReceived: (JavascriptMessage message) async {
-          if (_widget == null || _streamController == null || _isFirst) {
+          if (_widget == null || _isFirst) {
             return;
           }
           try {
@@ -240,7 +240,7 @@ class GoogleMapsController {
     return JavascriptChannel(
         name: 'Click',
         onMessageReceived: (JavascriptMessage message) async {
-          if (_widget == null || _streamController == null) {
+          if (_widget == null) {
             return;
           }
           try {
@@ -262,7 +262,7 @@ class GoogleMapsController {
     return JavascriptChannel(
         name: 'RightClick',
         onMessageReceived: (JavascriptMessage message) async {
-          if (_widget == null || _streamController == null) {
+          if (_widget == null) {
             return;
           }
           try {
@@ -283,7 +283,7 @@ class GoogleMapsController {
     return JavascriptChannel(
         name: 'MarkerClick',
         onMessageReceived: (JavascriptMessage message) async {
-          if (_widget == null || _streamController == null) {
+          if (_widget == null) {
             return;
           }
           try {
@@ -306,7 +306,7 @@ class GoogleMapsController {
     return JavascriptChannel(
         name: 'MarkerDragEnd',
         onMessageReceived: (JavascriptMessage message) async {
-          if (_widget == null || _streamController == null) {
+          if (_widget == null) {
             return;
           }
           try {
@@ -338,7 +338,7 @@ class GoogleMapsController {
     return JavascriptChannel(
         name: 'PolylineClick',
         onMessageReceived: (JavascriptMessage message) async {
-          if (_widget == null || _streamController == null) {
+          if (_widget == null) {
             return;
           }
           try {
@@ -362,7 +362,7 @@ class GoogleMapsController {
     return JavascriptChannel(
         name: 'PolygonClick',
         onMessageReceived: (JavascriptMessage message) async {
-          if (_widget == null || _streamController == null) {
+          if (_widget == null) {
             return;
           }
           try {
@@ -386,7 +386,7 @@ class GoogleMapsController {
     return JavascriptChannel(
         name: 'CircleClick',
         onMessageReceived: (JavascriptMessage message) async {
-          if (_widget == null || _streamController == null) {
+          if (_widget == null) {
             return;
           }
           try {
@@ -586,21 +586,16 @@ class GoogleMapsController {
             '{heading: ${json[1]['bearing']}, zoom: ${json[1]['zoom']}, tilt: ${json[1]['tilt']}}');
         await _setPanTo(
             '{lat:${json[1]['target'][0]}, lng: ${json[1]['target'][1]}}');
-        break;
       case 'newLatLng':
         await _setPanTo('{lat:${json[1][0]}, lng:${json[1][1]}}');
-        break;
       case 'newLatLngZoom':
         await _setMoveCamera('{zoom: ${json[2]}}');
         await _setPanTo('{lat:${json[1][0]}, lng: ${json[1][1]}}');
-        break;
       case 'newLatLngBounds':
         await _setFitBounds(
             '{south:${json[1][0][0]}, west:${json[1][0][1]}, north:${json[1][1][0]}, east:${json[1][1][1]}}, ${json[2]}');
-        break;
       case 'scrollBy':
         await _setPanBy('${json[1]}, ${json[2]}');
-        break;
       case 'zoomBy':
         String? focusLatLng;
         double zoomDelta = 0.0;
@@ -623,16 +618,12 @@ class GoogleMapsController {
         if (focusLatLng != null) {
           await _setPanTo(focusLatLng);
         }
-        break;
       case 'zoomIn':
         await _setZoom('${(await getZoomLevel()) + 1}');
-        break;
       case 'zoomOut':
         await _setZoom('${(await getZoomLevel()) - 1}');
-        break;
       case 'zoomTo':
         await _setZoom('${json[1]}');
-        break;
       default:
         throw UnimplementedError('Unimplemented CameraMove: ${json[0]}.');
     }

--- a/packages/google_maps_flutter/lib/src/google_maps_flutter_tizen.dart
+++ b/packages/google_maps_flutter/lib/src/google_maps_flutter_tizen.dart
@@ -3,7 +3,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-part of google_maps_flutter_tizen;
+part of '../google_maps_flutter_tizen.dart';
 
 /// The Tizen implementation of [GoogleMapsFlutterPlatform].
 ///
@@ -43,7 +43,6 @@ class GoogleMapsPlugin extends GoogleMapsFlutterPlatform {
   @override
   Future<void> init(int mapId) async {
     _map(mapId).init();
-    assert(_map(mapId) != null, 'Must call buildWidget before init!');
   }
 
   /// Updates the options of a given `mapId`.

--- a/packages/google_maps_flutter/lib/src/marker.dart
+++ b/packages/google_maps_flutter/lib/src/marker.dart
@@ -3,7 +3,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-part of google_maps_flutter_tizen;
+part of '../google_maps_flutter_tizen.dart';
 
 // Marker Size
 const int _markerWidth = 24;

--- a/packages/google_maps_flutter/lib/src/markers.dart
+++ b/packages/google_maps_flutter/lib/src/markers.dart
@@ -3,7 +3,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-part of google_maps_flutter_tizen;
+part of '../google_maps_flutter_tizen.dart';
 
 /// This class manages a set of [MarkerController]s associated to a [GoogleMapController].
 class MarkersController extends GeometryController {

--- a/packages/google_maps_flutter/lib/src/polygon.dart
+++ b/packages/google_maps_flutter/lib/src/polygon.dart
@@ -3,7 +3,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-part of google_maps_flutter_tizen;
+part of '../google_maps_flutter_tizen.dart';
 
 /// The `PolygonController` class wraps a [GPolygon] and its `onTap` behavior.
 class PolygonController {

--- a/packages/google_maps_flutter/lib/src/polygons.dart
+++ b/packages/google_maps_flutter/lib/src/polygons.dart
@@ -3,7 +3,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-part of google_maps_flutter_tizen;
+part of '../google_maps_flutter_tizen.dart';
 
 /// This class manages a set of [PolygonController]s associated to a [GoogleMapController].
 class PolygonsController extends GeometryController {

--- a/packages/google_maps_flutter/lib/src/polyline.dart
+++ b/packages/google_maps_flutter/lib/src/polyline.dart
@@ -3,7 +3,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-part of google_maps_flutter_tizen;
+part of '../google_maps_flutter_tizen.dart';
 
 /// The `PolygonController` class wraps a [GPolyline] and its `onTap` behavior.
 class PolylineController {

--- a/packages/google_maps_flutter/lib/src/polylines.dart
+++ b/packages/google_maps_flutter/lib/src/polylines.dart
@@ -3,7 +3,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-part of google_maps_flutter_tizen;
+part of '../google_maps_flutter_tizen.dart';
 
 /// This class manages a set of [PolylinesController]s associated to a [GoogleMapController].
 class PolylinesController extends GeometryController {

--- a/packages/google_maps_flutter/lib/src/types.dart
+++ b/packages/google_maps_flutter/lib/src/types.dart
@@ -3,7 +3,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-part of google_maps_flutter_tizen;
+part of '../google_maps_flutter_tizen.dart';
 
 /// A void function that handles a [LatLng] as a parameter.
 ///

--- a/packages/google_maps_flutter/lib/src/util.dart
+++ b/packages/google_maps_flutter/lib/src/util.dart
@@ -5,7 +5,7 @@
 
 // ignore_for_file: avoid_setters_without_getters
 
-//part of google_maps_flutter_tizen;
+//part of '../google_maps_flutter_tizen.dart';
 import 'dart:async';
 import 'package:google_maps_flutter_platform_interface/google_maps_flutter_platform_interface.dart';
 import 'package:webview_flutter/webview_flutter.dart';

--- a/packages/google_maps_flutter/pubspec.yaml
+++ b/packages/google_maps_flutter/pubspec.yaml
@@ -5,8 +5,8 @@ repository: https://github.com/flutter-tizen/plugins/tree/master/packages/google
 version: 0.1.5
 
 environment:
-  sdk: ">=2.18.0 <4.0.0"
-  flutter: ">=3.3.0"
+  sdk: ">=3.1.0 <4.0.0"
+  flutter: ">=3.13.0"
 
 flutter:
   plugin:

--- a/packages/google_sign_in/CHANGELOG.md
+++ b/packages/google_sign_in/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## NEXT
 
-* Increase the minimum Flutter version to 3.3.
+* Update minimum Flutter and Dart version to 3.13 and 3.1.
 
 ## 0.1.3
 

--- a/packages/google_sign_in/example/pubspec.yaml
+++ b/packages/google_sign_in/example/pubspec.yaml
@@ -3,8 +3,8 @@ description: Demonstrates how to use the google_sign_in_tizen plugin.
 publish_to: "none"
 
 environment:
-  sdk: ">=2.18.0 <4.0.0"
-  flutter: ">=3.3.0"
+  sdk: ">=3.1.0 <4.0.0"
+  flutter: ">=3.13.0"
 
 dependencies:
   flutter:

--- a/packages/google_sign_in/pubspec.yaml
+++ b/packages/google_sign_in/pubspec.yaml
@@ -5,8 +5,8 @@ repository: https://github.com/flutter-tizen/plugins/tree/master/packages/google
 version: 0.1.3
 
 environment:
-  sdk: ">=2.18.0 <4.0.0"
-  flutter: ">=3.3.0"
+  sdk: ">=3.1.0 <4.0.0"
+  flutter: ">=3.13.0"
 
 flutter:
   plugin:

--- a/packages/image_picker/CHANGELOG.md
+++ b/packages/image_picker/CHANGELOG.md
@@ -1,3 +1,7 @@
+## NEXT
+
+* Update minimum Flutter and Dart version to 3.13 and 3.1.
+
 ## 2.3.0
 
 * Update image_picker to 1.0.1.

--- a/packages/image_picker/example/pubspec.yaml
+++ b/packages/image_picker/example/pubspec.yaml
@@ -3,8 +3,8 @@ description: Demonstrates how to use the image_picker_tizen plugin.
 publish_to: "none"
 
 environment:
-  sdk: ">=2.18.0 <4.0.0"
-  flutter: ">=3.3.0"
+  sdk: ">=3.1.0 <4.0.0"
+  flutter: ">=3.13.0"
 
 dependencies:
   flutter:

--- a/packages/image_picker/pubspec.yaml
+++ b/packages/image_picker/pubspec.yaml
@@ -5,8 +5,8 @@ repository: https://github.com/flutter-tizen/plugins/tree/master/packages/image_
 version: 2.3.0
 
 environment:
-  sdk: ">=2.18.0 <4.0.0"
-  flutter: ">=3.3.0"
+  sdk: ">=3.1.0 <4.0.0"
+  flutter: ">=3.13.0"
 
 flutter:
   plugin:

--- a/packages/in_app_purchase/CHANGELOG.md
+++ b/packages/in_app_purchase/CHANGELOG.md
@@ -1,3 +1,8 @@
+## NEXT
+
+* Fix new lint warnings.
+* Update minimum Flutter and Dart version to 3.13 and 3.1.
+
 ## 0.1.0
 
 * Initial release.

--- a/packages/in_app_purchase/example/lib/main.dart
+++ b/packages/in_app_purchase/example/lib/main.dart
@@ -291,7 +291,7 @@ class _MyAppState extends State<_MyApp> {
     });
   }
 
-  Future<void> deliverProduct(PurchaseDetails purchaseDetails) async {
+  void deliverProduct(PurchaseDetails purchaseDetails) {
     // IMPORTANT!! Always verify purchase details before delivering the product.
     setState(() {
       _purchases.add(purchaseDetails);

--- a/packages/in_app_purchase/example/pubspec.yaml
+++ b/packages/in_app_purchase/example/pubspec.yaml
@@ -3,8 +3,8 @@ description: Demonstrates how to use the in_app_purchase_tizen plugin.
 publish_to: "none"
 
 environment:
-  sdk: ">=2.18.0 <4.0.0"
-  flutter: ">=3.3.0"
+  sdk: ">=3.1.0 <4.0.0"
+  flutter: ">=3.13.0"
 
 dependencies:
   flutter:

--- a/packages/in_app_purchase/lib/src/in_app_purchase_tizen_platform.dart
+++ b/packages/in_app_purchase/lib/src/in_app_purchase_tizen_platform.dart
@@ -140,7 +140,7 @@ class InAppPurchaseTizenPlatform extends InAppPurchasePlatform {
       final String invoiceId =
           billingResultWrapper.payDetails['InvoiceID'] ?? '';
 
-      billingManager
+      unawaited(billingManager
           .requestPurchases()
           .then((GetUserPurchaseListAPIResult responses) {
         for (int i = 0; i < responses.invoiceDetails.length; i++) {
@@ -163,7 +163,7 @@ class InAppPurchaseTizenPlatform extends InAppPurchasePlatform {
         }
       }).catchError((Object error) {
         _purchaseUpdatedController.addError(error);
-      });
+      }));
 
       return true;
     } else {
@@ -174,7 +174,7 @@ class InAppPurchaseTizenPlatform extends InAppPurchasePlatform {
   @override
   Future<bool> buyConsumable(
       {required PurchaseParam purchaseParam, bool autoConsume = true}) {
-    assert(autoConsume == true, 'On Tizen, we should always auto consume');
+    assert(autoConsume, 'On Tizen, we should always auto consume');
     return buyNonConsumable(purchaseParam: purchaseParam);
   }
 }

--- a/packages/in_app_purchase/pubspec.yaml
+++ b/packages/in_app_purchase/pubspec.yaml
@@ -5,8 +5,8 @@ repository: https://github.com/flutter-tizen/plugins/tree/master/packages/in_app
 version: 0.1.0
 
 environment:
-  sdk: ">=2.18.0 <4.0.0"
-  flutter: ">=3.3.0"
+  sdk: ">=3.1.0 <4.0.0"
+  flutter: ">=3.13.0"
 
 flutter:
   plugin:

--- a/packages/integration_test/CHANGELOG.md
+++ b/packages/integration_test/CHANGELOG.md
@@ -1,3 +1,7 @@
+## NEXT
+
+* Update minimum Flutter and Dart version to 3.13 and 3.1.
+
 ## 2.0.2
 
 * Increase the minimum Flutter version to 3.3.

--- a/packages/integration_test/example/pubspec.yaml
+++ b/packages/integration_test/example/pubspec.yaml
@@ -3,8 +3,8 @@ description: Demonstrates how to use the integration_test_tizen plugin.
 publish_to: "none"
 
 environment:
-  sdk: ">=2.18.0 <4.0.0"
-  flutter: ">=3.3.0"
+  sdk: ">=3.1.0 <4.0.0"
+  flutter: ">=3.13.0"
 
 dependencies:
   flutter:

--- a/packages/integration_test/pubspec.yaml
+++ b/packages/integration_test/pubspec.yaml
@@ -5,8 +5,8 @@ repository: https://github.com/flutter-tizen/plugins/tree/master/packages/integr
 version: 2.0.2
 
 environment:
-  sdk: ">=2.18.0 <4.0.0"
-  flutter: ">=3.3.0"
+  sdk: ">=3.1.0 <4.0.0"
+  flutter: ">=3.13.0"
 
 flutter:
   plugin:

--- a/packages/messageport/CHANGELOG.md
+++ b/packages/messageport/CHANGELOG.md
@@ -1,3 +1,8 @@
+## NEXT
+
+* Fix new lint warnings.
+* Update minimum Flutter and Dart version to 3.13 and 3.1.
+
 ## 0.3.2
 
 * Remove unnecessary `StreamHandlerError` implementation.

--- a/packages/messageport/example/lib/main.dart
+++ b/packages/messageport/example/lib/main.dart
@@ -67,7 +67,7 @@ class _MyAppState extends State<MyApp> {
           'Unregister',
           () async {
             try {
-              _localPort?.unregister();
+              await _localPort?.unregister();
               _log('Local port unregistration done');
               setState(() {});
             } catch (error) {

--- a/packages/messageport/example/pubspec.yaml
+++ b/packages/messageport/example/pubspec.yaml
@@ -3,8 +3,8 @@ description: Demonstrates how to use the messageport_tizen plugin.
 publish_to: "none"
 
 environment:
-  sdk: ">=2.18.0 <4.0.0"
-  flutter: ">=3.3.0"
+  sdk: ">=3.1.0 <4.0.0"
+  flutter: ">=3.13.0"
 
 dependencies:
   flutter:

--- a/packages/messageport/pubspec.yaml
+++ b/packages/messageport/pubspec.yaml
@@ -5,8 +5,8 @@ repository: https://github.com/flutter-tizen/plugins/tree/master/packages/messag
 version: 0.3.2
 
 environment:
-  sdk: ">=2.18.0 <4.0.0"
-  flutter: ">=3.3.0"
+  sdk: ">=3.1.0 <4.0.0"
+  flutter: ">=3.13.0"
 
 flutter:
   plugin:

--- a/packages/network_info_plus/CHANGELOG.md
+++ b/packages/network_info_plus/CHANGELOG.md
@@ -1,3 +1,7 @@
+## NEXT
+
+* Update minimum Flutter and Dart version to 3.13 and 3.1.
+
 ## 1.1.4
 
 * Update network_info_plus to 4.1.0.

--- a/packages/network_info_plus/example/pubspec.yaml
+++ b/packages/network_info_plus/example/pubspec.yaml
@@ -3,8 +3,8 @@ description: Demonstrates how to use the network_info_plus_tizen plugin.
 publish_to: "none"
 
 environment:
-  sdk: ">=2.18.0 <4.0.0"
-  flutter: ">=3.3.0"
+  sdk: ">=3.1.0 <4.0.0"
+  flutter: ">=3.13.0"
 
 dependencies:
   flutter:

--- a/packages/network_info_plus/pubspec.yaml
+++ b/packages/network_info_plus/pubspec.yaml
@@ -5,8 +5,8 @@ repository: https://github.com/flutter-tizen/plugins/tree/master/packages/networ
 version: 1.1.4
 
 environment:
-  sdk: ">=2.18.0 <4.0.0"
-  flutter: ">=3.3.0"
+  sdk: ">=3.1.0 <4.0.0"
+  flutter: ">=3.13.0"
 
 flutter:
   plugin:

--- a/packages/package_info_plus/CHANGELOG.md
+++ b/packages/package_info_plus/CHANGELOG.md
@@ -1,3 +1,7 @@
+## NEXT
+
+* Update minimum Flutter and Dart version to 3.13 and 3.1.
+
 ## 1.0.3
 
 * Update package_info_plus to 4.0.1.

--- a/packages/package_info_plus/example/pubspec.yaml
+++ b/packages/package_info_plus/example/pubspec.yaml
@@ -4,8 +4,8 @@ version: 1.2.3+4
 publish_to: "none"
 
 environment:
-  sdk: ">=2.18.0 <4.0.0"
-  flutter: ">=3.3.0"
+  sdk: ">=3.1.0 <4.0.0"
+  flutter: ">=3.13.0"
 
 dependencies:
   flutter:

--- a/packages/package_info_plus/pubspec.yaml
+++ b/packages/package_info_plus/pubspec.yaml
@@ -5,8 +5,8 @@ repository: https://github.com/flutter-tizen/plugins/tree/master/packages/packag
 version: 1.0.3
 
 environment:
-  sdk: ">=2.18.0 <4.0.0"
-  flutter: ">=3.3.0"
+  sdk: ">=3.1.0 <4.0.0"
+  flutter: ">=3.13.0"
 
 flutter:
   plugin:

--- a/packages/path_provider/CHANGELOG.md
+++ b/packages/path_provider/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## NEXT
 
-* Increase the minimum Flutter version to 3.3.
+* Fix new lint warnings.
+* Update minimum Flutter and Dart version to 3.13 and 3.1.
 
 ## 2.1.0
 

--- a/packages/path_provider/example/pubspec.yaml
+++ b/packages/path_provider/example/pubspec.yaml
@@ -3,8 +3,8 @@ description: Demonstrates how to use the path_provider_tizen plugin.
 publish_to: "none"
 
 environment:
-  sdk: ">=2.18.0 <4.0.0"
-  flutter: ">=3.3.0"
+  sdk: ">=3.1.0 <4.0.0"
+  flutter: ">=3.13.0"
 
 dependencies:
   flutter:

--- a/packages/path_provider/lib/path_provider_tizen.dart
+++ b/packages/path_provider/lib/path_provider_tizen.dart
@@ -39,31 +39,23 @@ class PathProviderPlugin extends PathProviderPlatform {
     switch (type) {
       case StorageDirectory.music:
         dirType = storage_directory_e.STORAGE_DIRECTORY_MUSIC;
-        break;
       case StorageDirectory.ringtones:
         dirType = storage_directory_e.STORAGE_DIRECTORY_SYSTEM_RINGTONES;
-        break;
       case StorageDirectory.pictures:
         dirType = storage_directory_e.STORAGE_DIRECTORY_IMAGES;
-        break;
       case StorageDirectory.movies:
         dirType = storage_directory_e.STORAGE_DIRECTORY_VIDEOS;
-        break;
       case StorageDirectory.downloads:
         dirType = storage_directory_e.STORAGE_DIRECTORY_DOWNLOADS;
-        break;
       case StorageDirectory.dcim:
         dirType = storage_directory_e.STORAGE_DIRECTORY_CAMERA;
-        break;
       case StorageDirectory.documents:
         dirType = storage_directory_e.STORAGE_DIRECTORY_DOCUMENTS;
-        break;
       case StorageDirectory.podcasts:
       case StorageDirectory.alarms:
       case StorageDirectory.notifications:
       case null:
         dirType = storage_directory_e.STORAGE_DIRECTORY_OTHERS;
-        break;
     }
     return <String>[await storage.getDirectory(dirType)];
   }

--- a/packages/path_provider/pubspec.yaml
+++ b/packages/path_provider/pubspec.yaml
@@ -5,8 +5,8 @@ repository: https://github.com/flutter-tizen/plugins/tree/master/packages/path_p
 version: 2.1.0
 
 environment:
-  sdk: ">=2.18.0 <4.0.0"
-  flutter: ">=3.3.0"
+  sdk: ">=3.1.0 <4.0.0"
+  flutter: ">=3.13.0"
 
 flutter:
   plugin:

--- a/packages/permission_handler/CHANGELOG.md
+++ b/packages/permission_handler/CHANGELOG.md
@@ -1,3 +1,7 @@
+## NEXT
+
+* Update minimum Flutter and Dart version to 3.13 and 3.1.
+
 ## 1.3.0
 
 * Increase the minimum Flutter version to 3.3.

--- a/packages/permission_handler/example/pubspec.yaml
+++ b/packages/permission_handler/example/pubspec.yaml
@@ -3,8 +3,8 @@ description: Demonstrates how to use the permission_handler_tizen plugin.
 publish_to: "none"
 
 environment:
-  sdk: ">=2.18.0 <4.0.0"
-  flutter: ">=3.3.0"
+  sdk: ">=3.1.0 <4.0.0"
+  flutter: ">=3.13.0"
 
 dependencies:
   baseflow_plugin_template: ^2.1.2

--- a/packages/permission_handler/pubspec.yaml
+++ b/packages/permission_handler/pubspec.yaml
@@ -5,8 +5,8 @@ repository: https://github.com/flutter-tizen/plugins/tree/master/packages/permis
 version: 1.3.0
 
 environment:
-  sdk: ">=2.18.0 <4.0.0"
-  flutter: ">=3.3.0"
+  sdk: ">=3.1.0 <4.0.0"
+  flutter: ">=3.13.0"
 
 flutter:
   plugin:

--- a/packages/sensors_plus/CHANGELOG.md
+++ b/packages/sensors_plus/CHANGELOG.md
@@ -1,3 +1,7 @@
+## NEXT
+
+* Update minimum Flutter and Dart version to 3.13 and 3.1.
+
 ## 1.1.4
 
 * Implement set*SamplingPeriod method call.

--- a/packages/sensors_plus/example/pubspec.yaml
+++ b/packages/sensors_plus/example/pubspec.yaml
@@ -3,8 +3,8 @@ description: Demonstrates how to use the sensors_plus plugin.
 publish_to: "none"
 
 environment:
-  sdk: ">=2.18.0 <4.0.0"
-  flutter: ">=3.3.0"
+  sdk: ">=3.1.0 <4.0.0"
+  flutter: ">=3.13.0"
 
 dependencies:
   flutter:

--- a/packages/sensors_plus/pubspec.yaml
+++ b/packages/sensors_plus/pubspec.yaml
@@ -5,8 +5,8 @@ repository: https://github.com/flutter-tizen/plugins/tree/master/packages/sensor
 version: 1.1.4
 
 environment:
-  sdk: ">=2.18.0 <4.0.0"
-  flutter: ">=3.3.0"
+  sdk: ">=3.1.0 <4.0.0"
+  flutter: ">=3.13.0"
 
 flutter:
   plugin:

--- a/packages/shared_preferences/CHANGELOG.md
+++ b/packages/shared_preferences/CHANGELOG.md
@@ -1,3 +1,7 @@
+## NEXT
+
+* Update minimum Flutter and Dart version to 3.13 and 3.1.
+
 ## 2.2.0
 
 * Increase the minimum Flutter version to 3.3.

--- a/packages/shared_preferences/example/pubspec.yaml
+++ b/packages/shared_preferences/example/pubspec.yaml
@@ -3,8 +3,8 @@ description: Demonstrates how to use the shared_preferences_tizen plugin.
 publish_to: "none"
 
 environment:
-  sdk: ">=2.18.0 <4.0.0"
-  flutter: ">=3.3.0"
+  sdk: ">=3.1.0 <4.0.0"
+  flutter: ">=3.13.0"
 
 dependencies:
   flutter:

--- a/packages/shared_preferences/pubspec.yaml
+++ b/packages/shared_preferences/pubspec.yaml
@@ -5,8 +5,8 @@ repository: https://github.com/flutter-tizen/plugins/tree/master/packages/shared
 version: 2.2.0
 
 environment:
-  sdk: ">=2.18.0 <4.0.0"
-  flutter: ">=3.3.0"
+  sdk: ">=3.1.0 <4.0.0"
+  flutter: ">=3.13.0"
 
 flutter:
   plugin:

--- a/packages/sqflite/CHANGELOG.md
+++ b/packages/sqflite/CHANGELOG.md
@@ -1,3 +1,7 @@
+## NEXT
+
+* Update minimum Flutter and Dart version to 3.13 and 3.1.
+
 ## 0.1.3
 
 * Update sqflite to 2.3.0.

--- a/packages/sqflite/example/pubspec.yaml
+++ b/packages/sqflite/example/pubspec.yaml
@@ -3,8 +3,8 @@ description: Demonstrates how to use the sqflite_tizen plugin.
 publish_to: "none"
 
 environment:
-  sdk: ">=3.0.0 <4.0.0"
-  flutter: ">=3.3.0"
+  sdk: ">=3.1.0 <4.0.0"
+  flutter: ">=3.13.0"
 
 dependencies:
   path: any

--- a/packages/sqflite/pubspec.yaml
+++ b/packages/sqflite/pubspec.yaml
@@ -5,8 +5,8 @@ repository: https://github.com/flutter-tizen/plugins/tree/master/packages/sqflit
 version: 0.1.3
 
 environment:
-  sdk: ">=3.0.0 <4.0.0"
-  flutter: ">=3.3.0"
+  sdk: ">=3.1.0 <4.0.0"
+  flutter: ">=3.13.0"
 
 flutter:
   plugin:

--- a/packages/tizen_app_control/CHANGELOG.md
+++ b/packages/tizen_app_control/CHANGELOG.md
@@ -1,3 +1,7 @@
+## NEXT
+
+* Update minimum Flutter and Dart version to 3.13 and 3.1.
+
 ## 0.2.3
 
 * Add static `AppControl.setAutoRestart` method.

--- a/packages/tizen_app_control/example/pubspec.yaml
+++ b/packages/tizen_app_control/example/pubspec.yaml
@@ -3,8 +3,8 @@ description: Demonstrates how to use the tizen_app_control plugin.
 publish_to: "none"
 
 environment:
-  sdk: ">=2.18.0 <4.0.0"
-  flutter: ">=3.3.0"
+  sdk: ">=3.1.0 <4.0.0"
+  flutter: ">=3.13.0"
 
 dependencies:
   flutter:

--- a/packages/tizen_app_control/pubspec.yaml
+++ b/packages/tizen_app_control/pubspec.yaml
@@ -5,8 +5,8 @@ repository: https://github.com/flutter-tizen/plugins/tree/master/packages/tizen_
 version: 0.2.3
 
 environment:
-  sdk: ">=2.18.0 <4.0.0"
-  flutter: ">=3.3.0"
+  sdk: ">=3.1.0 <4.0.0"
+  flutter: ">=3.13.0"
 
 dependencies:
   ffi: ">=1.1.2 <3.0.0"

--- a/packages/tizen_app_manager/CHANGELOG.md
+++ b/packages/tizen_app_manager/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## NEXT
 
-* Increase the minimum Flutter version to 3.3.
+* Update minimum Flutter and Dart version to 3.13 and 3.1.
 
 ## 0.2.2
 

--- a/packages/tizen_app_manager/example/pubspec.yaml
+++ b/packages/tizen_app_manager/example/pubspec.yaml
@@ -3,8 +3,8 @@ description: Demonstrates how to use the tizen_app_manager plugin.
 publish_to: "none"
 
 environment:
-  sdk: ">=2.18.0 <4.0.0"
-  flutter: ">=3.3.0"
+  sdk: ">=3.1.0 <4.0.0"
+  flutter: ">=3.13.0"
 
 dependencies:
   device_info_plus_tizen:

--- a/packages/tizen_app_manager/pubspec.yaml
+++ b/packages/tizen_app_manager/pubspec.yaml
@@ -5,8 +5,8 @@ repository: https://github.com/flutter-tizen/plugins/tree/master/packages/tizen_
 version: 0.2.2
 
 environment:
-  sdk: ">=2.18.0 <4.0.0"
-  flutter: ">=3.3.0"
+  sdk: ">=3.1.0 <4.0.0"
+  flutter: ">=3.13.0"
 
 dependencies:
   ffi: ^2.0.1

--- a/packages/tizen_audio_manager/CHANGELOG.md
+++ b/packages/tizen_audio_manager/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## NEXT
 
-* Increase the minimum Flutter version to 3.3.
+* Fix new lint warnings.
+* Update minimum Flutter and Dart version to 3.13 and 3.1.
 
 ## 0.1.1
 

--- a/packages/tizen_audio_manager/example/integration_test/audio_manager_test.dart
+++ b/packages/tizen_audio_manager/example/integration_test/audio_manager_test.dart
@@ -60,12 +60,12 @@ void main() {
   testWidgets('test alarm set level', (WidgetTester tester) async {
     final int max =
         await AudioManager.volumeController.getMaxLevel(AudioVolumeType.alarm);
-    AudioManager.volumeController.setLevel(AudioVolumeType.alarm, max);
+    await AudioManager.volumeController.setLevel(AudioVolumeType.alarm, max);
     int level =
         await AudioManager.volumeController.getLevel(AudioVolumeType.alarm);
     expect(level, equals(max));
 
-    AudioManager.volumeController.setLevel(AudioVolumeType.alarm, 0);
+    await AudioManager.volumeController.setLevel(AudioVolumeType.alarm, 0);
     level = await AudioManager.volumeController.getLevel(AudioVolumeType.alarm);
     expect(level, equals(0));
   });
@@ -73,12 +73,12 @@ void main() {
   testWidgets('test call set level', (WidgetTester tester) async {
     final int max =
         await AudioManager.volumeController.getMaxLevel(AudioVolumeType.call);
-    AudioManager.volumeController.setLevel(AudioVolumeType.call, max);
+    await AudioManager.volumeController.setLevel(AudioVolumeType.call, max);
     int level =
         await AudioManager.volumeController.getLevel(AudioVolumeType.call);
     expect(level, equals(max));
 
-    AudioManager.volumeController.setLevel(AudioVolumeType.call, 0);
+    await AudioManager.volumeController.setLevel(AudioVolumeType.call, 0);
     level = await AudioManager.volumeController.getLevel(AudioVolumeType.call);
     expect(level, equals(0));
   });
@@ -86,12 +86,12 @@ void main() {
   testWidgets('test media set level', (WidgetTester tester) async {
     final int max =
         await AudioManager.volumeController.getMaxLevel(AudioVolumeType.media);
-    AudioManager.volumeController.setLevel(AudioVolumeType.media, max);
+    await AudioManager.volumeController.setLevel(AudioVolumeType.media, max);
     int level =
         await AudioManager.volumeController.getLevel(AudioVolumeType.media);
     expect(level, equals(max));
 
-    AudioManager.volumeController.setLevel(AudioVolumeType.media, 0);
+    await AudioManager.volumeController.setLevel(AudioVolumeType.media, 0);
     level = await AudioManager.volumeController.getLevel(AudioVolumeType.media);
     expect(level, equals(0));
   });
@@ -99,12 +99,14 @@ void main() {
   testWidgets('test notification set level', (WidgetTester tester) async {
     final int max = await AudioManager.volumeController
         .getMaxLevel(AudioVolumeType.notification);
-    AudioManager.volumeController.setLevel(AudioVolumeType.notification, max);
+    await AudioManager.volumeController
+        .setLevel(AudioVolumeType.notification, max);
     int level = await AudioManager.volumeController
         .getLevel(AudioVolumeType.notification);
     expect(level, equals(max));
 
-    AudioManager.volumeController.setLevel(AudioVolumeType.notification, 0);
+    await AudioManager.volumeController
+        .setLevel(AudioVolumeType.notification, 0);
     level = await AudioManager.volumeController
         .getLevel(AudioVolumeType.notification);
     expect(level, equals(0));
@@ -113,12 +115,12 @@ void main() {
   testWidgets('test ringtone set level', (WidgetTester tester) async {
     final int max = await AudioManager.volumeController
         .getMaxLevel(AudioVolumeType.ringtone);
-    AudioManager.volumeController.setLevel(AudioVolumeType.ringtone, max);
+    await AudioManager.volumeController.setLevel(AudioVolumeType.ringtone, max);
     int level =
         await AudioManager.volumeController.getLevel(AudioVolumeType.ringtone);
     expect(level, equals(max));
 
-    AudioManager.volumeController.setLevel(AudioVolumeType.ringtone, 0);
+    await AudioManager.volumeController.setLevel(AudioVolumeType.ringtone, 0);
     level =
         await AudioManager.volumeController.getLevel(AudioVolumeType.ringtone);
     expect(level, equals(0));
@@ -127,12 +129,12 @@ void main() {
   testWidgets('test system set level', (WidgetTester tester) async {
     final int max =
         await AudioManager.volumeController.getMaxLevel(AudioVolumeType.system);
-    AudioManager.volumeController.setLevel(AudioVolumeType.system, max);
+    await AudioManager.volumeController.setLevel(AudioVolumeType.system, max);
     int level =
         await AudioManager.volumeController.getLevel(AudioVolumeType.system);
     expect(level, equals(max));
 
-    AudioManager.volumeController.setLevel(AudioVolumeType.system, 0);
+    await AudioManager.volumeController.setLevel(AudioVolumeType.system, 0);
     level =
         await AudioManager.volumeController.getLevel(AudioVolumeType.system);
     expect(level, equals(0));
@@ -141,12 +143,12 @@ void main() {
   testWidgets('test voice set level', (WidgetTester tester) async {
     final int max =
         await AudioManager.volumeController.getMaxLevel(AudioVolumeType.voice);
-    AudioManager.volumeController.setLevel(AudioVolumeType.voice, max);
+    await AudioManager.volumeController.setLevel(AudioVolumeType.voice, max);
     int level =
         await AudioManager.volumeController.getLevel(AudioVolumeType.voice);
     expect(level, equals(max));
 
-    AudioManager.volumeController.setLevel(AudioVolumeType.voice, 0);
+    await AudioManager.volumeController.setLevel(AudioVolumeType.voice, 0);
     level = await AudioManager.volumeController.getLevel(AudioVolumeType.voice);
     expect(level, equals(0));
   });
@@ -154,12 +156,12 @@ void main() {
   testWidgets('test voip set level', (WidgetTester tester) async {
     final int max =
         await AudioManager.volumeController.getMaxLevel(AudioVolumeType.voip);
-    AudioManager.volumeController.setLevel(AudioVolumeType.voip, max);
+    await AudioManager.volumeController.setLevel(AudioVolumeType.voip, max);
     int level =
         await AudioManager.volumeController.getLevel(AudioVolumeType.voip);
     expect(level, equals(max));
 
-    AudioManager.volumeController.setLevel(AudioVolumeType.voip, 0);
+    await AudioManager.volumeController.setLevel(AudioVolumeType.voip, 0);
     level = await AudioManager.volumeController.getLevel(AudioVolumeType.voip);
     expect(level, equals(0));
   });

--- a/packages/tizen_audio_manager/example/pubspec.yaml
+++ b/packages/tizen_audio_manager/example/pubspec.yaml
@@ -3,8 +3,8 @@ description: Demonstrates how to use the tizen_audio_manager plugin.
 publish_to: "none"
 
 environment:
-  sdk: ">=2.18.0 <4.0.0"
-  flutter: ">=3.3.0"
+  sdk: ">=3.1.0 <4.0.0"
+  flutter: ">=3.13.0"
 
 dependencies:
   flutter:

--- a/packages/tizen_audio_manager/pubspec.yaml
+++ b/packages/tizen_audio_manager/pubspec.yaml
@@ -5,8 +5,8 @@ repository: https://github.com/flutter-tizen/plugins/tree/master/packages/tizen_
 version: 0.1.1
 
 environment:
-  sdk: ">=2.18.0 <4.0.0"
-  flutter: ">=3.3.0"
+  sdk: ">=3.1.0 <4.0.0"
+  flutter: ">=3.13.0"
 
 dependencies:
   flutter:

--- a/packages/tizen_bundle/CHANGELOG.md
+++ b/packages/tizen_bundle/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## NEXT
 
-* Increase the minimum Flutter version to 3.3.
+* Update minimum Flutter and Dart version to 3.13 and 3.1.
 * Fix token in finalizer to be different from value.
 
 ## 0.1.1

--- a/packages/tizen_bundle/example/pubspec.yaml
+++ b/packages/tizen_bundle/example/pubspec.yaml
@@ -3,8 +3,8 @@ description: Demonstrates how to use the tizen_bundle plugin.
 publish_to: "none"
 
 environment:
-  sdk: ">=2.18.0 <4.0.0"
-  flutter: ">=3.3.0"
+  sdk: ">=3.1.0 <4.0.0"
+  flutter: ">=3.13.0"
 
 dependencies:
   flutter:

--- a/packages/tizen_bundle/pubspec.yaml
+++ b/packages/tizen_bundle/pubspec.yaml
@@ -5,8 +5,8 @@ repository: https://github.com/flutter-tizen/plugins/tree/master/packages/tizen_
 version: 0.1.1
 
 environment:
-  sdk: ">=2.18.0 <4.0.0"
-  flutter: ">=3.3.0"
+  sdk: ">=3.1.0 <4.0.0"
+  flutter: ">=3.13.0"
 
 dependencies:
   ffi: ^2.0.1

--- a/packages/tizen_log/CHANGELOG.md
+++ b/packages/tizen_log/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## NEXT
 
-* Increase the minimum Flutter version to 3.3.
+* Update minimum Flutter and Dart version to 3.13 and 3.1.
+* Fix new lint warnings.
 
 ## 0.1.2
 

--- a/packages/tizen_log/example/pubspec.yaml
+++ b/packages/tizen_log/example/pubspec.yaml
@@ -3,8 +3,8 @@ description: Demonstrates how to use the tizen_log plugin.
 publish_to: "none"
 
 environment:
-  sdk: ">=2.18.0 <4.0.0"
-  flutter: ">=3.3.0"
+  sdk: ">=3.1.0 <4.0.0"
+  flutter: ">=3.13.0"
 
 dependencies:
   flutter:

--- a/packages/tizen_log/lib/tizen_log.dart
+++ b/packages/tizen_log/lib/tizen_log.dart
@@ -175,7 +175,7 @@ class Log {
           _stackTraceRegExp.allMatches(StackTrace.current.toString());
       for (final RegExpMatch match in matches) {
         final List<String?> groups = match.groups(<int>[1, 2, 3, 4]);
-        if (groups.any((String? group) => group == null) == false) {
+        if (!groups.any((String? group) => group == null)) {
           final int frameIndex = int.parse(groups[0]!);
           if (frameIndex == index) {
             final List<String> funcParts = groups[1]!.trim().split('.');
@@ -197,17 +197,17 @@ class Log {
   }
 }
 
-class _LogPriority {
+enum _LogPriority {
+  verbose._(2),
+  debug._(3),
+  info._(4),
+  warn._(5),
+  error._(6),
+  fatal._(7);
+
   const _LogPriority._(this.value);
 
   final int value;
-
-  static const _LogPriority verbose = _LogPriority._(2);
-  static const _LogPriority debug = _LogPriority._(3);
-  static const _LogPriority info = _LogPriority._(4);
-  static const _LogPriority warn = _LogPriority._(5);
-  static const _LogPriority error = _LogPriority._(6);
-  static const _LogPriority fatal = _LogPriority._(7);
 }
 
 class _StackFrame {

--- a/packages/tizen_log/pubspec.yaml
+++ b/packages/tizen_log/pubspec.yaml
@@ -5,8 +5,8 @@ repository: https://github.com/flutter-tizen/plugins/tree/master/packages/tizen_
 version: 0.1.2
 
 environment:
-  sdk: ">=2.18.0 <4.0.0"
-  flutter: ">=3.3.0"
+  sdk: ">=3.1.0 <4.0.0"
+  flutter: ">=3.13.0"
 
 dependencies:
   ffi: ">=1.1.2 <3.0.0"

--- a/packages/tizen_notification/CHANGELOG.md
+++ b/packages/tizen_notification/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## NEXT
 
-* Increase the minimum Flutter version to 3.3.
+* Update minimum Flutter and Dart version to 3.13 and 3.1.
 
 ## 0.2.0
 

--- a/packages/tizen_notification/example/pubspec.yaml
+++ b/packages/tizen_notification/example/pubspec.yaml
@@ -3,8 +3,8 @@ description: Demonstrates how to use the tizen_notification plugin.
 publish_to: "none"
 
 environment:
-  sdk: ">=2.18.0 <4.0.0"
-  flutter: ">=3.3.0"
+  sdk: ">=3.1.0 <4.0.0"
+  flutter: ">=3.13.0"
 
 dependencies:
   flutter:

--- a/packages/tizen_notification/pubspec.yaml
+++ b/packages/tizen_notification/pubspec.yaml
@@ -5,8 +5,8 @@ repository: https://github.com/flutter-tizen/plugins/tree/master/packages/tizen_
 version: 0.2.0
 
 environment:
-  sdk: ">=2.18.0 <4.0.0"
-  flutter: ">=3.3.0"
+  sdk: ">=3.1.0 <4.0.0"
+  flutter: ">=3.13.0"
 
 dependencies:
   flutter:

--- a/packages/tizen_package_manager/CHANGELOG.md
+++ b/packages/tizen_package_manager/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## NEXT
 
-* Increase the minimum Flutter version to 3.3.
+* Update minimum Flutter and Dart version to 3.13 and 3.1.
 
 ## 0.2.1
 

--- a/packages/tizen_package_manager/example/pubspec.yaml
+++ b/packages/tizen_package_manager/example/pubspec.yaml
@@ -4,8 +4,8 @@ version: 1.0.0
 publish_to: "none"
 
 environment:
-  sdk: ">=2.18.0 <4.0.0"
-  flutter: ">=3.3.0"
+  sdk: ">=3.1.0 <4.0.0"
+  flutter: ">=3.13.0"
 
 dependencies:
   flutter:

--- a/packages/tizen_package_manager/pubspec.yaml
+++ b/packages/tizen_package_manager/pubspec.yaml
@@ -5,8 +5,8 @@ repository: https://github.com/flutter-tizen/plugins/tree/master/packages/tizen_
 version: 0.2.1
 
 environment:
-  sdk: ">=2.18.0 <4.0.0"
-  flutter: ">=3.3.0"
+  sdk: ">=3.1.0 <4.0.0"
+  flutter: ">=3.13.0"
 
 dependencies:
   flutter:

--- a/packages/tizen_rpc_port/CHANGELOG.md
+++ b/packages/tizen_rpc_port/CHANGELOG.md
@@ -1,6 +1,8 @@
 ## NEXT
 
 * Fix token in finalizer to be different from value.
+* Fix new lint warnings.
+* Update minimum Flutter and Dart version to 3.13 and 3.1.
 
 ## 0.1.3
 

--- a/packages/tizen_rpc_port/example/client/analysis_options.yaml
+++ b/packages/tizen_rpc_port/example/client/analysis_options.yaml
@@ -1,0 +1,6 @@
+include: ../../../../analysis_options.yaml
+
+analyzer:
+linter:
+  rules:
+    unawaited_futures: false

--- a/packages/tizen_rpc_port/example/client/pubspec.yaml
+++ b/packages/tizen_rpc_port/example/client/pubspec.yaml
@@ -3,8 +3,8 @@ description: Demonstrates how to use the tizen_rpc_port client API.
 publish_to: "none"
 
 environment:
-  sdk: ">=2.18.0 <4.0.0"
-  flutter: ">=3.3.0"
+  sdk: ">=3.1.0 <4.0.0"
+  flutter: ">=3.13.0"
 
 dependencies:
   flutter:

--- a/packages/tizen_rpc_port/example/server/analysis_options.yaml
+++ b/packages/tizen_rpc_port/example/server/analysis_options.yaml
@@ -1,0 +1,6 @@
+include: ../../../../analysis_options.yaml
+
+analyzer:
+linter:
+  rules:
+    unawaited_futures: false

--- a/packages/tizen_rpc_port/example/server/lib/main.dart
+++ b/packages/tizen_rpc_port/example/server/lib/main.dart
@@ -42,7 +42,7 @@ class EchoService extends ServiceBase {
   Future<int> onSend(String message) async {
     print('Received: $message');
     if (_callback != null) {
-      _callback!.invoke(_name!, message);
+      await _callback!.invoke(_name!, message);
     }
     return 0;
   }

--- a/packages/tizen_rpc_port/example/server/pubspec.yaml
+++ b/packages/tizen_rpc_port/example/server/pubspec.yaml
@@ -3,8 +3,8 @@ description: Demonstrates how to use the tizen_rpc_port server API.
 publish_to: "none"
 
 environment:
-  sdk: ">=2.18.0 <4.0.0"
-  flutter: ">=3.3.0"
+  sdk: ">=3.1.0 <4.0.0"
+  flutter: ">=3.13.0"
 
 dependencies:
   flutter:

--- a/packages/tizen_rpc_port/lib/src/proxy_base.dart
+++ b/packages/tizen_rpc_port/lib/src/proxy_base.dart
@@ -109,13 +109,13 @@ abstract class ProxyBase {
       } else if (event == 'disconnected') {
         _isConnected = false;
         await _onDisconnectedEvent();
-        _streamSubscription?.cancel();
+        await _streamSubscription?.cancel();
         _streamSubscription = null;
       } else if (event == 'rejected') {
         _isConnected = false;
         final String error = map['error'] as String;
         await _onRejectedEvent(error);
-        _streamSubscription?.cancel();
+        await _streamSubscription?.cancel();
         _streamSubscription = null;
       } else if (event == 'received') {
         final Uint8List rawData = map['rawData'] as Uint8List;

--- a/packages/tizen_rpc_port/lib/src/stub_base.dart
+++ b/packages/tizen_rpc_port/lib/src/stub_base.dart
@@ -130,7 +130,7 @@ abstract class StubBase {
   /// All active connections will be closed immediately. No operation can be
   /// made to this stub after this call.
   Future<void> close() async {
-    _streamSubscription?.cancel();
+    await _streamSubscription?.cancel();
     tizen.rpc_port_stub_destroy(_handle);
   }
 

--- a/packages/tizen_rpc_port/pubspec.yaml
+++ b/packages/tizen_rpc_port/pubspec.yaml
@@ -5,8 +5,8 @@ repository: https://github.com/flutter-tizen/plugins/tree/master/packages/tizen_
 version: 0.1.3
 
 environment:
-  sdk: ">=2.18.0 <4.0.0"
-  flutter: ">=3.3.0"
+  sdk: ">=3.1.0 <4.0.0"
+  flutter: ">=3.13.0"
 
 dependencies:
   ffi: ^2.0.1

--- a/packages/url_launcher/CHANGELOG.md
+++ b/packages/url_launcher/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## NEXT
 
-* Increase the minimum Flutter version to 3.3.
+* Update minimum Flutter and Dart version to 3.13 and 3.1.
 
 ## 2.1.2
 

--- a/packages/url_launcher/example/pubspec.yaml
+++ b/packages/url_launcher/example/pubspec.yaml
@@ -3,8 +3,8 @@ description: Demonstrates how to use the url_launcher_tizen plugin.
 publish_to: "none"
 
 environment:
-  sdk: ">=2.18.0 <4.0.0"
-  flutter: ">=3.3.0"
+  sdk: ">=3.1.0 <4.0.0"
+  flutter: ">=3.13.0"
 
 dependencies:
   flutter:

--- a/packages/url_launcher/pubspec.yaml
+++ b/packages/url_launcher/pubspec.yaml
@@ -5,8 +5,8 @@ repository: https://github.com/flutter-tizen/plugins/tree/master/packages/url_la
 version: 2.1.2
 
 environment:
-  sdk: ">=2.18.0 <4.0.0"
-  flutter: ">=3.3.0"
+  sdk: ">=3.1.0 <4.0.0"
+  flutter: ">=3.13.0"
 
 flutter:
   plugin:

--- a/packages/video_player/CHANGELOG.md
+++ b/packages/video_player/CHANGELOG.md
@@ -1,3 +1,8 @@
+## NEXT
+
+* Fix new lint warnings.
+* Update minimum Flutter and Dart version to 3.13 and 3.1.
+
 ## 2.4.9
 
 * Fix event channel issue, sending messages from native to Flutter on the platform thread.

--- a/packages/video_player/example/lib/main.dart
+++ b/packages/video_player/example/lib/main.dart
@@ -6,6 +6,8 @@
 
 /// An example of using the plugin, controlling lifecycle and playback of the
 /// video.
+library;
+
 import 'package:flutter/material.dart';
 import 'package:video_player/video_player.dart';
 
@@ -299,9 +301,9 @@ class _ControlsOverlay extends StatelessWidget {
           reverseDuration: const Duration(milliseconds: 200),
           child: controller.value.isPlaying
               ? const SizedBox.shrink()
-              : Container(
+              : const ColoredBox(
                   color: Colors.black26,
-                  child: const Center(
+                  child: Center(
                     child: Icon(
                       Icons.play_arrow,
                       color: Colors.white,

--- a/packages/video_player/example/pubspec.yaml
+++ b/packages/video_player/example/pubspec.yaml
@@ -3,8 +3,8 @@ description: Demonstrates how to use the video_player_tizen plugin.
 publish_to: "none"
 
 environment:
-  sdk: ">=2.18.0 <4.0.0"
-  flutter: ">=3.3.0"
+  sdk: ">=3.1.0 <4.0.0"
+  flutter: ">=3.13.0"
 
 dependencies:
   flutter:

--- a/packages/video_player/lib/video_player_tizen.dart
+++ b/packages/video_player/lib/video_player_tizen.dart
@@ -41,18 +41,14 @@ class VideoPlayerTizen extends VideoPlayerPlatform {
       case DataSourceType.asset:
         asset = dataSource.asset;
         packageName = dataSource.package;
-        break;
       case DataSourceType.network:
         uri = dataSource.uri;
         formatHint = _videoFormatStringMap[dataSource.formatHint];
         httpHeaders = dataSource.httpHeaders;
-        break;
       case DataSourceType.file:
         uri = dataSource.uri;
-        break;
       case DataSourceType.contentUri:
         uri = dataSource.uri;
-        break;
     }
     final CreateMessage message = CreateMessage(
       asset: asset,

--- a/packages/video_player/pubspec.yaml
+++ b/packages/video_player/pubspec.yaml
@@ -5,8 +5,8 @@ repository: https://github.com/flutter-tizen/plugins/tree/master/packages/video_
 version: 2.4.9
 
 environment:
-  sdk: ">=2.18.0 <4.0.0"
-  flutter: ">=3.3.0"
+  sdk: ">=3.1.0 <4.0.0"
+  flutter: ">=3.13.0"
 
 flutter:
   plugin:

--- a/packages/video_player_avplay/CHANGELOG.md
+++ b/packages/video_player_avplay/CHANGELOG.md
@@ -1,3 +1,8 @@
+## NEXT
+
+* Fix new lint warnings.
+* Update minimum Flutter and Dart version to 3.13 and 3.1.
+
 ## 0.4.0
 
 * Minor refactor.

--- a/packages/video_player_avplay/example/lib/main.dart
+++ b/packages/video_player_avplay/example/lib/main.dart
@@ -6,6 +6,7 @@
 
 /// An example of using the plugin, controlling lifecycle and playback of the
 /// video.
+library;
 
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
@@ -536,9 +537,9 @@ class _ControlsOverlay extends StatelessWidget {
           reverseDuration: const Duration(milliseconds: 200),
           child: controller.value.isPlaying
               ? const SizedBox.shrink()
-              : Container(
+              : const ColoredBox(
                   color: Colors.black26,
-                  child: const Center(
+                  child: Center(
                     child: Icon(
                       Icons.play_arrow,
                       color: Colors.white,

--- a/packages/video_player_avplay/example/pubspec.yaml
+++ b/packages/video_player_avplay/example/pubspec.yaml
@@ -3,8 +3,8 @@ description: Demonstrates how to use the video_player_avplay plugin.
 publish_to: "none"
 
 environment:
-  sdk: ">=2.18.0 <4.0.0"
-  flutter: ">=3.3.0"
+  sdk: ">=3.1.0 <4.0.0"
+  flutter: ">=3.13.0"
 
 dependencies:
   flutter:

--- a/packages/video_player_avplay/lib/src/video_player_tizen.dart
+++ b/packages/video_player_avplay/lib/src/video_player_tizen.dart
@@ -33,7 +33,6 @@ class VideoPlayerTizen extends VideoPlayerPlatform {
       case DataSourceType.asset:
         message.asset = dataSource.asset;
         message.packageName = dataSource.package;
-        break;
       case DataSourceType.network:
         message.uri = dataSource.uri;
         message.formatHint = _videoFormatStringMap[dataSource.formatHint];
@@ -47,13 +46,10 @@ class VideoPlayerTizen extends VideoPlayerPlatform {
                     in dataSource.streamingProperty!.entries)
                   _streamingPropertyType[entry.key]!: entry.value
               };
-        break;
       case DataSourceType.file:
         message.uri = dataSource.uri;
-        break;
       case DataSourceType.contentUri:
         message.uri = dataSource.uri;
-        break;
     }
 
     final PlayerMessage response = await _api.create(message);

--- a/packages/video_player_avplay/lib/video_player.dart
+++ b/packages/video_player_avplay/lib/video_player.dart
@@ -377,7 +377,6 @@ class VideoPlayerController extends ValueNotifier<VideoPlayerValue> {
           asset: dataSource,
           package: package,
         );
-        break;
       case DataSourceType.network:
         dataSourceDescription = DataSource(
           sourceType: DataSourceType.network,
@@ -388,19 +387,16 @@ class VideoPlayerController extends ValueNotifier<VideoPlayerValue> {
           playerOptions: playerOptions,
           streamingProperty: streamingProperty,
         );
-        break;
       case DataSourceType.file:
         dataSourceDescription = DataSource(
           sourceType: DataSourceType.file,
           uri: dataSource,
         );
-        break;
       case DataSourceType.contentUri:
         dataSourceDescription = DataSource(
           sourceType: DataSourceType.contentUri,
           uri: dataSource,
         );
-        break;
     }
 
     if (videoPlayerOptions?.mixWithOthers != null) {
@@ -435,7 +431,6 @@ class VideoPlayerController extends ValueNotifier<VideoPlayerValue> {
           _applyVolume();
           _durationTimer?.cancel();
           _durationTimer = _createDurationTimer();
-          break;
         case VideoEventType.completed:
           // In this case we need to stop _timer, set isPlaying=false, and
           // position=value.duration. Instead of setting the values directly,
@@ -443,16 +438,12 @@ class VideoPlayerController extends ValueNotifier<VideoPlayerValue> {
           // and seeks to the last frame of the video.
           pause().then((void pauseResult) => seekTo(value.duration.end));
           _durationTimer?.cancel();
-          break;
         case VideoEventType.bufferingUpdate:
           value = value.copyWith(buffered: event.buffered);
-          break;
         case VideoEventType.bufferingStart:
           value = value.copyWith(isBuffering: true);
-          break;
         case VideoEventType.bufferingEnd:
           value = value.copyWith(isBuffering: false);
-          break;
         case VideoEventType.subtitleUpdate:
           final Caption caption = Caption(
             number: 0,
@@ -461,7 +452,6 @@ class VideoPlayerController extends ValueNotifier<VideoPlayerValue> {
             text: event.text ?? '',
           );
           value = value.copyWith(caption: caption);
-          break;
         case VideoEventType.unknown:
           break;
       }

--- a/packages/video_player_avplay/pubspec.yaml
+++ b/packages/video_player_avplay/pubspec.yaml
@@ -5,8 +5,8 @@ repository: https://github.com/flutter-tizen/plugins/tree/master/packages/video_
 version: 0.4.0
 
 environment:
-  sdk: ">=2.18.0 <4.0.0"
-  flutter: ">=3.3.0"
+  sdk: ">=3.1.0 <4.0.0"
+  flutter: ">=3.13.0"
 
 flutter:
   plugin:

--- a/packages/video_player_videohole/CHANGELOG.md
+++ b/packages/video_player_videohole/CHANGELOG.md
@@ -1,3 +1,8 @@
+## NEXT
+
+* Fix new lint warnings.
+* Update minimum Flutter and Dart version to 3.13 and 3.1.
+
 ## 0.5.1
 
 * Free response buffer after install key.

--- a/packages/video_player_videohole/example/lib/main.dart
+++ b/packages/video_player_videohole/example/lib/main.dart
@@ -6,6 +6,7 @@
 
 /// An example of using the plugin, controlling lifecycle and playback of the
 /// video.
+library;
 
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
@@ -471,9 +472,9 @@ class _ControlsOverlay extends StatelessWidget {
           reverseDuration: const Duration(milliseconds: 200),
           child: controller.value.isPlaying
               ? const SizedBox.shrink()
-              : Container(
+              : const ColoredBox(
                   color: Colors.black26,
-                  child: const Center(
+                  child: Center(
                     child: Icon(
                       Icons.play_arrow,
                       color: Colors.white,

--- a/packages/video_player_videohole/example/pubspec.yaml
+++ b/packages/video_player_videohole/example/pubspec.yaml
@@ -3,8 +3,8 @@ description: Demonstrates how to use the video_player_videohole plugin.
 publish_to: "none"
 
 environment:
-  sdk: ">=2.18.0 <4.0.0"
-  flutter: ">=3.3.0"
+  sdk: ">=3.1.0 <4.0.0"
+  flutter: ">=3.13.0"
 
 dependencies:
   flutter:

--- a/packages/video_player_videohole/lib/src/video_player_tizen.dart
+++ b/packages/video_player_videohole/lib/src/video_player_tizen.dart
@@ -35,20 +35,16 @@ class VideoPlayerTizen extends VideoPlayerPlatform {
       case DataSourceType.asset:
         message.asset = dataSource.asset;
         message.packageName = dataSource.package;
-        break;
       case DataSourceType.network:
         message.uri = dataSource.uri;
         message.formatHint = _videoFormatStringMap[dataSource.formatHint];
         message.httpHeaders = dataSource.httpHeaders;
         message.drmConfigs = dataSource.drmConfigs?.toMap();
         message.playerOptions = dataSource.playerOptions;
-        break;
       case DataSourceType.file:
         message.uri = dataSource.uri;
-        break;
       case DataSourceType.contentUri:
         message.uri = dataSource.uri;
-        break;
     }
 
     final PlayerMessage response = await _api.create(message);

--- a/packages/video_player_videohole/lib/video_player.dart
+++ b/packages/video_player_videohole/lib/video_player.dart
@@ -368,7 +368,6 @@ class VideoPlayerController extends ValueNotifier<VideoPlayerValue> {
           asset: dataSource,
           package: package,
         );
-        break;
       case DataSourceType.network:
         dataSourceDescription = DataSource(
           sourceType: DataSourceType.network,
@@ -378,19 +377,16 @@ class VideoPlayerController extends ValueNotifier<VideoPlayerValue> {
           drmConfigs: drmConfigs,
           playerOptions: playerOptions,
         );
-        break;
       case DataSourceType.file:
         dataSourceDescription = DataSource(
           sourceType: DataSourceType.file,
           uri: dataSource,
         );
-        break;
       case DataSourceType.contentUri:
         dataSourceDescription = DataSource(
           sourceType: DataSourceType.contentUri,
           uri: dataSource,
         );
-        break;
     }
 
     if (videoPlayerOptions?.mixWithOthers != null) {
@@ -422,7 +418,6 @@ class VideoPlayerController extends ValueNotifier<VideoPlayerValue> {
           _applyPlayPause();
           _durationTimer?.cancel();
           _durationTimer = _createDurationTimer();
-          break;
         case VideoEventType.completed:
           // In this case we need to stop _timer, set isPlaying=false, and
           // position=value.duration. Instead of setting the values directly,
@@ -430,16 +425,12 @@ class VideoPlayerController extends ValueNotifier<VideoPlayerValue> {
           // and seeks to the last frame of the video.
           pause().then((void pauseResult) => seekTo(value.duration.end));
           _durationTimer?.cancel();
-          break;
         case VideoEventType.bufferingUpdate:
           value = value.copyWith(buffered: event.buffered);
-          break;
         case VideoEventType.bufferingStart:
           value = value.copyWith(isBuffering: true);
-          break;
         case VideoEventType.bufferingEnd:
           value = value.copyWith(isBuffering: false);
-          break;
         case VideoEventType.subtitleUpdate:
           final Caption caption = Caption(
             number: 0,
@@ -448,7 +439,6 @@ class VideoPlayerController extends ValueNotifier<VideoPlayerValue> {
             text: event.text ?? '',
           );
           value = value.copyWith(caption: caption);
-          break;
         case VideoEventType.unknown:
           break;
       }

--- a/packages/video_player_videohole/pubspec.yaml
+++ b/packages/video_player_videohole/pubspec.yaml
@@ -5,8 +5,8 @@ repository: https://github.com/flutter-tizen/plugins/tree/master/packages/video_
 version: 0.5.1
 
 environment:
-  sdk: ">=2.18.0 <4.0.0"
-  flutter: ">=3.3.0"
+  sdk: ">=3.1.0 <4.0.0"
+  flutter: ">=3.13.0"
 
 flutter:
   plugin:

--- a/packages/wakelock/CHANGELOG.md
+++ b/packages/wakelock/CHANGELOG.md
@@ -1,3 +1,7 @@
+## NEXT
+
+* Update minimum Flutter and Dart version to 3.13 and 3.1.
+
 ## 1.0.2
 
 * Switch to a MethodChannel-based implementation.

--- a/packages/wakelock/example/pubspec.yaml
+++ b/packages/wakelock/example/pubspec.yaml
@@ -3,8 +3,8 @@ description: Demonstrates how to use the wakelock_tizen plugin.
 publish_to: "none"
 
 environment:
-  sdk: ">=2.18.0 <4.0.0"
-  flutter: ">=3.3.0"
+  sdk: ">=3.1.0 <4.0.0"
+  flutter: ">=3.13.0"
 
 dependencies:
   flutter:

--- a/packages/wakelock/pubspec.yaml
+++ b/packages/wakelock/pubspec.yaml
@@ -5,8 +5,8 @@ repository: https://github.com/flutter-tizen/plugins/tree/master/packages/wakelo
 version: 1.0.2
 
 environment:
-  sdk: ">=2.18.0 <4.0.0"
-  flutter: ">=3.3.0"
+  sdk: ">=3.1.0 <4.0.0"
+  flutter: ">=3.13.0"
 
 flutter:
   plugin:

--- a/packages/wearable_rotary/CHANGELOG.md
+++ b/packages/wearable_rotary/CHANGELOG.md
@@ -1,3 +1,8 @@
+## NEXT
+
+* Fix new lint warnings.
+* Update minimum Flutter and Dart version to 3.13 and 3.1.
+
 ## 2.0.2
 
 * Adds namespace to `build.gradle` for compatibility with Gradle 8

--- a/packages/wearable_rotary/example/pubspec.yaml
+++ b/packages/wearable_rotary/example/pubspec.yaml
@@ -3,8 +3,8 @@ description: Demonstrates how to use the wearable_rotary plugin.
 publish_to: "none"
 
 environment:
-  sdk: ">=2.18.0 <4.0.0"
-  flutter: ">=3.3.0"
+  sdk: ">=3.1.0 <4.0.0"
+  flutter: ">=3.13.0"
 
 dependencies:
   flutter:

--- a/packages/wearable_rotary/lib/wearable_rotary.dart
+++ b/packages/wearable_rotary/lib/wearable_rotary.dart
@@ -1,4 +1,2 @@
-library wearable_rotary;
-
 export 'src/rotary_scroll_controller.dart';
 export 'src/wearable_rotary_base.dart';

--- a/packages/wearable_rotary/pubspec.yaml
+++ b/packages/wearable_rotary/pubspec.yaml
@@ -5,8 +5,8 @@ repository: https://github.com/flutter-tizen/plugins/tree/master/packages/wearab
 version: 2.0.2
 
 environment:
-  sdk: ">=2.18.0 <4.0.0"
-  flutter: ">=3.3.0"
+  sdk: ">=3.1.0 <4.0.0"
+  flutter: ">=3.13.0"
 
 flutter:
   plugin:

--- a/packages/webview_flutter/CHANGELOG.md
+++ b/packages/webview_flutter/CHANGELOG.md
@@ -1,6 +1,8 @@
 ## NEXT
 
 * Add ewk_set_version_policy() call.
+* Fix new lint warnings.
+* Update minimum Flutter and Dart version to 3.13 and 3.1.
 
 ## 0.9.0
 

--- a/packages/webview_flutter/example/lib/main.dart
+++ b/packages/webview_flutter/example/lib/main.dart
@@ -231,46 +231,32 @@ class SampleMenu extends StatelessWidget {
         switch (value) {
           case MenuOptions.showUserAgent:
             _onShowUserAgent();
-            break;
           case MenuOptions.listCookies:
             _onListCookies(context);
-            break;
           case MenuOptions.clearCookies:
             _onClearCookies(context);
-            break;
           case MenuOptions.addToCache:
             _onAddToCache(context);
-            break;
           case MenuOptions.listCache:
             _onListCache();
-            break;
           case MenuOptions.clearCache:
             _onClearCache(context);
-            break;
           case MenuOptions.navigationDelegate:
             _onNavigationDelegateExample();
-            break;
           case MenuOptions.doPostRequest:
             _onDoPostRequest();
-            break;
           case MenuOptions.loadLocalFile:
             _onLoadLocalFileExample();
-            break;
           case MenuOptions.loadFlutterAsset:
             _onLoadFlutterAssetExample();
-            break;
           case MenuOptions.loadHtmlString:
             _onLoadHtmlStringExample();
-            break;
           case MenuOptions.transparentBackground:
             _onTransparentBackground();
-            break;
           case MenuOptions.setCookie:
             _onSetCookie();
-            break;
           case MenuOptions.logExample:
             _onLogExample();
-            break;
         }
       },
       itemBuilder: (BuildContext context) => <PopupMenuItem<MenuOptions>>[

--- a/packages/webview_flutter/example/pubspec.yaml
+++ b/packages/webview_flutter/example/pubspec.yaml
@@ -3,8 +3,8 @@ description: Demonstrates how to use the webview_flutter_tizen plugin.
 publish_to: "none"
 
 environment:
-  sdk: ">=2.18.0 <4.0.0"
-  flutter: ">=3.3.0"
+  sdk: ">=3.1.0 <4.0.0"
+  flutter: ">=3.13.0"
 
 dependencies:
   flutter:

--- a/packages/webview_flutter/lib/src/tizen_webview_controller.dart
+++ b/packages/webview_flutter/lib/src/tizen_webview_controller.dart
@@ -47,19 +47,14 @@ class TizenWebViewController extends PlatformWebViewController {
           switch (arguments['level']! as String) {
             case 'error':
               level = JavaScriptLogLevel.error;
-              break;
             case 'warning':
               level = JavaScriptLogLevel.warning;
-              break;
             case 'debug':
               level = JavaScriptLogLevel.debug;
-              break;
             case 'info':
               level = JavaScriptLogLevel.info;
-              break;
             case 'log':
               level = JavaScriptLogLevel.log;
-              break;
           }
 
           if (_onConsoleLogCallback != null) {
@@ -88,7 +83,7 @@ class TizenWebViewController extends PlatformWebViewController {
 
   @override
   Future<void> loadFile(String absoluteFilePath) {
-    assert(absoluteFilePath != null);
+    assert(absoluteFilePath.isNotEmpty);
     return _webview.loadFile(absoluteFilePath);
   }
 
@@ -103,7 +98,7 @@ class TizenWebViewController extends PlatformWebViewController {
     String html, {
     String? baseUrl,
   }) {
-    assert(html != null);
+    assert(html.isNotEmpty);
     return _webview.loadHtmlString(html, baseUrl: baseUrl);
   }
 

--- a/packages/webview_flutter/lib/webview_flutter_tizen.dart
+++ b/packages/webview_flutter/lib/webview_flutter_tizen.dart
@@ -3,8 +3,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-library webview_flutter_tizen;
-
 export 'src/tizen_webview_controller.dart';
 export 'src/tizen_webview_cookie_manager.dart';
 export 'src/tizen_webview_platform.dart';

--- a/packages/webview_flutter/pubspec.yaml
+++ b/packages/webview_flutter/pubspec.yaml
@@ -5,8 +5,8 @@ repository: https://github.com/flutter-tizen/plugins/tree/master/packages/webvie
 version: 0.9.0
 
 environment:
-  sdk: ">=2.18.0 <4.0.0"
-  flutter: ">=3.3.0"
+  sdk: ">=3.1.0 <4.0.0"
+  flutter: ">=3.13.0"
 
 flutter:
   plugin:

--- a/packages/webview_flutter_lwe/CHANGELOG.md
+++ b/packages/webview_flutter_lwe/CHANGELOG.md
@@ -1,3 +1,8 @@
+## NEXT
+
+* Fix new lint warnings.
+* Update minimum Flutter and Dart version to 3.13 and 3.1.
+
 ## 0.3.0
 
 * Update webivew_flutter to 4.4.2.

--- a/packages/webview_flutter_lwe/example/lib/main.dart
+++ b/packages/webview_flutter_lwe/example/lib/main.dart
@@ -225,46 +225,32 @@ class SampleMenu extends StatelessWidget {
         switch (value) {
           case MenuOptions.showUserAgent:
             _onShowUserAgent();
-            break;
           case MenuOptions.listCookies:
             _onListCookies(context);
-            break;
           case MenuOptions.clearCookies:
             _onClearCookies(context);
-            break;
           case MenuOptions.addToCache:
             _onAddToCache(context);
-            break;
           case MenuOptions.listCache:
             _onListCache();
-            break;
           case MenuOptions.clearCache:
             _onClearCache(context);
-            break;
           case MenuOptions.navigationDelegate:
             _onNavigationDelegateExample();
-            break;
           case MenuOptions.doPostRequest:
             _onDoPostRequest();
-            break;
           case MenuOptions.loadLocalFile:
             _onLoadLocalFileExample();
-            break;
           case MenuOptions.loadFlutterAsset:
             _onLoadFlutterAssetExample();
-            break;
           case MenuOptions.loadHtmlString:
             _onLoadHtmlStringExample();
-            break;
           case MenuOptions.transparentBackground:
             _onTransparentBackground();
-            break;
           case MenuOptions.setCookie:
             _onSetCookie();
-            break;
           case MenuOptions.logExample:
             _onLogExample();
-            break;
         }
       },
       itemBuilder: (BuildContext context) => <PopupMenuItem<MenuOptions>>[

--- a/packages/webview_flutter_lwe/example/pubspec.yaml
+++ b/packages/webview_flutter_lwe/example/pubspec.yaml
@@ -3,8 +3,8 @@ description: Demonstrates how to use the webview_flutter_lwe plugin.
 publish_to: "none"
 
 environment:
-  sdk: ">=2.18.0 <4.0.0"
-  flutter: ">=3.3.0"
+  sdk: ">=3.1.0 <4.0.0"
+  flutter: ">=3.13.0"
 
 dependencies:
   flutter:

--- a/packages/webview_flutter_lwe/lib/src/lwe_webview_controller.dart
+++ b/packages/webview_flutter_lwe/lib/src/lwe_webview_controller.dart
@@ -36,7 +36,7 @@ class LweWebViewController extends PlatformWebViewController {
 
   @override
   Future<void> loadFile(String absoluteFilePath) {
-    assert(absoluteFilePath != null);
+    assert(absoluteFilePath.isNotEmpty);
     return _webview.loadFile(absoluteFilePath);
   }
 
@@ -51,7 +51,7 @@ class LweWebViewController extends PlatformWebViewController {
     String html, {
     String? baseUrl,
   }) {
-    assert(html != null);
+    assert(html.isNotEmpty);
     return _webview.loadHtmlString(html, baseUrl: baseUrl);
   }
 

--- a/packages/webview_flutter_lwe/lib/webview_flutter_lwe.dart
+++ b/packages/webview_flutter_lwe/lib/webview_flutter_lwe.dart
@@ -3,8 +3,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-library webview_flutter_lwe;
-
 export 'src/lwe_webview_controller.dart';
 export 'src/lwe_webview_cookie_manager.dart';
 export 'src/lwe_webview_platform.dart';

--- a/packages/webview_flutter_lwe/pubspec.yaml
+++ b/packages/webview_flutter_lwe/pubspec.yaml
@@ -5,8 +5,8 @@ repository: https://github.com/flutter-tizen/plugins/tree/master/packages/webvie
 version: 0.3.0
 
 environment:
-  sdk: ">=2.18.0 <4.0.0"
-  flutter: ">=3.3.0"
+  sdk: ">=3.1.0 <4.0.0"
+  flutter: ">=3.13.0"
 
 flutter:
   plugin:


### PR DESCRIPTION
This change is a continuation of this PR.
https://github.com/flutter-tizen/plugins/pull/675
This change will enable the lint option below and apply the changes.
And update the SDK version to apply these lint options. 
This should be common to all plugins, so apply them together.

- unnecessary_null_comparison
- unawaited_futures
- dangling_library_doc_comments
- no_literal_bool_comparisons
- unnecessary_library_directive
- use_colored_box
- use_enums
- use_string_in_part_of_directives