### PR TITLE
[video_player] Update video_player to 2.5.0

### DIFF
--- a/packages/video_player/CHANGELOG.md
+++ b/packages/video_player/CHANGELOG.md
@@ -4,7 +4,7 @@
 * Update video_player_platform_interface to 6.2.0.
 * Update the example app and integration_test.
 * Fix new lint warnings.
-* Update minimum Flutter and Dart version to 3.19 and 3.1.
+* Update minimum Flutter and Dart version to 3.19 and 3.3.
 * Synchronizes VideoPlayerValue.isPlaying with underlying video player.
 
 ## 2.4.9

--- a/packages/video_player/CHANGELOG.md
+++ b/packages/video_player/CHANGELOG.md
@@ -1,7 +1,11 @@
-## NEXT
+## 2.5.0
 
+* Update video_player to 2.9.1.
+* Update video_player_platform_interface to 6.2.0.
+* Update the example app and integration_test.
 * Fix new lint warnings.
-* Update minimum Flutter and Dart version to 3.13 and 3.1.
+* Update minimum Flutter and Dart version to 3.19 and 3.1.
+* Synchronizes VideoPlayerValue.isPlaying with underlying video player.
 
 ## 2.4.9
 

--- a/packages/video_player/CHANGELOG.md
+++ b/packages/video_player/CHANGELOG.md
@@ -5,7 +5,7 @@
 * Update the example app and integration_test.
 * Fix new lint warnings.
 * Update minimum Flutter and Dart version to 3.19 and 3.3.
-* Synchronizes VideoPlayerValue.isPlaying with underlying video player.
+* Synchronize VideoPlayerValue.isPlaying with underlying video player.
 
 ## 2.4.9
 

--- a/packages/video_player/README.md
+++ b/packages/video_player/README.md
@@ -14,8 +14,8 @@ This package is not an _endorsed_ implementation of `video_player`. Therefore, y
 
 ```yaml
 dependencies:
-  video_player: ^2.4.2
-  video_player_tizen: ^2.4.9
+  video_player: ^2.9.1
+  video_player_tizen: ^2.5.0
 ```
 
 Then you can import `video_player` in your Dart code:
@@ -50,7 +50,7 @@ This plugin is not supported on TV emulators.
 
 The following options are not supported on Tizen.
 
-- The `httpHeaders` option of `VideoPlayerController.network`
+- The `httpHeaders` option of `VideoPlayerController.networkUrl`
 - `VideoPlayerOptions.allowBackgroundPlayback`
 - `VideoPlayerOptions.mixWithOthers`
 

--- a/packages/video_player/example/lib/main.dart
+++ b/packages/video_player/example/lib/main.dart
@@ -122,21 +122,26 @@ class _ExampleCard extends StatelessWidget {
             leading: const Icon(Icons.airline_seat_flat_angled),
             title: Text(title),
           ),
-          ButtonBar(
-            children: <Widget>[
-              TextButton(
-                child: const Text('BUY TICKETS'),
-                onPressed: () {
-                  /* ... */
-                },
-              ),
-              TextButton(
-                child: const Text('SELL TICKETS'),
-                onPressed: () {
-                  /* ... */
-                },
-              ),
-            ],
+          Padding(
+            padding: const EdgeInsets.all(8.0),
+            child: OverflowBar(
+              alignment: MainAxisAlignment.end,
+              spacing: 8.0,
+              children: <Widget>[
+                TextButton(
+                  child: const Text('BUY TICKETS'),
+                  onPressed: () {
+                    /* ... */
+                  },
+                ),
+                TextButton(
+                  child: const Text('SELL TICKETS'),
+                  onPressed: () {
+                    /* ... */
+                  },
+                ),
+              ],
+            ),
           ),
         ],
       ),
@@ -218,8 +223,9 @@ class _BumbleBeeRemoteVideoState extends State<_BumbleBeeRemoteVideo> {
   @override
   void initState() {
     super.initState();
-    _controller = VideoPlayerController.network(
-      'https://flutter.github.io/assets-for-api-docs/assets/videos/bee.mp4',
+    _controller = VideoPlayerController.networkUrl(
+      Uri.parse(
+          'https://flutter.github.io/assets-for-api-docs/assets/videos/bee.mp4'),
       closedCaptionFile: _loadCaptions(),
       videoPlayerOptions: VideoPlayerOptions(mixWithOthers: true),
     );

--- a/packages/video_player/example/pubspec.yaml
+++ b/packages/video_player/example/pubspec.yaml
@@ -3,13 +3,13 @@ description: Demonstrates how to use the video_player_tizen plugin.
 publish_to: "none"
 
 environment:
-  sdk: ">=3.1.0 <4.0.0"
-  flutter: ">=3.13.0"
+  sdk: ">=3.3.0 <4.0.0"
+  flutter: ">=3.19.0"
 
 dependencies:
   flutter:
     sdk: flutter
-  video_player: ^2.4.2
+  video_player: ^2.9.1
   video_player_tizen:
     path: ../
 

--- a/packages/video_player/lib/video_player_tizen.dart
+++ b/packages/video_player/lib/video_player_tizen.dart
@@ -143,6 +143,11 @@ class VideoPlayerTizen extends VideoPlayerPlatform {
           return VideoEvent(eventType: VideoEventType.bufferingStart);
         case 'bufferingEnd':
           return VideoEvent(eventType: VideoEventType.bufferingEnd);
+        case 'isPlayingStateUpdate':
+          return VideoEvent(
+            eventType: VideoEventType.isPlayingStateUpdate,
+            isPlaying: map['isPlaying'] as bool,
+          );
         default:
           return VideoEvent(eventType: VideoEventType.unknown);
       }

--- a/packages/video_player/pubspec.yaml
+++ b/packages/video_player/pubspec.yaml
@@ -2,11 +2,11 @@ name: video_player_tizen
 description: Tizen implementation of the video_player plugin.
 homepage: https://github.com/flutter-tizen/plugins
 repository: https://github.com/flutter-tizen/plugins/tree/master/packages/video_player
-version: 2.4.9
+version: 2.5.0
 
 environment:
-  sdk: ">=3.1.0 <4.0.0"
-  flutter: ">=3.13.0"
+  sdk: ">=3.3.0 <4.0.0"
+  flutter: ">=3.19.0"
 
 flutter:
   plugin:
@@ -19,7 +19,7 @@ flutter:
 dependencies:
   flutter:
     sdk: flutter
-  video_player_platform_interface: ^5.1.2
+  video_player_platform_interface: ^6.2.0
 
 dev_dependencies:
   pigeon: ^10.0.0

--- a/packages/video_player/tizen/src/video_player.cc
+++ b/packages/video_player/tizen/src/video_player.cc
@@ -270,6 +270,8 @@ void VideoPlayer::Play() {
 #ifdef TV_PROFILE
   timer_ = ecore_timer_add(30, ResetScreensaverTimeout, this);
 #endif
+
+  SendIsPlayingStateUpdate(true);
 }
 
 void VideoPlayer::Pause() {
@@ -294,6 +296,8 @@ void VideoPlayer::Pause() {
     ecore_timer_del(timer_);
     timer_ = nullptr;
   }
+
+  SendIsPlayingStateUpdate(false);
 }
 
 void VideoPlayer::SetLooping(bool is_looping) {
@@ -472,6 +476,16 @@ void VideoPlayer::SendInitialized() {
     };
     PushEvent(flutter::EncodableValue(result));
   }
+}
+
+void VideoPlayer::SendIsPlayingStateUpdate(bool is_playing) {
+  flutter::EncodableMap result = {
+      {flutter::EncodableValue("event"),
+       flutter::EncodableValue("isPlayingStateUpdate")},
+      {flutter::EncodableValue("isPlaying"),
+       flutter::EncodableValue(is_playing)},
+  };
+  PushEvent(flutter::EncodableValue(result));
 }
 
 Eina_Bool VideoPlayer::ResetScreensaverTimeout(void *data) {

--- a/packages/video_player/tizen/src/video_player.h
+++ b/packages/video_player/tizen/src/video_player.h
@@ -54,6 +54,7 @@ class VideoPlayer {
   void SetUpEventChannel(flutter::BinaryMessenger *messenger);
   void Initialize();
   void SendInitialized();
+  void SendIsPlayingStateUpdate(bool is_playing);
   void InitScreenSaverApi();
 
   static void OnPrepared(void *data);


### PR DESCRIPTION
* Update video_player to 2.9.1.
* Update video_player_platform_interface to 6.2.0.
* Update the example app and integration_test.
* Fix new lint warnings.
* Update minimum Flutter and Dart version to 3.19 and 3.3.
* Synchronizes VideoPlayerValue.isPlaying with underlying video player.

issue: https://github.com/flutter-tizen/plugins/issues/727