### PR TITLE
[video_player_avplay] Add setBufferConfig interface

### DIFF
--- a/packages/video_player_avplay/CHANGELOG.md
+++ b/packages/video_player_avplay/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.4.7
+
+* Add SetBufferConfig interface.
+
 ## 0.4.6
 
 * Upgrade plusplayer

--- a/packages/video_player_avplay/README.md
+++ b/packages/video_player_avplay/README.md
@@ -12,7 +12,7 @@ To use this package, add `video_player_avplay` as a dependency in your `pubspec.
 
 ```yaml
 dependencies:
-  video_player_avplay: ^0.4.6
+  video_player_avplay: ^0.4.7
 ```
 
 Then you can import `video_player_avplay` in your Dart code:

--- a/packages/video_player_avplay/lib/src/messages.g.dart
+++ b/packages/video_player_avplay/lib/src/messages.g.dart
@@ -416,51 +416,85 @@ class StreamingPropertyTypeMessage {
   }
 }
 
+class BufferConfigMessage {
+  BufferConfigMessage({
+    required this.playerId,
+    required this.bufferConfigType,
+    required this.bufferConfigValue,
+  });
+
+  int playerId;
+
+  String bufferConfigType;
+
+  int bufferConfigValue;
+
+  Object encode() {
+    return <Object?>[
+      playerId,
+      bufferConfigType,
+      bufferConfigValue,
+    ];
+  }
+
+  static BufferConfigMessage decode(Object result) {
+    result as List<Object?>;
+    return BufferConfigMessage(
+      playerId: result[0]! as int,
+      bufferConfigType: result[1]! as String,
+      bufferConfigValue: result[2]! as int,
+    );
+  }
+}
+
 class _VideoPlayerAvplayApiCodec extends StandardMessageCodec {
   const _VideoPlayerAvplayApiCodec();
   @override
   void writeValue(WriteBuffer buffer, Object? value) {
-    if (value is CreateMessage) {
+    if (value is BufferConfigMessage) {
       buffer.putUint8(128);
       writeValue(buffer, value.encode());
-    } else if (value is DurationMessage) {
+    } else if (value is CreateMessage) {
       buffer.putUint8(129);
       writeValue(buffer, value.encode());
-    } else if (value is GeometryMessage) {
+    } else if (value is DurationMessage) {
       buffer.putUint8(130);
       writeValue(buffer, value.encode());
-    } else if (value is LoopingMessage) {
+    } else if (value is GeometryMessage) {
       buffer.putUint8(131);
       writeValue(buffer, value.encode());
-    } else if (value is MixWithOthersMessage) {
+    } else if (value is LoopingMessage) {
       buffer.putUint8(132);
       writeValue(buffer, value.encode());
-    } else if (value is PlaybackSpeedMessage) {
+    } else if (value is MixWithOthersMessage) {
       buffer.putUint8(133);
       writeValue(buffer, value.encode());
-    } else if (value is PlayerMessage) {
+    } else if (value is PlaybackSpeedMessage) {
       buffer.putUint8(134);
       writeValue(buffer, value.encode());
-    } else if (value is PositionMessage) {
+    } else if (value is PlayerMessage) {
       buffer.putUint8(135);
       writeValue(buffer, value.encode());
-    } else if (value is SelectedTracksMessage) {
+    } else if (value is PositionMessage) {
       buffer.putUint8(136);
       writeValue(buffer, value.encode());
-    } else if (value is StreamingPropertyMessage) {
+    } else if (value is SelectedTracksMessage) {
       buffer.putUint8(137);
       writeValue(buffer, value.encode());
-    } else if (value is StreamingPropertyTypeMessage) {
+    } else if (value is StreamingPropertyMessage) {
       buffer.putUint8(138);
       writeValue(buffer, value.encode());
-    } else if (value is TrackMessage) {
+    } else if (value is StreamingPropertyTypeMessage) {
       buffer.putUint8(139);
       writeValue(buffer, value.encode());
-    } else if (value is TrackTypeMessage) {
+    } else if (value is TrackMessage) {
       buffer.putUint8(140);
       writeValue(buffer, value.encode());
-    } else if (value is VolumeMessage) {
+    } else if (value is TrackTypeMessage) {
       buffer.putUint8(141);
+      writeValue(buffer, value.encode());
+    } else if (value is VolumeMessage) {
+      buffer.putUint8(142);
       writeValue(buffer, value.encode());
     } else {
       super.writeValue(buffer, value);
@@ -471,32 +505,34 @@ class _VideoPlayerAvplayApiCodec extends StandardMessageCodec {
   Object? readValueOfType(int type, ReadBuffer buffer) {
     switch (type) {
       case 128:
-        return CreateMessage.decode(readValue(buffer)!);
+        return BufferConfigMessage.decode(readValue(buffer)!);
       case 129:
-        return DurationMessage.decode(readValue(buffer)!);
+        return CreateMessage.decode(readValue(buffer)!);
       case 130:
-        return GeometryMessage.decode(readValue(buffer)!);
+        return DurationMessage.decode(readValue(buffer)!);
       case 131:
-        return LoopingMessage.decode(readValue(buffer)!);
+        return GeometryMessage.decode(readValue(buffer)!);
       case 132:
-        return MixWithOthersMessage.decode(readValue(buffer)!);
+        return LoopingMessage.decode(readValue(buffer)!);
       case 133:
-        return PlaybackSpeedMessage.decode(readValue(buffer)!);
+        return MixWithOthersMessage.decode(readValue(buffer)!);
       case 134:
-        return PlayerMessage.decode(readValue(buffer)!);
+        return PlaybackSpeedMessage.decode(readValue(buffer)!);
       case 135:
-        return PositionMessage.decode(readValue(buffer)!);
+        return PlayerMessage.decode(readValue(buffer)!);
       case 136:
-        return SelectedTracksMessage.decode(readValue(buffer)!);
+        return PositionMessage.decode(readValue(buffer)!);
       case 137:
-        return StreamingPropertyMessage.decode(readValue(buffer)!);
+        return SelectedTracksMessage.decode(readValue(buffer)!);
       case 138:
-        return StreamingPropertyTypeMessage.decode(readValue(buffer)!);
+        return StreamingPropertyMessage.decode(readValue(buffer)!);
       case 139:
-        return TrackMessage.decode(readValue(buffer)!);
+        return StreamingPropertyTypeMessage.decode(readValue(buffer)!);
       case 140:
-        return TrackTypeMessage.decode(readValue(buffer)!);
+        return TrackMessage.decode(readValue(buffer)!);
       case 141:
+        return TrackTypeMessage.decode(readValue(buffer)!);
+      case 142:
         return VolumeMessage.decode(readValue(buffer)!);
       default:
         return super.readValueOfType(type, buffer);
@@ -965,6 +1001,34 @@ class VideoPlayerAvplayApi {
       );
     } else {
       return (replyList[0] as StreamingPropertyMessage?)!;
+    }
+  }
+
+  Future<bool> setBufferConfig(BufferConfigMessage arg_msg) async {
+    final BasicMessageChannel<Object?> channel = BasicMessageChannel<Object?>(
+        'dev.flutter.pigeon.video_player_avplay.VideoPlayerAvplayApi.setBufferConfig',
+        codec,
+        binaryMessenger: _binaryMessenger);
+    final List<Object?>? replyList =
+        await channel.send(<Object?>[arg_msg]) as List<Object?>?;
+    if (replyList == null) {
+      throw PlatformException(
+        code: 'channel-error',
+        message: 'Unable to establish connection on channel.',
+      );
+    } else if (replyList.length > 1) {
+      throw PlatformException(
+        code: replyList[0]! as String,
+        message: replyList[1] as String?,
+        details: replyList[2],
+      );
+    } else if (replyList[0] == null) {
+      throw PlatformException(
+        code: 'null-error',
+        message: 'Host platform returned null value for non-null return value.',
+      );
+    } else {
+      return (replyList[0] as bool?)!;
     }
   }
 }

--- a/packages/video_player_avplay/lib/src/video_player_tizen.dart
+++ b/packages/video_player_avplay/lib/src/video_player_tizen.dart
@@ -208,6 +208,14 @@ class VideoPlayerTizen extends VideoPlayerPlatform {
   }
 
   @override
+  Future<bool> setBufferConfig(int playerId, BufferConfigType type, int value) {
+    return _api.setBufferConfig(BufferConfigMessage(
+        playerId: playerId,
+        bufferConfigType: _bufferConfigTypeMap[type]!,
+        bufferConfigValue: value));
+  }
+
+  @override
   Stream<VideoEvent> videoEventsFor(int playerId) {
     return _eventChannelFor(playerId)
         .receiveBroadcastStream()
@@ -313,5 +321,18 @@ class VideoPlayerTizen extends VideoPlayerPlatform {
     StreamingPropertyType.setMode4K: 'SET_MODE_4K',
     StreamingPropertyType.userAgent: 'USER_AGENT',
     StreamingPropertyType.useVideoMixer: 'USE_VIDEOMIXER',
+  };
+
+  static const Map<BufferConfigType, String> _bufferConfigTypeMap =
+      <BufferConfigType, String>{
+    BufferConfigType.totalBufferSizeInByte: 'total_buffer_size_in_byte',
+    BufferConfigType.totalBufferSizeInTime: 'total_buffer_size_in_time',
+    BufferConfigType.bufferSizeInByteForPlay: 'buffer_size_in_byte_for_play',
+    BufferConfigType.bufferSizeInSecForPlay: 'buffer_size_in_sec_for_play',
+    BufferConfigType.bufferSizeInByteForResume:
+        'buffer_size_in_byte_for_resume',
+    BufferConfigType.bufferSizeInSecForResume: 'buffer_size_in_sec_for_resume',
+    BufferConfigType.bufferingTimeoutInSecForPlay:
+        'buffering_timeout_in_sec_for_play',
   };
 }

--- a/packages/video_player_avplay/lib/video_player.dart
+++ b/packages/video_player_avplay/lib/video_player.dart
@@ -712,6 +712,17 @@ class VideoPlayerController extends ValueNotifier<VideoPlayerValue> {
     return _videoPlayerPlatform.getStreamingProperty(_playerId, type);
   }
 
+  /// Sets the buffer size for the play and resume scenarios. The time buffer size must be at least 4 seconds.
+  /// For example, if a 10 second buffer size is set, playback can only start or resume after 10 seconds of media has accumulated in the buffer.
+  /// Play scenarios include user-initiated streaming playback and whenever media playback is starting for the first time.
+  /// Resume scenarios include resuming playback after pause or seek operations, or when lack of data causes playback rebuffering.
+  Future<bool> setBufferConfig(BufferConfigType type, int value) async {
+    if (_isDisposedOrNotInitialized) {
+      return false;
+    }
+    return _videoPlayerPlatform.setBufferConfig(_playerId, type, value);
+  }
+
   /// Sets the playback speed of [this].
   ///
   /// [speed] indicates a speed value with different platforms accepting

--- a/packages/video_player_avplay/lib/video_player_platform_interface.dart
+++ b/packages/video_player_avplay/lib/video_player_platform_interface.dart
@@ -139,6 +139,11 @@ abstract class VideoPlayerPlatform extends PlatformInterface {
         'getStreamingProperty() has not been implemented.');
   }
 
+  /// Sets the buffer size for the player.
+  Future<bool> setBufferConfig(int playerId, BufferConfigType type, int value) {
+    throw UnimplementedError('setBufferConfig() has not been implemented.');
+  }
+
   /// Returns a widget displaying the video with a given playerId.
   Widget buildView(int playerId) {
     throw UnimplementedError('buildView() has not been implemented.');
@@ -315,6 +320,30 @@ enum StreamingPropertyType {
 
   /// Property to select the Scaler type, By Default MAIN Scaler selected.
   inAppMultiView,
+}
+
+/// The different types of buffer configurations that can be set on the player.
+enum BufferConfigType {
+  /// Total buffer size in byte.
+  totalBufferSizeInByte,
+
+  /// Total buffer size in time.
+  totalBufferSizeInTime,
+
+  /// Buffer size for play in byte.
+  bufferSizeInByteForPlay,
+
+  /// Buffer size for play in time.
+  bufferSizeInSecForPlay,
+
+  /// Buffer size for resume in byte.
+  bufferSizeInByteForResume,
+
+  /// Buffer size for resume in time.
+  bufferSizeInSecForResume,
+
+  /// Buffering timeout for play in seconds.
+  bufferingTimeoutInSecForPlay,
 }
 
 /// Event emitted from the platform implementation.

--- a/packages/video_player_avplay/pigeons/messages.dart
+++ b/packages/video_player_avplay/pigeons/messages.dart
@@ -101,6 +101,14 @@ class StreamingPropertyTypeMessage {
   String streamingPropertyType;
 }
 
+class BufferConfigMessage {
+  BufferConfigMessage(
+      this.playerId, this.bufferConfigType, this.bufferConfigValue);
+  int playerId;
+  String bufferConfigType;
+  int bufferConfigValue;
+}
+
 @HostApi()
 abstract class VideoPlayerAvplayApi {
   void initialize();
@@ -123,4 +131,5 @@ abstract class VideoPlayerAvplayApi {
   void setDisplayGeometry(GeometryMessage msg);
   StreamingPropertyMessage getStreamingProperty(
       StreamingPropertyTypeMessage msg);
+  bool setBufferConfig(BufferConfigMessage msg);
 }

--- a/packages/video_player_avplay/pubspec.yaml
+++ b/packages/video_player_avplay/pubspec.yaml
@@ -2,7 +2,7 @@ name: video_player_avplay
 description: Flutter plugin for displaying inline video on Tizen TV devices.
 homepage: https://github.com/flutter-tizen/plugins
 repository: https://github.com/flutter-tizen/plugins/tree/master/packages/video_player_avplay
-version: 0.4.6
+version: 0.4.7
 
 environment:
   sdk: ">=3.1.0 <4.0.0"

--- a/packages/video_player_avplay/tizen/src/messages.cc
+++ b/packages/video_player_avplay/tizen/src/messages.cc
@@ -634,52 +634,102 @@ StreamingPropertyTypeMessage StreamingPropertyTypeMessage::FromEncodableList(
   return decoded;
 }
 
+// BufferConfigMessage
+
+BufferConfigMessage::BufferConfigMessage(int64_t player_id,
+                                         const std::string& buffer_config_type,
+                                         int64_t buffer_config_value)
+    : player_id_(player_id),
+      buffer_config_type_(buffer_config_type),
+      buffer_config_value_(buffer_config_value) {}
+
+int64_t BufferConfigMessage::player_id() const { return player_id_; }
+
+void BufferConfigMessage::set_player_id(int64_t value_arg) {
+  player_id_ = value_arg;
+}
+
+const std::string& BufferConfigMessage::buffer_config_type() const {
+  return buffer_config_type_;
+}
+
+void BufferConfigMessage::set_buffer_config_type(std::string_view value_arg) {
+  buffer_config_type_ = value_arg;
+}
+
+int64_t BufferConfigMessage::buffer_config_value() const {
+  return buffer_config_value_;
+}
+
+void BufferConfigMessage::set_buffer_config_value(int64_t value_arg) {
+  buffer_config_value_ = value_arg;
+}
+
+EncodableList BufferConfigMessage::ToEncodableList() const {
+  EncodableList list;
+  list.reserve(3);
+  list.push_back(EncodableValue(player_id_));
+  list.push_back(EncodableValue(buffer_config_type_));
+  list.push_back(EncodableValue(buffer_config_value_));
+  return list;
+}
+
+BufferConfigMessage BufferConfigMessage::FromEncodableList(
+    const EncodableList& list) {
+  BufferConfigMessage decoded(
+      list[0].LongValue(), std::get<std::string>(list[1]), list[2].LongValue());
+  return decoded;
+}
+
 VideoPlayerAvplayApiCodecSerializer::VideoPlayerAvplayApiCodecSerializer() {}
 
 EncodableValue VideoPlayerAvplayApiCodecSerializer::ReadValueOfType(
     uint8_t type, flutter::ByteStreamReader* stream) const {
   switch (type) {
     case 128:
-      return CustomEncodableValue(CreateMessage::FromEncodableList(
+      return CustomEncodableValue(BufferConfigMessage::FromEncodableList(
           std::get<EncodableList>(ReadValue(stream))));
     case 129:
-      return CustomEncodableValue(DurationMessage::FromEncodableList(
+      return CustomEncodableValue(CreateMessage::FromEncodableList(
           std::get<EncodableList>(ReadValue(stream))));
     case 130:
-      return CustomEncodableValue(GeometryMessage::FromEncodableList(
+      return CustomEncodableValue(DurationMessage::FromEncodableList(
           std::get<EncodableList>(ReadValue(stream))));
     case 131:
-      return CustomEncodableValue(LoopingMessage::FromEncodableList(
+      return CustomEncodableValue(GeometryMessage::FromEncodableList(
           std::get<EncodableList>(ReadValue(stream))));
     case 132:
-      return CustomEncodableValue(MixWithOthersMessage::FromEncodableList(
+      return CustomEncodableValue(LoopingMessage::FromEncodableList(
           std::get<EncodableList>(ReadValue(stream))));
     case 133:
-      return CustomEncodableValue(PlaybackSpeedMessage::FromEncodableList(
+      return CustomEncodableValue(MixWithOthersMessage::FromEncodableList(
           std::get<EncodableList>(ReadValue(stream))));
     case 134:
-      return CustomEncodableValue(PlayerMessage::FromEncodableList(
+      return CustomEncodableValue(PlaybackSpeedMessage::FromEncodableList(
           std::get<EncodableList>(ReadValue(stream))));
     case 135:
-      return CustomEncodableValue(PositionMessage::FromEncodableList(
+      return CustomEncodableValue(PlayerMessage::FromEncodableList(
           std::get<EncodableList>(ReadValue(stream))));
     case 136:
-      return CustomEncodableValue(SelectedTracksMessage::FromEncodableList(
+      return CustomEncodableValue(PositionMessage::FromEncodableList(
           std::get<EncodableList>(ReadValue(stream))));
     case 137:
-      return CustomEncodableValue(StreamingPropertyMessage::FromEncodableList(
+      return CustomEncodableValue(SelectedTracksMessage::FromEncodableList(
           std::get<EncodableList>(ReadValue(stream))));
     case 138:
+      return CustomEncodableValue(StreamingPropertyMessage::FromEncodableList(
+          std::get<EncodableList>(ReadValue(stream))));
+    case 139:
       return CustomEncodableValue(
           StreamingPropertyTypeMessage::FromEncodableList(
               std::get<EncodableList>(ReadValue(stream))));
-    case 139:
+    case 140:
       return CustomEncodableValue(TrackMessage::FromEncodableList(
           std::get<EncodableList>(ReadValue(stream))));
-    case 140:
+    case 141:
       return CustomEncodableValue(TrackTypeMessage::FromEncodableList(
           std::get<EncodableList>(ReadValue(stream))));
-    case 141:
+    case 142:
       return CustomEncodableValue(VolumeMessage::FromEncodableList(
           std::get<EncodableList>(ReadValue(stream))));
     default:
@@ -691,8 +741,16 @@ void VideoPlayerAvplayApiCodecSerializer::WriteValue(
     const EncodableValue& value, flutter::ByteStreamWriter* stream) const {
   if (const CustomEncodableValue* custom_value =
           std::get_if<CustomEncodableValue>(&value)) {
-    if (custom_value->type() == typeid(CreateMessage)) {
+    if (custom_value->type() == typeid(BufferConfigMessage)) {
       stream->WriteByte(128);
+      WriteValue(
+          EncodableValue(std::any_cast<BufferConfigMessage>(*custom_value)
+                             .ToEncodableList()),
+          stream);
+      return;
+    }
+    if (custom_value->type() == typeid(CreateMessage)) {
+      stream->WriteByte(129);
       WriteValue(
           EncodableValue(
               std::any_cast<CreateMessage>(*custom_value).ToEncodableList()),
@@ -700,7 +758,7 @@ void VideoPlayerAvplayApiCodecSerializer::WriteValue(
       return;
     }
     if (custom_value->type() == typeid(DurationMessage)) {
-      stream->WriteByte(129);
+      stream->WriteByte(130);
       WriteValue(
           EncodableValue(
               std::any_cast<DurationMessage>(*custom_value).ToEncodableList()),
@@ -708,7 +766,7 @@ void VideoPlayerAvplayApiCodecSerializer::WriteValue(
       return;
     }
     if (custom_value->type() == typeid(GeometryMessage)) {
-      stream->WriteByte(130);
+      stream->WriteByte(131);
       WriteValue(
           EncodableValue(
               std::any_cast<GeometryMessage>(*custom_value).ToEncodableList()),
@@ -716,7 +774,7 @@ void VideoPlayerAvplayApiCodecSerializer::WriteValue(
       return;
     }
     if (custom_value->type() == typeid(LoopingMessage)) {
-      stream->WriteByte(131);
+      stream->WriteByte(132);
       WriteValue(
           EncodableValue(
               std::any_cast<LoopingMessage>(*custom_value).ToEncodableList()),
@@ -724,7 +782,7 @@ void VideoPlayerAvplayApiCodecSerializer::WriteValue(
       return;
     }
     if (custom_value->type() == typeid(MixWithOthersMessage)) {
-      stream->WriteByte(132);
+      stream->WriteByte(133);
       WriteValue(
           EncodableValue(std::any_cast<MixWithOthersMessage>(*custom_value)
                              .ToEncodableList()),
@@ -732,7 +790,7 @@ void VideoPlayerAvplayApiCodecSerializer::WriteValue(
       return;
     }
     if (custom_value->type() == typeid(PlaybackSpeedMessage)) {
-      stream->WriteByte(133);
+      stream->WriteByte(134);
       WriteValue(
           EncodableValue(std::any_cast<PlaybackSpeedMessage>(*custom_value)
                              .ToEncodableList()),
@@ -740,7 +798,7 @@ void VideoPlayerAvplayApiCodecSerializer::WriteValue(
       return;
     }
     if (custom_value->type() == typeid(PlayerMessage)) {
-      stream->WriteByte(134);
+      stream->WriteByte(135);
       WriteValue(
           EncodableValue(
               std::any_cast<PlayerMessage>(*custom_value).ToEncodableList()),
@@ -748,7 +806,7 @@ void VideoPlayerAvplayApiCodecSerializer::WriteValue(
       return;
     }
     if (custom_value->type() == typeid(PositionMessage)) {
-      stream->WriteByte(135);
+      stream->WriteByte(136);
       WriteValue(
           EncodableValue(
               std::any_cast<PositionMessage>(*custom_value).ToEncodableList()),
@@ -756,7 +814,7 @@ void VideoPlayerAvplayApiCodecSerializer::WriteValue(
       return;
     }
     if (custom_value->type() == typeid(SelectedTracksMessage)) {
-      stream->WriteByte(136);
+      stream->WriteByte(137);
       WriteValue(
           EncodableValue(std::any_cast<SelectedTracksMessage>(*custom_value)
                              .ToEncodableList()),
@@ -764,7 +822,7 @@ void VideoPlayerAvplayApiCodecSerializer::WriteValue(
       return;
     }
     if (custom_value->type() == typeid(StreamingPropertyMessage)) {
-      stream->WriteByte(137);
+      stream->WriteByte(138);
       WriteValue(
           EncodableValue(std::any_cast<StreamingPropertyMessage>(*custom_value)
                              .ToEncodableList()),
@@ -772,7 +830,7 @@ void VideoPlayerAvplayApiCodecSerializer::WriteValue(
       return;
     }
     if (custom_value->type() == typeid(StreamingPropertyTypeMessage)) {
-      stream->WriteByte(138);
+      stream->WriteByte(139);
       WriteValue(EncodableValue(
                      std::any_cast<StreamingPropertyTypeMessage>(*custom_value)
                          .ToEncodableList()),
@@ -780,7 +838,7 @@ void VideoPlayerAvplayApiCodecSerializer::WriteValue(
       return;
     }
     if (custom_value->type() == typeid(TrackMessage)) {
-      stream->WriteByte(139);
+      stream->WriteByte(140);
       WriteValue(
           EncodableValue(
               std::any_cast<TrackMessage>(*custom_value).ToEncodableList()),
@@ -788,7 +846,7 @@ void VideoPlayerAvplayApiCodecSerializer::WriteValue(
       return;
     }
     if (custom_value->type() == typeid(TrackTypeMessage)) {
-      stream->WriteByte(140);
+      stream->WriteByte(141);
       WriteValue(
           EncodableValue(
               std::any_cast<TrackTypeMessage>(*custom_value).ToEncodableList()),
@@ -796,7 +854,7 @@ void VideoPlayerAvplayApiCodecSerializer::WriteValue(
       return;
     }
     if (custom_value->type() == typeid(VolumeMessage)) {
-      stream->WriteByte(141);
+      stream->WriteByte(142);
       WriteValue(
           EncodableValue(
               std::any_cast<VolumeMessage>(*custom_value).ToEncodableList()),
@@ -1433,6 +1491,41 @@ void VideoPlayerAvplayApi::SetUp(flutter::BinaryMessenger* binary_messenger,
               EncodableList wrapped;
               wrapped.push_back(
                   CustomEncodableValue(std::move(output).TakeValue()));
+              reply(EncodableValue(std::move(wrapped)));
+            } catch (const std::exception& exception) {
+              reply(WrapError(exception.what()));
+            }
+          });
+    } else {
+      channel->SetMessageHandler(nullptr);
+    }
+  }
+  {
+    auto channel = std::make_unique<BasicMessageChannel<>>(
+        binary_messenger,
+        "dev.flutter.pigeon.video_player_avplay.VideoPlayerAvplayApi."
+        "setBufferConfig",
+        &GetCodec());
+    if (api != nullptr) {
+      channel->SetMessageHandler(
+          [api](const EncodableValue& message,
+                const flutter::MessageReply<EncodableValue>& reply) {
+            try {
+              const auto& args = std::get<EncodableList>(message);
+              const auto& encodable_msg_arg = args.at(0);
+              if (encodable_msg_arg.IsNull()) {
+                reply(WrapError("msg_arg unexpectedly null."));
+                return;
+              }
+              const auto& msg_arg = std::any_cast<const BufferConfigMessage&>(
+                  std::get<CustomEncodableValue>(encodable_msg_arg));
+              ErrorOr<bool> output = api->SetBufferConfig(msg_arg);
+              if (output.has_error()) {
+                reply(WrapError(output.error()));
+                return;
+              }
+              EncodableList wrapped;
+              wrapped.push_back(EncodableValue(std::move(output).TakeValue()));
               reply(EncodableValue(std::move(wrapped)));
             } catch (const std::exception& exception) {
               reply(WrapError(exception.what()));

--- a/packages/video_player_avplay/tizen/src/messages.h
+++ b/packages/video_player_avplay/tizen/src/messages.h
@@ -411,6 +411,34 @@ class StreamingPropertyTypeMessage {
   std::string streaming_property_type_;
 };
 
+// Generated class from Pigeon that represents data sent in messages.
+class BufferConfigMessage {
+ public:
+  // Constructs an object setting all fields.
+  explicit BufferConfigMessage(int64_t player_id,
+                               const std::string& buffer_config_type,
+                               int64_t buffer_config_value);
+
+  int64_t player_id() const;
+  void set_player_id(int64_t value_arg);
+
+  const std::string& buffer_config_type() const;
+  void set_buffer_config_type(std::string_view value_arg);
+
+  int64_t buffer_config_value() const;
+  void set_buffer_config_value(int64_t value_arg);
+
+ private:
+  static BufferConfigMessage FromEncodableList(
+      const flutter::EncodableList& list);
+  flutter::EncodableList ToEncodableList() const;
+  friend class VideoPlayerAvplayApi;
+  friend class VideoPlayerAvplayApiCodecSerializer;
+  int64_t player_id_;
+  std::string buffer_config_type_;
+  int64_t buffer_config_value_;
+};
+
 class VideoPlayerAvplayApiCodecSerializer
     : public flutter::StandardCodecSerializer {
  public:
@@ -459,6 +487,7 @@ class VideoPlayerAvplayApi {
       const GeometryMessage& msg) = 0;
   virtual ErrorOr<StreamingPropertyMessage> GetStreamingProperty(
       const StreamingPropertyTypeMessage& msg) = 0;
+  virtual ErrorOr<bool> SetBufferConfig(const BufferConfigMessage& msg) = 0;
 
   // The codec used by VideoPlayerAvplayApi.
   static const flutter::StandardMessageCodec& GetCodec();

--- a/packages/video_player_avplay/tizen/src/plus_player.cc
+++ b/packages/video_player_avplay/tizen/src/plus_player.cc
@@ -583,6 +583,21 @@ std::string PlusPlayer::GetStreamingProperty(
   return ::GetStreamingProperty(player_, streaming_property_type);
 }
 
+bool PlusPlayer::SetBufferConfig(const std::string &key, int64_t value) {
+  if (!player_) {
+    LOG_ERROR("[PlusPlayer] Player not created.");
+    return false;
+  }
+
+  plusplayer::State state = GetState(player_);
+  if (state == plusplayer::State::kNone) {
+    LOG_ERROR("[PlusPlayer]:Player is in invalid state[%d]", state);
+    return false;
+  }
+  const std::pair<std::string, int> config = std::make_pair(key, value);
+  return ::SetBufferConfig(player_, config);
+}
+
 bool PlusPlayer::OnLicenseAcquired(int *drm_handle, unsigned int length,
                                    unsigned char *pssh_data, void *user_data) {
   LOG_INFO("[PlusPlayer] License acquired.");

--- a/packages/video_player_avplay/tizen/src/plus_player.h
+++ b/packages/video_player_avplay/tizen/src/plus_player.h
@@ -43,6 +43,7 @@ class PlusPlayer : public VideoPlayer {
   bool SetTrackSelection(int32_t track_id, std::string track_type) override;
   std::string GetStreamingProperty(
       const std::string &streaming_property_type) override;
+  bool SetBufferConfig(const std::string &key, int64_t value) override;
 
  private:
   bool IsLive();

--- a/packages/video_player_avplay/tizen/src/video_player.h
+++ b/packages/video_player_avplay/tizen/src/video_player.h
@@ -52,6 +52,9 @@ class VideoPlayer {
       const std::string &streaming_property_type) {
     return "";
   };
+  virtual bool SetBufferConfig(const std::string &key, int64_t value) {
+    return false;
+  };
 
  protected:
   virtual void GetVideoSize(int32_t *width, int32_t *height) = 0;

--- a/packages/video_player_avplay/tizen/src/video_player_tizen_plugin.cc
+++ b/packages/video_player_avplay/tizen/src/video_player_tizen_plugin.cc
@@ -57,6 +57,7 @@ class VideoPlayerTizenPlugin : public flutter::Plugin,
       const GeometryMessage &msg) override;
   ErrorOr<StreamingPropertyMessage> GetStreamingProperty(
       const StreamingPropertyTypeMessage &msg) override;
+  ErrorOr<bool> SetBufferConfig(const BufferConfigMessage &msg) override;
 
   static VideoPlayer *FindPlayerById(int64_t player_id) {
     auto iter = players_.find(player_id);
@@ -311,6 +312,16 @@ ErrorOr<StreamingPropertyMessage> VideoPlayerTizenPlugin::GetStreamingProperty(
       msg.player_id(),
       player->GetStreamingProperty(msg.streaming_property_type()));
   return result;
+}
+
+ErrorOr<bool> VideoPlayerTizenPlugin::SetBufferConfig(
+    const BufferConfigMessage &msg) {
+  VideoPlayer *player = FindPlayerById(msg.player_id());
+  if (!player) {
+    return FlutterError("Invalid argument", "Player not found");
+  }
+  return player->SetBufferConfig(msg.buffer_config_type(),
+                                 msg.buffer_config_value());
 }
 
 std::optional<FlutterError> VideoPlayerTizenPlugin::SetMixWithOthers(


### PR DESCRIPTION
Add a new interface
```dart
/// Sets the buffer size for the play and resume scenarios. The time buffer size must be at least 4 seconds.
/// For example, if a 10 second buffer size is set, playback can only start or resume after 10 seconds of media has accumulated in the buffer.
/// Play scenarios include user-initiated streaming playback and whenever media playback is starting for the first time.
/// Resume scenarios include resuming playback after pause or seek operations, or when lack of data causes playback rebuffering.
setBufferConfig(BufferConfigType type, int value)
```