### PR TITLE
[video_player_avplay] Call the open before calling the SetStreamingProperty

### DIFF
--- a/packages/video_player_avplay/CHANGELOG.md
+++ b/packages/video_player_avplay/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## NEXT
 
 * Call the open before calling the SetStreamingProperty.
+* Change getStreamingProperty API return type from StreamingPropertyMessage to String.
 
 ## 0.4.7
 

--- a/packages/video_player_avplay/CHANGELOG.md
+++ b/packages/video_player_avplay/CHANGELOG.md
@@ -1,3 +1,7 @@
+## NEXT
+
+* Call the open before calling the SetStreamingProperty.
+
 ## 0.4.7
 
 * Add SetBufferConfig interface.

--- a/packages/video_player_avplay/lib/src/messages.g.dart
+++ b/packages/video_player_avplay/lib/src/messages.g.dart
@@ -364,32 +364,6 @@ class DurationMessage {
   }
 }
 
-class StreamingPropertyMessage {
-  StreamingPropertyMessage({
-    required this.playerId,
-    required this.streamingProperty,
-  });
-
-  int playerId;
-
-  String streamingProperty;
-
-  Object encode() {
-    return <Object?>[
-      playerId,
-      streamingProperty,
-    ];
-  }
-
-  static StreamingPropertyMessage decode(Object result) {
-    result as List<Object?>;
-    return StreamingPropertyMessage(
-      playerId: result[0]! as int,
-      streamingProperty: result[1]! as String,
-    );
-  }
-}
-
 class StreamingPropertyTypeMessage {
   StreamingPropertyTypeMessage({
     required this.playerId,
@@ -481,20 +455,17 @@ class _VideoPlayerAvplayApiCodec extends StandardMessageCodec {
     } else if (value is SelectedTracksMessage) {
       buffer.putUint8(137);
       writeValue(buffer, value.encode());
-    } else if (value is StreamingPropertyMessage) {
+    } else if (value is StreamingPropertyTypeMessage) {
       buffer.putUint8(138);
       writeValue(buffer, value.encode());
-    } else if (value is StreamingPropertyTypeMessage) {
+    } else if (value is TrackMessage) {
       buffer.putUint8(139);
       writeValue(buffer, value.encode());
-    } else if (value is TrackMessage) {
+    } else if (value is TrackTypeMessage) {
       buffer.putUint8(140);
       writeValue(buffer, value.encode());
-    } else if (value is TrackTypeMessage) {
-      buffer.putUint8(141);
-      writeValue(buffer, value.encode());
     } else if (value is VolumeMessage) {
-      buffer.putUint8(142);
+      buffer.putUint8(141);
       writeValue(buffer, value.encode());
     } else {
       super.writeValue(buffer, value);
@@ -525,14 +496,12 @@ class _VideoPlayerAvplayApiCodec extends StandardMessageCodec {
       case 137:
         return SelectedTracksMessage.decode(readValue(buffer)!);
       case 138:
-        return StreamingPropertyMessage.decode(readValue(buffer)!);
-      case 139:
         return StreamingPropertyTypeMessage.decode(readValue(buffer)!);
-      case 140:
+      case 139:
         return TrackMessage.decode(readValue(buffer)!);
-      case 141:
+      case 140:
         return TrackTypeMessage.decode(readValue(buffer)!);
-      case 142:
+      case 141:
         return VolumeMessage.decode(readValue(buffer)!);
       default:
         return super.readValueOfType(type, buffer);
@@ -975,7 +944,7 @@ class VideoPlayerAvplayApi {
     }
   }
 
-  Future<StreamingPropertyMessage> getStreamingProperty(
+  Future<String> getStreamingProperty(
       StreamingPropertyTypeMessage arg_msg) async {
     final BasicMessageChannel<Object?> channel = BasicMessageChannel<Object?>(
         'dev.flutter.pigeon.video_player_avplay.VideoPlayerAvplayApi.getStreamingProperty',
@@ -1000,7 +969,7 @@ class VideoPlayerAvplayApi {
         message: 'Host platform returned null value for non-null return value.',
       );
     } else {
-      return (replyList[0] as StreamingPropertyMessage?)!;
+      return (replyList[0] as String?)!;
     }
   }
 

--- a/packages/video_player_avplay/lib/src/video_player_tizen.dart
+++ b/packages/video_player_avplay/lib/src/video_player_tizen.dart
@@ -200,11 +200,9 @@ class VideoPlayerTizen extends VideoPlayerPlatform {
   @override
   Future<String> getStreamingProperty(
       int playerId, StreamingPropertyType type) async {
-    final StreamingPropertyMessage streamingPropertyMessage =
-        await _api.getStreamingProperty(StreamingPropertyTypeMessage(
-            playerId: playerId,
-            streamingPropertyType: _streamingPropertyType[type]!));
-    return streamingPropertyMessage.streamingProperty;
+    return _api.getStreamingProperty(StreamingPropertyTypeMessage(
+        playerId: playerId,
+        streamingPropertyType: _streamingPropertyType[type]!));
   }
 
   @override

--- a/packages/video_player_avplay/pigeons/messages.dart
+++ b/packages/video_player_avplay/pigeons/messages.dart
@@ -89,12 +89,6 @@ class DurationMessage {
   List<int?>? durationRange;
 }
 
-class StreamingPropertyMessage {
-  StreamingPropertyMessage(this.playerId, this.streamingProperty);
-  int playerId;
-  String streamingProperty;
-}
-
 class StreamingPropertyTypeMessage {
   StreamingPropertyTypeMessage(this.playerId, this.streamingPropertyType);
   int playerId;
@@ -129,7 +123,6 @@ abstract class VideoPlayerAvplayApi {
   void pause(PlayerMessage msg);
   void setMixWithOthers(MixWithOthersMessage msg);
   void setDisplayGeometry(GeometryMessage msg);
-  StreamingPropertyMessage getStreamingProperty(
-      StreamingPropertyTypeMessage msg);
+  String getStreamingProperty(StreamingPropertyTypeMessage msg);
   bool setBufferConfig(BufferConfigMessage msg);
 }

--- a/packages/video_player_avplay/tizen/src/messages.cc
+++ b/packages/video_player_avplay/tizen/src/messages.cc
@@ -560,42 +560,6 @@ DurationMessage DurationMessage::FromEncodableList(const EncodableList& list) {
   return decoded;
 }
 
-// StreamingPropertyMessage
-
-StreamingPropertyMessage::StreamingPropertyMessage(
-    int64_t player_id, const std::string& streaming_property)
-    : player_id_(player_id), streaming_property_(streaming_property) {}
-
-int64_t StreamingPropertyMessage::player_id() const { return player_id_; }
-
-void StreamingPropertyMessage::set_player_id(int64_t value_arg) {
-  player_id_ = value_arg;
-}
-
-const std::string& StreamingPropertyMessage::streaming_property() const {
-  return streaming_property_;
-}
-
-void StreamingPropertyMessage::set_streaming_property(
-    std::string_view value_arg) {
-  streaming_property_ = value_arg;
-}
-
-EncodableList StreamingPropertyMessage::ToEncodableList() const {
-  EncodableList list;
-  list.reserve(2);
-  list.push_back(EncodableValue(player_id_));
-  list.push_back(EncodableValue(streaming_property_));
-  return list;
-}
-
-StreamingPropertyMessage StreamingPropertyMessage::FromEncodableList(
-    const EncodableList& list) {
-  StreamingPropertyMessage decoded(list[0].LongValue(),
-                                   std::get<std::string>(list[1]));
-  return decoded;
-}
-
 // StreamingPropertyTypeMessage
 
 StreamingPropertyTypeMessage::StreamingPropertyTypeMessage(
@@ -717,19 +681,16 @@ EncodableValue VideoPlayerAvplayApiCodecSerializer::ReadValueOfType(
       return CustomEncodableValue(SelectedTracksMessage::FromEncodableList(
           std::get<EncodableList>(ReadValue(stream))));
     case 138:
-      return CustomEncodableValue(StreamingPropertyMessage::FromEncodableList(
-          std::get<EncodableList>(ReadValue(stream))));
-    case 139:
       return CustomEncodableValue(
           StreamingPropertyTypeMessage::FromEncodableList(
               std::get<EncodableList>(ReadValue(stream))));
-    case 140:
+    case 139:
       return CustomEncodableValue(TrackMessage::FromEncodableList(
           std::get<EncodableList>(ReadValue(stream))));
-    case 141:
+    case 140:
       return CustomEncodableValue(TrackTypeMessage::FromEncodableList(
           std::get<EncodableList>(ReadValue(stream))));
-    case 142:
+    case 141:
       return CustomEncodableValue(VolumeMessage::FromEncodableList(
           std::get<EncodableList>(ReadValue(stream))));
     default:
@@ -821,16 +782,8 @@ void VideoPlayerAvplayApiCodecSerializer::WriteValue(
           stream);
       return;
     }
-    if (custom_value->type() == typeid(StreamingPropertyMessage)) {
-      stream->WriteByte(138);
-      WriteValue(
-          EncodableValue(std::any_cast<StreamingPropertyMessage>(*custom_value)
-                             .ToEncodableList()),
-          stream);
-      return;
-    }
     if (custom_value->type() == typeid(StreamingPropertyTypeMessage)) {
-      stream->WriteByte(139);
+      stream->WriteByte(138);
       WriteValue(EncodableValue(
                      std::any_cast<StreamingPropertyTypeMessage>(*custom_value)
                          .ToEncodableList()),
@@ -838,7 +791,7 @@ void VideoPlayerAvplayApiCodecSerializer::WriteValue(
       return;
     }
     if (custom_value->type() == typeid(TrackMessage)) {
-      stream->WriteByte(140);
+      stream->WriteByte(139);
       WriteValue(
           EncodableValue(
               std::any_cast<TrackMessage>(*custom_value).ToEncodableList()),
@@ -846,7 +799,7 @@ void VideoPlayerAvplayApiCodecSerializer::WriteValue(
       return;
     }
     if (custom_value->type() == typeid(TrackTypeMessage)) {
-      stream->WriteByte(141);
+      stream->WriteByte(140);
       WriteValue(
           EncodableValue(
               std::any_cast<TrackTypeMessage>(*custom_value).ToEncodableList()),
@@ -854,7 +807,7 @@ void VideoPlayerAvplayApiCodecSerializer::WriteValue(
       return;
     }
     if (custom_value->type() == typeid(VolumeMessage)) {
-      stream->WriteByte(142);
+      stream->WriteByte(141);
       WriteValue(
           EncodableValue(
               std::any_cast<VolumeMessage>(*custom_value).ToEncodableList()),
@@ -1482,15 +1435,13 @@ void VideoPlayerAvplayApi::SetUp(flutter::BinaryMessenger* binary_messenger,
               const auto& msg_arg =
                   std::any_cast<const StreamingPropertyTypeMessage&>(
                       std::get<CustomEncodableValue>(encodable_msg_arg));
-              ErrorOr<StreamingPropertyMessage> output =
-                  api->GetStreamingProperty(msg_arg);
+              ErrorOr<std::string> output = api->GetStreamingProperty(msg_arg);
               if (output.has_error()) {
                 reply(WrapError(output.error()));
                 return;
               }
               EncodableList wrapped;
-              wrapped.push_back(
-                  CustomEncodableValue(std::move(output).TakeValue()));
+              wrapped.push_back(EncodableValue(std::move(output).TakeValue()));
               reply(EncodableValue(std::move(wrapped)));
             } catch (const std::exception& exception) {
               reply(WrapError(exception.what()));

--- a/packages/video_player_avplay/tizen/src/messages.h
+++ b/packages/video_player_avplay/tizen/src/messages.h
@@ -366,29 +366,6 @@ class DurationMessage {
 };
 
 // Generated class from Pigeon that represents data sent in messages.
-class StreamingPropertyMessage {
- public:
-  // Constructs an object setting all fields.
-  explicit StreamingPropertyMessage(int64_t player_id,
-                                    const std::string& streaming_property);
-
-  int64_t player_id() const;
-  void set_player_id(int64_t value_arg);
-
-  const std::string& streaming_property() const;
-  void set_streaming_property(std::string_view value_arg);
-
- private:
-  static StreamingPropertyMessage FromEncodableList(
-      const flutter::EncodableList& list);
-  flutter::EncodableList ToEncodableList() const;
-  friend class VideoPlayerAvplayApi;
-  friend class VideoPlayerAvplayApiCodecSerializer;
-  int64_t player_id_;
-  std::string streaming_property_;
-};
-
-// Generated class from Pigeon that represents data sent in messages.
 class StreamingPropertyTypeMessage {
  public:
   // Constructs an object setting all fields.
@@ -485,7 +462,7 @@ class VideoPlayerAvplayApi {
       const MixWithOthersMessage& msg) = 0;
   virtual std::optional<FlutterError> SetDisplayGeometry(
       const GeometryMessage& msg) = 0;
-  virtual ErrorOr<StreamingPropertyMessage> GetStreamingProperty(
+  virtual ErrorOr<std::string> GetStreamingProperty(
       const StreamingPropertyTypeMessage& msg) = 0;
   virtual ErrorOr<bool> SetBufferConfig(const BufferConfigMessage& msg) = 0;
 

--- a/packages/video_player_avplay/tizen/src/plus_player.cc
+++ b/packages/video_player_avplay/tizen/src/plus_player.cc
@@ -87,6 +87,13 @@ int64_t PlusPlayer::Create(const std::string &uri,
     return -1;
   }
 
+
+  if (!Open(player_, uri)) {
+    LOG_ERROR("[PlusPlayer] Fail to open uri :  %s.", uri.c_str());
+    return -1;
+  }
+  LOG_INFO("[PlusPlayer] Uri: %s", uri.c_str());
+
   if (create_message.streaming_property() != nullptr &&
       !create_message.streaming_property()->empty()) {
     for (const auto &[key, value] : *create_message.streaming_property()) {
@@ -94,12 +101,6 @@ int64_t PlusPlayer::Create(const std::string &uri,
                            std::get<std::string>(value));
     }
   }
-
-  if (!Open(player_, uri)) {
-    LOG_ERROR("[PlusPlayer] Fail to open uri :  %s.", uri.c_str());
-    return -1;
-  }
-  LOG_INFO("[PlusPlayer] Uri: %s", uri.c_str());
 
   char *appId = nullptr;
   int ret = app_manager_get_app_id(getpid(), &appId);
@@ -345,7 +346,6 @@ std::pair<int64_t, int64_t> PlusPlayer::GetDuration() {
       LOG_ERROR("[PlusPlayer] Player fail to get the duration.");
       return std::make_pair(0, 0);
     }
-    LOG_INFO("[PlusPlayer] Video duration: %lld.", duration);
     return std::make_pair(0, duration);
   }
 }

--- a/packages/video_player_avplay/tizen/src/plus_player.cc
+++ b/packages/video_player_avplay/tizen/src/plus_player.cc
@@ -87,7 +87,6 @@ int64_t PlusPlayer::Create(const std::string &uri,
     return -1;
   }
 
-
   if (!Open(player_, uri)) {
     LOG_ERROR("[PlusPlayer] Fail to open uri :  %s.", uri.c_str());
     return -1;

--- a/packages/video_player_avplay/tizen/src/video_player_tizen_plugin.cc
+++ b/packages/video_player_avplay/tizen/src/video_player_tizen_plugin.cc
@@ -55,7 +55,7 @@ class VideoPlayerTizenPlugin : public flutter::Plugin,
       const MixWithOthersMessage &msg) override;
   std::optional<FlutterError> SetDisplayGeometry(
       const GeometryMessage &msg) override;
-  ErrorOr<StreamingPropertyMessage> GetStreamingProperty(
+  ErrorOr<std::string> GetStreamingProperty(
       const StreamingPropertyTypeMessage &msg) override;
   ErrorOr<bool> SetBufferConfig(const BufferConfigMessage &msg) override;
 
@@ -302,16 +302,13 @@ std::optional<FlutterError> VideoPlayerTizenPlugin::SetDisplayGeometry(
   return std::nullopt;
 }
 
-ErrorOr<StreamingPropertyMessage> VideoPlayerTizenPlugin::GetStreamingProperty(
+ErrorOr<std::string> VideoPlayerTizenPlugin::GetStreamingProperty(
     const StreamingPropertyTypeMessage &msg) {
   VideoPlayer *player = FindPlayerById(msg.player_id());
   if (!player) {
     return FlutterError("Invalid argument", "Player not found");
   }
-  StreamingPropertyMessage result(
-      msg.player_id(),
-      player->GetStreamingProperty(msg.streaming_property_type()));
-  return result;
+  return player->GetStreamingProperty(msg.streaming_property_type());
 }
 
 ErrorOr<bool> VideoPlayerTizenPlugin::SetBufferConfig(


### PR DESCRIPTION
From SetStreamingProperty API guide:
```
  /**
   * @brief     Set streamingengine property
   * @param     [in] type : attribute type. \n
   *             type can be \n
   *               "COOKIE" \n
   *               "USER_AGENT" \n
   *               "RESUME_TIME" \n
   *               "ADAPTIVE_INFO"
   * @param     [in] value : value of attribute type
   * @pre       The player state can be all of #State except #State::kNone
   */
``` 
We need call open first, then call SetStreamingProperty.