### PR TITLE
[video_player_avplay] Add setStreamingProperty API

### DIFF
--- a/packages/video_player_avplay/CHANGELOG.md
+++ b/packages/video_player_avplay/CHANGELOG.md
@@ -1,7 +1,8 @@
-## NEXT
+## 0.4.8
 
 * Call the open before calling the SetStreamingProperty.
 * Change getStreamingProperty API return type from StreamingPropertyMessage to String.
+* Add setStreamingProperty API.
 
 ## 0.4.7
 

--- a/packages/video_player_avplay/README.md
+++ b/packages/video_player_avplay/README.md
@@ -12,7 +12,7 @@ To use this package, add `video_player_avplay` as a dependency in your `pubspec.
 
 ```yaml
 dependencies:
-  video_player_avplay: ^0.4.7
+  video_player_avplay: ^0.4.8
 ```
 
 Then you can import `video_player_avplay` in your Dart code:

--- a/packages/video_player_avplay/lib/src/messages.g.dart
+++ b/packages/video_player_avplay/lib/src/messages.g.dart
@@ -390,6 +390,37 @@ class StreamingPropertyTypeMessage {
   }
 }
 
+class StreamingPropertyMessage {
+  StreamingPropertyMessage({
+    required this.playerId,
+    required this.streamingPropertyType,
+    required this.streamingPropertyValue,
+  });
+
+  int playerId;
+
+  String streamingPropertyType;
+
+  String streamingPropertyValue;
+
+  Object encode() {
+    return <Object?>[
+      playerId,
+      streamingPropertyType,
+      streamingPropertyValue,
+    ];
+  }
+
+  static StreamingPropertyMessage decode(Object result) {
+    result as List<Object?>;
+    return StreamingPropertyMessage(
+      playerId: result[0]! as int,
+      streamingPropertyType: result[1]! as String,
+      streamingPropertyValue: result[2]! as String,
+    );
+  }
+}
+
 class BufferConfigMessage {
   BufferConfigMessage({
     required this.playerId,
@@ -455,17 +486,20 @@ class _VideoPlayerAvplayApiCodec extends StandardMessageCodec {
     } else if (value is SelectedTracksMessage) {
       buffer.putUint8(137);
       writeValue(buffer, value.encode());
-    } else if (value is StreamingPropertyTypeMessage) {
+    } else if (value is StreamingPropertyMessage) {
       buffer.putUint8(138);
       writeValue(buffer, value.encode());
-    } else if (value is TrackMessage) {
+    } else if (value is StreamingPropertyTypeMessage) {
       buffer.putUint8(139);
       writeValue(buffer, value.encode());
-    } else if (value is TrackTypeMessage) {
+    } else if (value is TrackMessage) {
       buffer.putUint8(140);
       writeValue(buffer, value.encode());
-    } else if (value is VolumeMessage) {
+    } else if (value is TrackTypeMessage) {
       buffer.putUint8(141);
+      writeValue(buffer, value.encode());
+    } else if (value is VolumeMessage) {
+      buffer.putUint8(142);
       writeValue(buffer, value.encode());
     } else {
       super.writeValue(buffer, value);
@@ -496,12 +530,14 @@ class _VideoPlayerAvplayApiCodec extends StandardMessageCodec {
       case 137:
         return SelectedTracksMessage.decode(readValue(buffer)!);
       case 138:
-        return StreamingPropertyTypeMessage.decode(readValue(buffer)!);
+        return StreamingPropertyMessage.decode(readValue(buffer)!);
       case 139:
-        return TrackMessage.decode(readValue(buffer)!);
+        return StreamingPropertyTypeMessage.decode(readValue(buffer)!);
       case 140:
-        return TrackTypeMessage.decode(readValue(buffer)!);
+        return TrackMessage.decode(readValue(buffer)!);
       case 141:
+        return TrackTypeMessage.decode(readValue(buffer)!);
+      case 142:
         return VolumeMessage.decode(readValue(buffer)!);
       default:
         return super.readValueOfType(type, buffer);
@@ -998,6 +1034,29 @@ class VideoPlayerAvplayApi {
       );
     } else {
       return (replyList[0] as bool?)!;
+    }
+  }
+
+  Future<void> setStreamingProperty(StreamingPropertyMessage arg_msg) async {
+    final BasicMessageChannel<Object?> channel = BasicMessageChannel<Object?>(
+        'dev.flutter.pigeon.video_player_avplay.VideoPlayerAvplayApi.setStreamingProperty',
+        codec,
+        binaryMessenger: _binaryMessenger);
+    final List<Object?>? replyList =
+        await channel.send(<Object?>[arg_msg]) as List<Object?>?;
+    if (replyList == null) {
+      throw PlatformException(
+        code: 'channel-error',
+        message: 'Unable to establish connection on channel.',
+      );
+    } else if (replyList.length > 1) {
+      throw PlatformException(
+        code: replyList[0]! as String,
+        message: replyList[1] as String?,
+        details: replyList[2],
+      );
+    } else {
+      return;
     }
   }
 }

--- a/packages/video_player_avplay/lib/src/video_player_tizen.dart
+++ b/packages/video_player_avplay/lib/src/video_player_tizen.dart
@@ -206,11 +206,21 @@ class VideoPlayerTizen extends VideoPlayerPlatform {
   }
 
   @override
-  Future<bool> setBufferConfig(int playerId, BufferConfigType type, int value) {
+  Future<bool> setBufferConfig(
+      int playerId, BufferConfigType type, int value) async {
     return _api.setBufferConfig(BufferConfigMessage(
         playerId: playerId,
         bufferConfigType: _bufferConfigTypeMap[type]!,
         bufferConfigValue: value));
+  }
+
+  @override
+  Future<void> setStreamingProperty(
+      int playerId, StreamingPropertyType type, String value) async {
+    await _api.setStreamingProperty(StreamingPropertyMessage(
+        playerId: playerId,
+        streamingPropertyType: _streamingPropertyType[type]!,
+        streamingPropertyValue: value));
   }
 
   @override

--- a/packages/video_player_avplay/lib/video_player.dart
+++ b/packages/video_player_avplay/lib/video_player.dart
@@ -712,6 +712,17 @@ class VideoPlayerController extends ValueNotifier<VideoPlayerValue> {
     return _videoPlayerPlatform.getStreamingProperty(_playerId, type);
   }
 
+  /// Sets specific feature values for HTTP, MMS, or specific streaming engine (Smooth Streaming, HLS, DASH, DivX Plus Streaming, or Widevine).
+  /// The available streaming properties depend on the streaming protocol or engine.
+  /// Use the CUSTOM_MESSAGE property for streaming engine or CP-specific settings.
+  Future<void> setStreamingProperty(
+      StreamingPropertyType type, String value) async {
+    if (_isDisposedOrNotInitialized) {
+      return;
+    }
+    return _videoPlayerPlatform.setStreamingProperty(_playerId, type, value);
+  }
+
   /// Sets the buffer size for the play and resume scenarios. The time buffer size must be at least 4 seconds.
   /// For example, if a 10 second buffer size is set, playback can only start or resume after 10 seconds of media has accumulated in the buffer.
   /// Play scenarios include user-initiated streaming playback and whenever media playback is starting for the first time.

--- a/packages/video_player_avplay/lib/video_player_platform_interface.dart
+++ b/packages/video_player_avplay/lib/video_player_platform_interface.dart
@@ -144,6 +144,13 @@ abstract class VideoPlayerPlatform extends PlatformInterface {
     throw UnimplementedError('setBufferConfig() has not been implemented.');
   }
 
+  /// Set streamingengine property.
+  Future<void> setStreamingProperty(
+      int playerId, StreamingPropertyType type, String value) {
+    throw UnimplementedError(
+        'setStreamingProperty() has not been implemented.');
+  }
+
   /// Returns a widget displaying the video with a given playerId.
   Widget buildView(int playerId) {
     throw UnimplementedError('buildView() has not been implemented.');

--- a/packages/video_player_avplay/pigeons/messages.dart
+++ b/packages/video_player_avplay/pigeons/messages.dart
@@ -95,6 +95,14 @@ class StreamingPropertyTypeMessage {
   String streamingPropertyType;
 }
 
+class StreamingPropertyMessage {
+  StreamingPropertyMessage(
+      this.playerId, this.streamingPropertyType, this.streamingPropertyValue);
+  int playerId;
+  String streamingPropertyType;
+  String streamingPropertyValue;
+}
+
 class BufferConfigMessage {
   BufferConfigMessage(
       this.playerId, this.bufferConfigType, this.bufferConfigValue);
@@ -125,4 +133,5 @@ abstract class VideoPlayerAvplayApi {
   void setDisplayGeometry(GeometryMessage msg);
   String getStreamingProperty(StreamingPropertyTypeMessage msg);
   bool setBufferConfig(BufferConfigMessage msg);
+  void setStreamingProperty(StreamingPropertyMessage msg);
 }

--- a/packages/video_player_avplay/pubspec.yaml
+++ b/packages/video_player_avplay/pubspec.yaml
@@ -2,7 +2,7 @@ name: video_player_avplay
 description: Flutter plugin for displaying inline video on Tizen TV devices.
 homepage: https://github.com/flutter-tizen/plugins
 repository: https://github.com/flutter-tizen/plugins/tree/master/packages/video_player_avplay
-version: 0.4.7
+version: 0.4.8
 
 environment:
   sdk: ">=3.1.0 <4.0.0"

--- a/packages/video_player_avplay/tizen/src/messages.h
+++ b/packages/video_player_avplay/tizen/src/messages.h
@@ -389,6 +389,34 @@ class StreamingPropertyTypeMessage {
 };
 
 // Generated class from Pigeon that represents data sent in messages.
+class StreamingPropertyMessage {
+ public:
+  // Constructs an object setting all fields.
+  explicit StreamingPropertyMessage(
+      int64_t player_id, const std::string& streaming_property_type,
+      const std::string& streaming_property_value);
+
+  int64_t player_id() const;
+  void set_player_id(int64_t value_arg);
+
+  const std::string& streaming_property_type() const;
+  void set_streaming_property_type(std::string_view value_arg);
+
+  const std::string& streaming_property_value() const;
+  void set_streaming_property_value(std::string_view value_arg);
+
+ private:
+  static StreamingPropertyMessage FromEncodableList(
+      const flutter::EncodableList& list);
+  flutter::EncodableList ToEncodableList() const;
+  friend class VideoPlayerAvplayApi;
+  friend class VideoPlayerAvplayApiCodecSerializer;
+  int64_t player_id_;
+  std::string streaming_property_type_;
+  std::string streaming_property_value_;
+};
+
+// Generated class from Pigeon that represents data sent in messages.
 class BufferConfigMessage {
  public:
   // Constructs an object setting all fields.
@@ -465,6 +493,8 @@ class VideoPlayerAvplayApi {
   virtual ErrorOr<std::string> GetStreamingProperty(
       const StreamingPropertyTypeMessage& msg) = 0;
   virtual ErrorOr<bool> SetBufferConfig(const BufferConfigMessage& msg) = 0;
+  virtual std::optional<FlutterError> SetStreamingProperty(
+      const StreamingPropertyMessage& msg) = 0;
 
   // The codec used by VideoPlayerAvplayApi.
   static const flutter::StandardMessageCodec& GetCodec();

--- a/packages/video_player_avplay/tizen/src/plus_player.cc
+++ b/packages/video_player_avplay/tizen/src/plus_player.cc
@@ -96,8 +96,8 @@ int64_t PlusPlayer::Create(const std::string &uri,
   if (create_message.streaming_property() != nullptr &&
       !create_message.streaming_property()->empty()) {
     for (const auto &[key, value] : *create_message.streaming_property()) {
-      SetStreamingProp(std::get<std::string>(key),
-                       std::get<std::string>(value));
+      SetStreamingProperty(std::get<std::string>(key),
+                           std::get<std::string>(value));
     }
   }
 
@@ -597,8 +597,8 @@ bool PlusPlayer::SetBufferConfig(const std::string &key, int64_t value) {
   return ::SetBufferConfig(player_, config);
 }
 
-void PlusPlayer::SetStreamingProp(const std::string &type,
-                                  const std::string &value) {
+void PlusPlayer::SetStreamingProperty(const std::string &type,
+                                      const std::string &value) {
   if (!player_) {
     LOG_ERROR("[PlusPlayer] Player not created.");
     return;

--- a/packages/video_player_avplay/tizen/src/plus_player.cc
+++ b/packages/video_player_avplay/tizen/src/plus_player.cc
@@ -96,8 +96,8 @@ int64_t PlusPlayer::Create(const std::string &uri,
   if (create_message.streaming_property() != nullptr &&
       !create_message.streaming_property()->empty()) {
     for (const auto &[key, value] : *create_message.streaming_property()) {
-      SetStreamingProperty(player_, std::get<std::string>(key),
-                           std::get<std::string>(value));
+      SetStreamingProp(std::get<std::string>(key),
+                       std::get<std::string>(value));
     }
   }
 
@@ -595,6 +595,23 @@ bool PlusPlayer::SetBufferConfig(const std::string &key, int64_t value) {
   }
   const std::pair<std::string, int> config = std::make_pair(key, value);
   return ::SetBufferConfig(player_, config);
+}
+
+void PlusPlayer::SetStreamingProp(const std::string &type,
+                                  const std::string &value) {
+  if (!player_) {
+    LOG_ERROR("[PlusPlayer] Player not created.");
+    return;
+  }
+  plusplayer::State state = GetState(player_);
+  if (state == plusplayer::State::kNone) {
+    LOG_ERROR("[PlusPlayer]:Player is in invalid state[%d]", state);
+    return;
+  }
+
+  LOG_INFO("[PlusPlayer] SetStreamingProp: type[%s], value[%s]", type.c_str(),
+           value.c_str());
+  ::SetStreamingProperty(player_, type, value);
 }
 
 bool PlusPlayer::OnLicenseAcquired(int *drm_handle, unsigned int length,

--- a/packages/video_player_avplay/tizen/src/plus_player.cc
+++ b/packages/video_player_avplay/tizen/src/plus_player.cc
@@ -605,7 +605,7 @@ void PlusPlayer::SetStreamingProperty(const std::string &type,
   }
   plusplayer::State state = GetState(player_);
   if (state == plusplayer::State::kNone) {
-    LOG_ERROR("[PlusPlayer]:Player is in invalid state[%d]", state);
+    LOG_ERROR("[PlusPlayer] Player is in invalid state[%d]", state);
     return;
   }
 

--- a/packages/video_player_avplay/tizen/src/plus_player.h
+++ b/packages/video_player_avplay/tizen/src/plus_player.h
@@ -44,8 +44,8 @@ class PlusPlayer : public VideoPlayer {
   std::string GetStreamingProperty(
       const std::string &streaming_property_type) override;
   bool SetBufferConfig(const std::string &key, int64_t value) override;
-  void SetStreamingProp(const std::string &type,
-                        const std::string &value) override;
+  void SetStreamingProperty(const std::string &type,
+                            const std::string &value) override;
 
  private:
   bool IsLive();

--- a/packages/video_player_avplay/tizen/src/plus_player.h
+++ b/packages/video_player_avplay/tizen/src/plus_player.h
@@ -44,6 +44,8 @@ class PlusPlayer : public VideoPlayer {
   std::string GetStreamingProperty(
       const std::string &streaming_property_type) override;
   bool SetBufferConfig(const std::string &key, int64_t value) override;
+  void SetStreamingProp(const std::string &type,
+                        const std::string &value) override;
 
  private:
   bool IsLive();

--- a/packages/video_player_avplay/tizen/src/video_player.h
+++ b/packages/video_player_avplay/tizen/src/video_player.h
@@ -56,6 +56,9 @@ class VideoPlayer {
     return false;
   };
 
+  virtual void SetStreamingProp(const std::string &type,
+                                const std::string &value){};
+
  protected:
   virtual void GetVideoSize(int32_t *width, int32_t *height) = 0;
   void *GetWindowHandle();

--- a/packages/video_player_avplay/tizen/src/video_player.h
+++ b/packages/video_player_avplay/tizen/src/video_player.h
@@ -56,8 +56,8 @@ class VideoPlayer {
     return false;
   };
 
-  virtual void SetStreamingProp(const std::string &type,
-                                const std::string &value){};
+  virtual void SetStreamingProperty(const std::string &type,
+                                    const std::string &value){};
 
  protected:
   virtual void GetVideoSize(int32_t *width, int32_t *height) = 0;

--- a/packages/video_player_avplay/tizen/src/video_player_tizen_plugin.cc
+++ b/packages/video_player_avplay/tizen/src/video_player_tizen_plugin.cc
@@ -329,8 +329,8 @@ std::optional<FlutterError> VideoPlayerTizenPlugin::SetStreamingProperty(
   if (!player) {
     return FlutterError("Invalid argument", "Player not found");
   }
-  player->SetStreamingProp(msg.streaming_property_type(),
-                           msg.streaming_property_value());
+  player->SetStreamingProperty(msg.streaming_property_type(),
+                               msg.streaming_property_value());
   return std::nullopt;
 }
 

--- a/packages/video_player_avplay/tizen/src/video_player_tizen_plugin.cc
+++ b/packages/video_player_avplay/tizen/src/video_player_tizen_plugin.cc
@@ -58,6 +58,8 @@ class VideoPlayerTizenPlugin : public flutter::Plugin,
   ErrorOr<std::string> GetStreamingProperty(
       const StreamingPropertyTypeMessage &msg) override;
   ErrorOr<bool> SetBufferConfig(const BufferConfigMessage &msg) override;
+  std::optional<FlutterError> SetStreamingProperty(
+      const StreamingPropertyMessage &msg) override;
 
   static VideoPlayer *FindPlayerById(int64_t player_id) {
     auto iter = players_.find(player_id);
@@ -319,6 +321,17 @@ ErrorOr<bool> VideoPlayerTizenPlugin::SetBufferConfig(
   }
   return player->SetBufferConfig(msg.buffer_config_type(),
                                  msg.buffer_config_value());
+}
+
+std::optional<FlutterError> VideoPlayerTizenPlugin::SetStreamingProperty(
+    const StreamingPropertyMessage &msg) {
+  VideoPlayer *player = FindPlayerById(msg.player_id());
+  if (!player) {
+    return FlutterError("Invalid argument", "Player not found");
+  }
+  player->SetStreamingProp(msg.streaming_property_type(),
+                           msg.streaming_property_value());
+  return std::nullopt;
 }
 
 std::optional<FlutterError> VideoPlayerTizenPlugin::SetMixWithOthers(


### PR DESCRIPTION
Add setStreamingProperty API:

```dart
  /// Sets specific feature values for HTTP, MMS, or specific streaming engine (Smooth Streaming, HLS, DASH, DivX Plus Streaming, or Widevine).
  /// The available streaming properties depend on the streaming protocol or engine.
  /// Use the CUSTOM_MESSAGE property for streaming engine or CP-specific settings.
  Future<void> setStreamingProperty(StreamingPropertyType type, String value) ;
```
Native interface:
```C++
/**
   * @brief     Set streamingengine property
   * @param     [in] type : attribute type. \n
   *             type can be \n
   *               "COOKIE" \n
   *               "USER_AGENT" \n
   *               "RESUME_TIME" \n
   *               "ADAPTIVE_INFO"
   * @param     [in] value : value of attribute type
   * @pre       The player state can be all of #State except #State::kNone
   */
  virtual void SetStreamingProperty(const std::string& type,
                                    const std::string& value)
```
