### PR TITLE
[flutter_webrtc] Fix analyze issue

### DIFF
--- a/packages/flutter_webrtc/CHANGELOG.md
+++ b/packages/flutter_webrtc/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## NEXT
 
 * Update minimum Flutter and Dart version to 3.13 and 3.1.
+* Fix analyze issue.
 
 ## 0.1.3
 

--- a/packages/flutter_webrtc/example/flutter_webrtc_demo/lib/src/utils/screen_select_dialog.dart
+++ b/packages/flutter_webrtc/example/flutter_webrtc_demo/lib/src/utils/screen_select_dialog.dart
@@ -276,7 +276,7 @@ class ScreenSelectDialog extends Dialog {
             ),
             Container(
               width: double.infinity,
-              child: ButtonBar(
+              child: OverflowBar(
                 children: <Widget>[
                   MaterialButton(
                     child: Text(

--- a/packages/flutter_webrtc/example/flutter_webrtc_demo/lib/src/widgets/screen_select_dialog.dart
+++ b/packages/flutter_webrtc/example/flutter_webrtc_demo/lib/src/widgets/screen_select_dialog.dart
@@ -276,7 +276,7 @@ class ScreenSelectDialog extends Dialog {
             ),
             Container(
               width: double.infinity,
-              child: ButtonBar(
+              child: OverflowBar(
                 children: <Widget>[
                   MaterialButton(
                     child: Text(

--- a/packages/flutter_webrtc/example/flutter_webrtc_example/lib/main.dart
+++ b/packages/flutter_webrtc/example/flutter_webrtc_example/lib/main.dart
@@ -28,7 +28,7 @@ Future<bool> startForegroundService() async {
   final androidConfig = FlutterBackgroundAndroidConfig(
     notificationTitle: 'Title of the notification',
     notificationText: 'Text of the notification',
-    notificationImportance: AndroidNotificationImportance.Default,
+    notificationImportance: AndroidNotificationImportance.normal,
     notificationIcon: AndroidResource(
         name: 'background_icon',
         defType: 'drawable'), // Default is ic_launcher from folder mipmap

--- a/packages/flutter_webrtc/example/flutter_webrtc_example/lib/src/get_display_media_sample.dart
+++ b/packages/flutter_webrtc/example/flutter_webrtc_example/lib/src/get_display_media_sample.dart
@@ -61,7 +61,7 @@ class _GetDisplayMediaSampleState extends State<GetDisplayMediaSample> {
               const androidConfig = FlutterBackgroundAndroidConfig(
                 notificationTitle: 'Screen Sharing',
                 notificationText: 'LiveKit Example is sharing the screen.',
-                notificationImportance: AndroidNotificationImportance.Default,
+                notificationImportance: AndroidNotificationImportance.normal,
                 notificationIcon: AndroidResource(
                     name: 'livekit_ic_launcher', defType: 'mipmap'),
               );

--- a/packages/flutter_webrtc/example/flutter_webrtc_example/lib/src/loopback_sample_unified_tracks.dart
+++ b/packages/flutter_webrtc/example/flutter_webrtc_example/lib/src/loopback_sample_unified_tracks.dart
@@ -844,7 +844,7 @@ class _MyAppState extends State<LoopBackSampleUnifiedTracks> {
               ),
               Align(
                 alignment: Alignment.bottomCenter,
-                child: ButtonBar(
+                child: OverflowBar(
                   children: [
                     FloatingActionButton(
                         heroTag: null,

--- a/packages/flutter_webrtc/example/flutter_webrtc_example/lib/src/widgets/screen_select_dialog.dart
+++ b/packages/flutter_webrtc/example/flutter_webrtc_example/lib/src/widgets/screen_select_dialog.dart
@@ -276,7 +276,7 @@ class ScreenSelectDialog extends Dialog {
             ),
             Container(
               width: double.infinity,
-              child: ButtonBar(
+              child: OverflowBar(
                 children: <Widget>[
                   MaterialButton(
                     child: Text(


### PR DESCRIPTION
Resolve following issues:
```
error • example/flutter_webrtc_example/lib/main.dart:31:59 • There's no constant named 'Default' in 'AndroidNotificationImportance'. Try correcting the name to the name of an existing constant, or
        defining a constant named 'Default'. • undefined_enum_constant
error • example/flutter_webrtc_example/lib/src/get_display_media_sample.dart:64:41 • Invalid constant value. • invalid_constant error • example/flutter_webrtc_example/lib/src/get_display_media_sample.dart:64:71 • There's no constant named 'Default' in 'AndroidNotificationImportance'. Try correcting the name to the name of an
        existing constant, or defining a constant named 'Default'. • undefined_enum_constant
 info • example/flutter_webrtc_demo/lib/src/utils/screen_select_dialog.dart:279:22 • 'ButtonBar' is deprecated and shouldn't be used. Use OverflowBar instead. This feature was deprecated after
        v3.21.0-10.0.pre. Try replacing the use of the deprecated member with the replacement. • deprecated_member_use
 info • example/flutter_webrtc_demo/lib/src/utils/screen_select_dialog.dart:279:22 • 'ButtonBar.new' is deprecated and shouldn't be used. Use OverflowBar instead. This feature was deprecated after
        v3.21.0-10.0.pre. Try replacing the use of the deprecated member with the replacement. • deprecated_member_use
 info • example/flutter_webrtc_demo/lib/src/widgets/screen_select_dialog.dart:279:22 • 'ButtonBar' is deprecated and shouldn't be used. Use OverflowBar instead. This feature was deprecated after
        v3.21.0-10.0.pre. Try replacing the use of the deprecated member with the replacement. • deprecated_member_use
 info • example/flutter_webrtc_demo/lib/src/widgets/screen_select_dialog.dart:279:22 • 'ButtonBar.new' is deprecated and shouldn't be used. Use OverflowBar instead. This feature was deprecated after
        v3.21.0-10.0.pre. Try replacing the use of the deprecated member with the replacement. • deprecated_member_use
 info • example/flutter_webrtc_example/lib/src/loopback_sample_unified_tracks.dart:847:24 • 'ButtonBar' is deprecated and shouldn't be used. Use OverflowBar instead. This feature was deprecated after
        v3.21.0-10.0.pre. Try replacing the use of the deprecated member with the replacement. • deprecated_member_use
 info • example/flutter_webrtc_example/lib/src/loopback_sample_unified_tracks.dart:847:24 • 'ButtonBar.new' is deprecated and shouldn't be used. Use OverflowBar instead. This feature was deprecated
        after v3.21.0-10.0.pre. Try replacing the use of the deprecated member with the replacement. • deprecated_member_use
 info • example/flutter_webrtc_example/lib/src/widgets/screen_select_dialog.dart:279:22 • 'ButtonBar' is deprecated and shouldn't be used. Use OverflowBar instead. This feature was deprecated after
        v3.21.0-10.0.pre. Try replacing the use of the deprecated member with the replacement. • deprecated_member_use
 info • example/flutter_webrtc_example/lib/src/widgets/screen_select_dialog.dart:279:22 • 'ButtonBar.new' is deprecated and shouldn't be used. Use OverflowBar instead. This feature was deprecated after
        v3.21.0-10.0.pre. Try replacing the use of the deprecated member with the replacement. • deprecated_member_use
```