### PR TITLE
[flutter_secure_storage] Fix Crashes on Encrypting/Decrypting Empty Strings

### DIFF
--- a/packages/flutter_secure_storage/CHANGELOG.md
+++ b/packages/flutter_secure_storage/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## NEXT
 
+* Fixed an issue causing crashes when encrypting or decrypting empty strings by adding appropriate checks and handling in `Encrypt` and `Decrypt` methods.
 * Fix new lint warnings.
 * Update minimum Flutter and Dart version to 3.13 and 3.1.
 

--- a/packages/flutter_secure_storage/tizen/src/secure_storage.cc
+++ b/packages/flutter_secure_storage/tizen/src/secure_storage.cc
@@ -128,6 +128,7 @@ std::string SecureStorage::Decrypt(const std::vector<uint8_t> &value) {
   if (value.size() <= kInitializationVectorSize) {
     return "";
   }
+  
   std::vector<uint8_t> iv(value.begin(),
                           value.begin() + kInitializationVectorSize);
   ckmc_raw_buffer_s iv_buffer;

--- a/packages/flutter_secure_storage/tizen/src/secure_storage.cc
+++ b/packages/flutter_secure_storage/tizen/src/secure_storage.cc
@@ -92,7 +92,7 @@ void SecureStorage::CreateAesKeyOnce() {
 }
 
 std::vector<uint8_t> SecureStorage::Encrypt(const std::string &value) {
-  if (value.empty()) {       
+  if (value.empty()) {
     return std::vector<uint8_t>{0x00};
   }
 
@@ -128,7 +128,7 @@ std::string SecureStorage::Decrypt(const std::vector<uint8_t> &value) {
   if (value.size() <= kInitializationVectorSize) {
     return "";
   }
-  
+
   std::vector<uint8_t> iv(value.begin(),
                           value.begin() + kInitializationVectorSize);
   ckmc_raw_buffer_s iv_buffer;

--- a/packages/flutter_secure_storage/tizen/src/secure_storage.cc
+++ b/packages/flutter_secure_storage/tizen/src/secure_storage.cc
@@ -92,6 +92,10 @@ void SecureStorage::CreateAesKeyOnce() {
 }
 
 std::vector<uint8_t> SecureStorage::Encrypt(const std::string &value) {
+  if (value.empty()) {       
+    return std::vector<uint8_t>{0x00};
+  }
+
   ckmc_raw_buffer_s plain_buffer;
   plain_buffer.data =
       const_cast<uint8_t *>(reinterpret_cast<const uint8_t *>(value.c_str()));
@@ -121,6 +125,9 @@ std::vector<uint8_t> SecureStorage::Encrypt(const std::string &value) {
 }
 
 std::string SecureStorage::Decrypt(const std::vector<uint8_t> &value) {
+  if (value.size() <= kInitializationVectorSize) {
+    return "";
+  }
   std::vector<uint8_t> iv(value.begin(),
                           value.begin() + kInitializationVectorSize);
   ckmc_raw_buffer_s iv_buffer;


### PR DESCRIPTION
### Summary

This PR addresses an issue that caused the application to crash when attempting to encrypt or decrypt an empty string.

### Changes

- **Encrypt Method:**
  - Added a check to return a vector containing a single null byte when the input string is empty. This ensures that the function handles empty inputs without errors.

- **Decrypt Method:**
  - Added a check to return an empty string when the input vector size is less than or equal to the initialization vector size. This prevents errors during decryption when the input is insufficient.

### Testing

- Verified that attempting to encrypt or decrypt an empty string no longer causes the application to crash.
- To test with the example app, edit the value in the text field, remove all content to make it an empty string, and then save it. The application should handle this gracefully without crashing.

### Notes

These changes improve the robustness of the encryption and decryption functions by ensuring they handle edge cases gracefully.
