### PR TITLE
[ci] Modify tizen package installation

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,7 +36,7 @@ jobs:
           $HOME/tizen-studio/package-manager/package-manager-cli.bin install \
             NativeToolchain-Gcc-9.2 \
             IOT-Headed-6.0-NativeAppDevelopment-CLI \
-            IOT-Headed-6.5-NativeAppDevelopment-CLI
+            MOBILE-6.5-NativeAppDevelopment-CLI
       - name: Create a Tizen certificate profile
         if: ${{ env.HAS_CHANGED_PACKAGES == 'true' }}
         run: |


### PR DESCRIPTION
tizen_rpc_port requires tizen 6.5, and TV emulator uses Mobile 6.5 rootstrap.
Therefore, MOBILE package, not IOT-Headed, is required.

Part of the fixes missing in https://github.com/flutter-tizen/plugins/pull/686.
