### PR TITLE
[package_info_plus] upgrade package info plus dependencies

### DIFF
--- a/packages/package_info_plus/CHANGELOG.md
+++ b/packages/package_info_plus/CHANGELOG.md
@@ -1,3 +1,7 @@
+## NEXT
+
+* Update minimum Flutter and Dart version to 3.13 and 3.1.
+  
 ## 1.0.4
 
 * Update package_info_plus to 8.0.0.

--- a/packages/package_info_plus/CHANGELOG.md
+++ b/packages/package_info_plus/CHANGELOG.md
@@ -1,6 +1,7 @@
-## NEXT
+## 1.0.4
 
-* Update minimum Flutter and Dart version to 3.13 and 3.1.
+* Update package_info_plus to 8.0.0.
+* Update package_info_plus_platform_interface to 3.0.0.
 
 ## 1.0.3
 

--- a/packages/package_info_plus/CHANGELOG.md
+++ b/packages/package_info_plus/CHANGELOG.md
@@ -4,6 +4,7 @@
   
 ## 1.0.4
 
+* Update minimum Flutter and Dart version to 3.13 and 3.1.
 * Update package_info_plus to 8.0.0.
 * Update package_info_plus_platform_interface to 3.0.0.
 

--- a/packages/package_info_plus/CHANGELOG.md
+++ b/packages/package_info_plus/CHANGELOG.md
@@ -1,7 +1,3 @@
-## NEXT
-
-* Update minimum Flutter and Dart version to 3.13 and 3.1.
-  
 ## 1.0.4
 
 * Update minimum Flutter and Dart version to 3.13 and 3.1.

--- a/packages/package_info_plus/README.md
+++ b/packages/package_info_plus/README.md
@@ -10,8 +10,8 @@ This package is not an _endorsed_ implementation of `package_info_plus`. Therefo
 
 ```yaml
 dependencies:
-  package_info_plus: ^4.0.1
-  package_info_plus_tizen: ^1.0.3
+  package_info_plus: ^8.0.0
+  package_info_plus_tizen: ^1.0.4
 ```
 
 Then you can import `package_info_plus` in your Dart code.

--- a/packages/package_info_plus/example/pubspec.yaml
+++ b/packages/package_info_plus/example/pubspec.yaml
@@ -10,7 +10,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  package_info_plus: ^4.0.1
+  package_info_plus: ^8.0.0
   package_info_plus_tizen:
     path: ../
 

--- a/packages/package_info_plus/pubspec.yaml
+++ b/packages/package_info_plus/pubspec.yaml
@@ -2,7 +2,7 @@ name: package_info_plus_tizen
 description: Tizen implementation of the package_info_plus plugin.
 homepage: https://github.com/flutter-tizen/plugins
 repository: https://github.com/flutter-tizen/plugins/tree/master/packages/package_info_plus
-version: 1.0.3
+version: 1.0.4
 
 environment:
   sdk: ">=3.1.0 <4.0.0"
@@ -18,7 +18,7 @@ flutter:
 dependencies:
   flutter:
     sdk: flutter
-  package_info_plus_platform_interface: ^2.0.1
+  package_info_plus_platform_interface: ^3.0.0
 
 dev_dependencies:
   flutter_lints: ^2.0.1


### PR DESCRIPTION
What I did:

- upgrade package_info_plus_platform_interface to 3.0.0
- upgrade package_info_plus to 8.0.0
- update CHANGELOG (min version already 3.13 and 3.1)
- update README
- integration test passed