### PR TITLE
[webview_flutter_tizen] Prevent duplicate Dispose() calls

### DIFF
--- a/packages/webview_flutter/CHANGELOG.md
+++ b/packages/webview_flutter/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.9.3
+
+* Prevent duplicate Dispose() calls.
+
 ## 0.9.2
 
 * Supports multiple JavaScriptChannel method call.

--- a/packages/webview_flutter/README.md
+++ b/packages/webview_flutter/README.md
@@ -23,7 +23,7 @@ This package is not an _endorsed_ implementation of `webview_flutter`. Therefore
 ```yaml
 dependencies:
   webview_flutter: ^4.4.2
-  webview_flutter_tizen: ^0.9.2
+  webview_flutter_tizen: ^0.9.3
 ```
 
 ## Example

--- a/packages/webview_flutter/tizen/src/webview.cc
+++ b/packages/webview_flutter/tizen/src/webview.cc
@@ -171,34 +171,36 @@ std::string WebView::GetNavigationDelegateChannelName() {
 }
 
 void WebView::Dispose() {
-  if (!disposed_) {
-    texture_registrar_->UnregisterTexture(GetTextureId(), nullptr);
-
-    if (webview_instance_) {
-      evas_object_smart_callback_del(webview_instance_,
-                                     "offscreen,frame,rendered",
-                                     &WebView::OnFrameRendered);
-      evas_object_smart_callback_del(webview_instance_, "load,started",
-                                     &WebView::OnLoadStarted);
-      evas_object_smart_callback_del(webview_instance_, "load,finished",
-                                     &WebView::OnLoadFinished);
-      evas_object_smart_callback_del(webview_instance_, "load,progress",
-                                     &WebView::OnProgress);
-      evas_object_smart_callback_del(webview_instance_, "load,error",
-                                     &WebView::OnLoadError);
-      evas_object_smart_callback_del(webview_instance_, "console,message",
-                                     &WebView::OnConsoleMessage);
-      evas_object_smart_callback_del(webview_instance_,
-                                     "policy,navigation,decide",
-                                     &WebView::OnNavigationPolicy);
-      evas_object_smart_callback_del(webview_instance_, "url,changed",
-                                     &WebView::OnUrlChange);
-      evas_object_del(webview_instance_);
-    }
-
-    ewk_shutdown();
-    disposed_ = true;
+  if (disposed_) {
+    return;
   }
+
+  texture_registrar_->UnregisterTexture(GetTextureId(), nullptr);
+
+  if (webview_instance_) {
+    evas_object_smart_callback_del(webview_instance_,
+                                   "offscreen,frame,rendered",
+                                   &WebView::OnFrameRendered);
+    evas_object_smart_callback_del(webview_instance_, "load,started",
+                                   &WebView::OnLoadStarted);
+    evas_object_smart_callback_del(webview_instance_, "load,finished",
+                                   &WebView::OnLoadFinished);
+    evas_object_smart_callback_del(webview_instance_, "load,progress",
+                                   &WebView::OnProgress);
+    evas_object_smart_callback_del(webview_instance_, "load,error",
+                                   &WebView::OnLoadError);
+    evas_object_smart_callback_del(webview_instance_, "console,message",
+                                   &WebView::OnConsoleMessage);
+    evas_object_smart_callback_del(webview_instance_,
+                                   "policy,navigation,decide",
+                                   &WebView::OnNavigationPolicy);
+    evas_object_smart_callback_del(webview_instance_, "url,changed",
+                                   &WebView::OnUrlChange);
+    evas_object_del(webview_instance_);
+  }
+
+  ewk_shutdown();
+  disposed_ = true;
 }
 
 void WebView::Offset(double left, double top) {

--- a/packages/webview_flutter/tizen/src/webview.cc
+++ b/packages/webview_flutter/tizen/src/webview.cc
@@ -372,6 +372,7 @@ void WebView::HandleWebViewMethodCall(const FlMethodCall& method_call,
       engine_policy_ = *engine_policy;
     }
     result->Success();
+    return;
   }
 
   if (!webview_instance_) {

--- a/packages/webview_flutter/tizen/src/webview.cc
+++ b/packages/webview_flutter/tizen/src/webview.cc
@@ -171,31 +171,34 @@ std::string WebView::GetNavigationDelegateChannelName() {
 }
 
 void WebView::Dispose() {
-  texture_registrar_->UnregisterTexture(GetTextureId(), nullptr);
+  if (!disposed_) {
+    texture_registrar_->UnregisterTexture(GetTextureId(), nullptr);
 
-  if (webview_instance_) {
-    evas_object_smart_callback_del(webview_instance_,
-                                   "offscreen,frame,rendered",
-                                   &WebView::OnFrameRendered);
-    evas_object_smart_callback_del(webview_instance_, "load,started",
-                                   &WebView::OnLoadStarted);
-    evas_object_smart_callback_del(webview_instance_, "load,finished",
-                                   &WebView::OnLoadFinished);
-    evas_object_smart_callback_del(webview_instance_, "load,progress",
-                                   &WebView::OnProgress);
-    evas_object_smart_callback_del(webview_instance_, "load,error",
-                                   &WebView::OnLoadError);
-    evas_object_smart_callback_del(webview_instance_, "console,message",
-                                   &WebView::OnConsoleMessage);
-    evas_object_smart_callback_del(webview_instance_,
-                                   "policy,navigation,decide",
-                                   &WebView::OnNavigationPolicy);
-    evas_object_smart_callback_del(webview_instance_, "url,changed",
-                                   &WebView::OnUrlChange);
-    evas_object_del(webview_instance_);
+    if (webview_instance_) {
+      evas_object_smart_callback_del(webview_instance_,
+                                     "offscreen,frame,rendered",
+                                     &WebView::OnFrameRendered);
+      evas_object_smart_callback_del(webview_instance_, "load,started",
+                                     &WebView::OnLoadStarted);
+      evas_object_smart_callback_del(webview_instance_, "load,finished",
+                                     &WebView::OnLoadFinished);
+      evas_object_smart_callback_del(webview_instance_, "load,progress",
+                                     &WebView::OnProgress);
+      evas_object_smart_callback_del(webview_instance_, "load,error",
+                                     &WebView::OnLoadError);
+      evas_object_smart_callback_del(webview_instance_, "console,message",
+                                     &WebView::OnConsoleMessage);
+      evas_object_smart_callback_del(webview_instance_,
+                                     "policy,navigation,decide",
+                                     &WebView::OnNavigationPolicy);
+      evas_object_smart_callback_del(webview_instance_, "url,changed",
+                                     &WebView::OnUrlChange);
+      evas_object_del(webview_instance_);
+    }
+
+    ewk_shutdown();
+    disposed_ = true;
   }
-
-  ewk_shutdown();
 }
 
 void WebView::Offset(double left, double top) {

--- a/packages/webview_flutter/tizen/src/webview.h
+++ b/packages/webview_flutter/tizen/src/webview.h
@@ -100,6 +100,7 @@ class WebView : public PlatformView {
   std::unique_ptr<flutter::TextureVariant> texture_variant_;
   std::mutex mutex_;
   std::unique_ptr<BufferPool> tbm_pool_;
+  bool disposed_ = false;
 };
 
 #endif  // FLUTTER_PLUGIN_WEBVIEW_H_


### PR DESCRIPTION
Dispose() is called redundantly on destructor and PlatformView.
Modify it to only operate once.

+) Minor fix - Do `setEnginePolicy` method call and returns immediately. It prevents duplicate calls to `result`.