### PR TITLE
[google_maps_flutter] Support longpress event

### DIFF
--- a/packages/google_maps_flutter/CHANGELOG.md
+++ b/packages/google_maps_flutter/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.1.8
+
+* Support longpress event.
+
 ## 0.1.7
 
 * Update webview_flutter_lwe to 0.3.2.

--- a/packages/google_maps_flutter/README.md
+++ b/packages/google_maps_flutter/README.md
@@ -21,7 +21,7 @@ This package is not an _endorsed_ implementation of `google_maps_flutter`. There
 ```yaml
 dependencies:
   google_maps_flutter: ^2.7.0
-  google_maps_flutter_tizen: ^0.1.7
+  google_maps_flutter_tizen: ^0.1.8
 ```
 
 For detailed usage, see https://pub.dev/packages/google_maps_flutter#sample-usage.

--- a/packages/google_maps_flutter/pubspec.yaml
+++ b/packages/google_maps_flutter/pubspec.yaml
@@ -2,7 +2,7 @@ name: google_maps_flutter_tizen
 description: Tizen implementation of the google_maps_flutter plugin.
 homepage: https://github.com/flutter-tizen/plugins
 repository: https://github.com/flutter-tizen/plugins/tree/master/packages/google_maps_flutter
-version: 0.1.7
+version: 0.1.8
 
 environment:
   sdk: ">=3.1.0 <4.0.0"


### PR DESCRIPTION
GoogleMaps interface has a longpress event, but Google Javascript API does not provide a longpress event.
The existing code implemented longpress using the rightclick event,
but the rightclick event was deprecated when the Javascript API of Google Maps was updated. (https://developers.google.com/maps/documentation/javascript/reference/map#Map.rightclick)
Therefore, Implement longpress event using mousedown/up events.