### PR TITLE
[video_player_avplay] Remove set looping failed message

### DIFF
--- a/packages/video_player_avplay/CHANGELOG.md
+++ b/packages/video_player_avplay/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 * Add notes for creating dash player.
 * [Dash] Fix no EOS event of dashplayer.
+* Remove set looping failed message.
 
 ## 0.4.1
 

--- a/packages/video_player_avplay/README.md
+++ b/packages/video_player_avplay/README.md
@@ -134,4 +134,4 @@ This plugin has the following limitations.
 - The `setPlaybackSpeed` method will fail if triggered within the last 3 seconds of the video.
 - The playback speed will reset to 1.0 when the video is replayed in loop mode.
 - The `seekTo` method works only when the playback speed is 1.0, and it sets the video position to the nearest keyframe, not the exact value passed.
-- 
+- The `setLooping` method only works when the player's DataSourceType is DataSourceType.asset.

--- a/packages/video_player_avplay/tizen/src/plus_player.cc
+++ b/packages/video_player_avplay/tizen/src/plus_player.cc
@@ -247,7 +247,7 @@ bool PlusPlayer::Pause() {
 
 bool PlusPlayer::SetLooping(bool is_looping) {
   LOG_ERROR("[PlusPlayer] Not support to set looping.");
-  return false;
+  return true;
 }
 
 bool PlusPlayer::SetVolume(double volume) {


### PR DESCRIPTION
Plusplayer doesn't support setLoop method, so it will show a error message when calling setLoop method.
Now plsuplayer return true directly and add a instructions in the README.md
