### PR TITLE
[shared_preferences] Update tizen_interop to 0.3.0

### DIFF
--- a/packages/shared_preferences/CHANGELOG.md
+++ b/packages/shared_preferences/CHANGELOG.md
@@ -1,6 +1,8 @@
-## NEXT
+## 2.2.1
 
 * Update minimum Flutter and Dart version to 3.13 and 3.1.
+* Fix a type cast error when reading a string list.
+* Update tizen_interop to 0.3.0.
 
 ## 2.2.0
 

--- a/packages/shared_preferences/README.md
+++ b/packages/shared_preferences/README.md
@@ -11,7 +11,7 @@ This package is not an _endorsed_ implementation of `shared_preferences`. Theref
 ```yaml
 dependencies:
   shared_preferences: ^2.2.0
-  shared_preferences_tizen: ^2.2.0
+  shared_preferences_tizen: ^2.2.1
 ```
 
 Then you can import `shared_preferences` in your Dart code:

--- a/packages/shared_preferences/lib/shared_preferences_tizen.dart
+++ b/packages/shared_preferences/lib/shared_preferences_tizen.dart
@@ -8,7 +8,7 @@ import 'dart:ffi';
 import 'package:ffi/ffi.dart';
 import 'package:shared_preferences_platform_interface/shared_preferences_platform_interface.dart';
 import 'package:shared_preferences_platform_interface/types.dart';
-import 'package:tizen_interop/4.0/tizen.dart';
+import 'package:tizen_interop/6.0/tizen.dart';
 
 /// The Tizen implementation of [SharedPreferencesStorePlatform].
 class SharedPreferencesPlugin extends SharedPreferencesStorePlatform {

--- a/packages/shared_preferences/pubspec.yaml
+++ b/packages/shared_preferences/pubspec.yaml
@@ -2,7 +2,7 @@ name: shared_preferences_tizen
 description: Tizen implementation of the shared_preferences plugin.
 homepage: https://github.com/flutter-tizen/plugins
 repository: https://github.com/flutter-tizen/plugins/tree/master/packages/shared_preferences
-version: 2.2.0
+version: 2.2.1
 
 environment:
   sdk: ">=3.1.0 <4.0.0"
@@ -19,4 +19,4 @@ dependencies:
   flutter:
     sdk: flutter
   shared_preferences_platform_interface: ^2.3.0
-  tizen_interop: ^0.2.0
+  tizen_interop: ^0.3.0


### PR DESCRIPTION
Creating a release for https://github.com/flutter-tizen/plugins/pull/700. Also update the outdated tizen_interop version.