### PR TITLE
[permission_handler] Fix analyze issue

### DIFF
--- a/packages/permission_handler/CHANGELOG.md
+++ b/packages/permission_handler/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## NEXT
 
 * Update minimum Flutter and Dart version to 3.13 and 3.1.
+* Fix analyze issue.
 
 ## 1.3.0
 

--- a/packages/permission_handler/example/lib/main.dart
+++ b/packages/permission_handler/example/lib/main.dart
@@ -17,10 +17,13 @@ final MaterialColor themeMaterialColor =
 
 /// A Flutter application demonstrating the functionality of this plugin
 class PermissionHandlerWidget extends StatefulWidget {
+  /// Default Constructor
+  const PermissionHandlerWidget({super.key});
+
   /// Create a page containing the functionality of this plugin
   static ExamplePage createPage() {
     return ExamplePage(
-        Icons.location_on, (context) => PermissionHandlerWidget());
+        Icons.location_on, (context) => const PermissionHandlerWidget());
   }
 
   @override
@@ -69,23 +72,24 @@ class _PermissionHandlerWidgetState extends State<PermissionHandlerWidget> {
 /// Permission widget containing information about the passed [Permission]
 class PermissionWidget extends StatefulWidget {
   /// Constructs a [PermissionWidget] for the supplied [Permission]
-  const PermissionWidget(this._permission);
+  const PermissionWidget(this._permission, {super.key});
 
   final Permission _permission;
 
   @override
-  _PermissionState createState() => _PermissionState(_permission);
+  _PermissionState createState() {
+    return _PermissionState();
+  }
 }
 
 class _PermissionState extends State<PermissionWidget> {
-  _PermissionState(this._permission);
-
-  final Permission _permission;
+  late Permission _permission;
   PermissionStatus _permissionStatus = PermissionStatus.denied;
 
   @override
   void initState() {
     super.initState();
+    _permission = widget._permission;
 
     _listenForPermissionStatus();
   }
@@ -147,9 +151,9 @@ class _PermissionState extends State<PermissionWidget> {
     final status = await permission.request();
 
     setState(() {
-      print(status);
+      debugPrint(status.toString());
       _permissionStatus = status;
-      print(_permissionStatus);
+      debugPrint(_permissionStatus.toString());
     });
   }
 }


### PR DESCRIPTION
Resolve following issues:
```
info • example/lib/main.dart:19:7 • Constructors for public widgets should have a named 'key' parameter. Try adding a named parameter to the constructor. • use_key_in_widget_constructors
info • example/lib/main.dart:72:9 • Constructors for public widgets should have a named 'key' parameter. Try adding a named parameter to the constructor. • use_key_in_widget_constructors
info • example/lib/main.dart:77:37 • Don't put any logic in 'createState'. Try moving the logic out of 'createState'. • no_logic_in_create_state
info • example/lib/main.dart:150:7 • Don't invoke 'print' in production code. Try using a logging framework. • avoid_print
info • example/lib/main.dart:152:7 • Don't invoke 'print' in production code. Try using a logging framework. • avoid_print
```