### PR TITLE
[webview_flutter_lwe] Supports multiple JavaScriptChannel method call

### DIFF
--- a/packages/webview_flutter_lwe/CHANGELOG.md
+++ b/packages/webview_flutter_lwe/CHANGELOG.md
@@ -1,7 +1,8 @@
-## NEXT
+## 0.3.1
 
 * Fix new lint warnings.
 * Update minimum Flutter and Dart version to 3.13 and 3.1.
+* Supports multiple JavaScriptChannel method call.
 
 ## 0.3.0
 

--- a/packages/webview_flutter_lwe/README.md
+++ b/packages/webview_flutter_lwe/README.md
@@ -21,7 +21,7 @@ This package is not an _endorsed_ implementation of `webview_flutter`. Therefore
 ```yaml
 dependencies:
   webview_flutter: ^4.4.2
-  webview_flutter_lwe: ^0.3.0
+  webview_flutter_lwe: ^0.3.1
 ```
 
 ## Example

--- a/packages/webview_flutter_lwe/lib/src/lwe_webview.dart
+++ b/packages/webview_flutter_lwe/lib/src/lwe_webview.dart
@@ -48,7 +48,13 @@ class LweWebView {
 
   Future<T?> _invokeChannelMethod<T>(String method, [dynamic arguments]) async {
     if (!_isCreated) {
-      _pendingMethodCalls[method] = arguments;
+      if (method == 'addJavaScriptChannel' ||
+          method == 'runJavaScript' ||
+          method == 'runJavaScriptReturningResult') {
+        _pendingMethodCalls['${method}_$arguments'] = arguments;
+      } else {
+        _pendingMethodCalls[method] = arguments;
+      }
       return null;
     }
 
@@ -73,7 +79,17 @@ class LweWebView {
     }
 
     _pendingMethodCalls.forEach((String method, dynamic arguments) {
-      _lweWebViewChannel.invokeMethod<void>(method, arguments);
+      if (method.contains('addJavaScriptChannel_')) {
+        _lweWebViewChannel.invokeMethod<void>(
+            'addJavaScriptChannel', arguments);
+      } else if (method.contains('runJavaScript_')) {
+        _lweWebViewChannel.invokeMethod<void>('runJavaScript', arguments);
+      } else if (method.contains('runJavaScriptReturningResult_')) {
+        _lweWebViewChannel.invokeMethod<void>(
+            'runJavaScriptReturningResult', arguments);
+      } else {
+        _lweWebViewChannel.invokeMethod<void>(method, arguments);
+      }
     });
     _pendingMethodCalls.clear();
   }

--- a/packages/webview_flutter_lwe/lib/src/lwe_webview.dart
+++ b/packages/webview_flutter_lwe/lib/src/lwe_webview.dart
@@ -51,7 +51,14 @@ class LweWebView {
       if (method == 'addJavaScriptChannel' ||
           method == 'runJavaScript' ||
           method == 'runJavaScriptReturningResult') {
-        _pendingMethodCalls['${method}_$arguments'] = arguments;
+        if (_pendingMethodCalls[method] == null) {
+          _pendingMethodCalls[method] = <String>[];
+        }
+        final List<String> argumentsList =
+            _pendingMethodCalls[method] as List<String>;
+        if (!argumentsList.contains('$arguments')) {
+          argumentsList.add('$arguments');
+        }
       } else {
         _pendingMethodCalls[method] = arguments;
       }
@@ -79,14 +86,18 @@ class LweWebView {
     }
 
     _pendingMethodCalls.forEach((String method, dynamic arguments) {
-      if (method.contains('addJavaScriptChannel_')) {
-        _lweWebViewChannel.invokeMethod<void>(
-            'addJavaScriptChannel', arguments);
-      } else if (method.contains('runJavaScript_')) {
-        _lweWebViewChannel.invokeMethod<void>('runJavaScript', arguments);
-      } else if (method.contains('runJavaScriptReturningResult_')) {
-        _lweWebViewChannel.invokeMethod<void>(
-            'runJavaScriptReturningResult', arguments);
+      if (method == 'addJavaScriptChannel' ||
+          method == 'runJavaScript' ||
+          method == 'runJavaScriptReturningResult') {
+        if (_pendingMethodCalls[method] != null) {
+          final List<String> argumentsList =
+              _pendingMethodCalls[method] as List<String>;
+          for (final String javaScriptMethodArguments in argumentsList) {
+            _lweWebViewChannel.invokeMethod<void>(
+                method, javaScriptMethodArguments);
+          }
+          argumentsList.clear();
+        }
       } else {
         _lweWebViewChannel.invokeMethod<void>(method, arguments);
       }

--- a/packages/webview_flutter_lwe/pubspec.yaml
+++ b/packages/webview_flutter_lwe/pubspec.yaml
@@ -2,7 +2,7 @@ name: webview_flutter_lwe
 description: Tizen implementation of the webview_flutter plugin backed by Lightweight Web Engine.
 homepage: https://github.com/flutter-tizen/plugins
 repository: https://github.com/flutter-tizen/plugins/tree/master/packages/webview_flutter_lwe
-version: 0.3.0
+version: 0.3.1
 
 environment:
   sdk: ">=3.1.0 <4.0.0"


### PR DESCRIPTION
Previously, javascript channel methods that are called before the webview is created are stored in the pending list.(based on name) Because of that, there was a problem with channels being missing when adding multiple channels.

When the javascript channel method is called,
it is stored differently depending on the name to prevent it from being missed.

```dart
controller
..addJavaScriptChannel(
        'method1',...)
..addJavaScriptChannel(
        'method2',...);
```