### PR TITLE
[google_maps_flutter] Add temporary code to prevent errors

### DIFF
--- a/packages/google_maps_flutter/lib/src/google_maps_flutter_tizen.dart
+++ b/packages/google_maps_flutter/lib/src/google_maps_flutter_tizen.dart
@@ -102,6 +102,22 @@ class GoogleMapsPlugin extends GoogleMapsFlutterPlatform {
   }
 
   @override
+  Future<void> updateHeatmaps(
+    HeatmapUpdates heatmapUpdates, {
+    required int mapId,
+  }) async {
+    return; // Noop for now!
+  }
+
+  @override
+  Future<void> updateClusterManagers(
+    ClusterManagerUpdates clusterManagerUpdates, {
+    required int mapId,
+  }) async {
+    return; // Noop for now!
+  }
+
+  @override
   Future<void> clearTileCache(
     TileOverlayId tileOverlayId, {
     required int mapId,
@@ -282,6 +298,11 @@ class GoogleMapsPlugin extends GoogleMapsFlutterPlatform {
   @override
   Stream<MapLongPressEvent> onLongPress({required int mapId}) {
     return _events(mapId).whereType<MapLongPressEvent>();
+  }
+
+  @override
+  Stream<ClusterTapEvent> onClusterTap({required int mapId}) {
+    return _events(mapId).whereType<ClusterTapEvent>();
   }
 
   /// Disposes of the current map. It can't be used afterwards!

--- a/packages/google_maps_flutter/pubspec.yaml
+++ b/packages/google_maps_flutter/pubspec.yaml
@@ -20,4 +20,4 @@ dependencies:
   google_maps_flutter_platform_interface: ^2.7.0
   stream_transform: ^2.0.0
   webview_flutter: ^4.4.2
-  webview_flutter_lwe: ^0.3.2
+  webview_flutter_lwe: ^0.3.3


### PR DESCRIPTION
google_maps_flutter plugin was updated to 2.9.0 and new APIs were also added. Due to this, Unimplemented Error and Crash occur.
Therefore, temporary code is added to prevent these errors until implementation. (In addition, this commit must be merged after webview_flutter_lwe 0.3.3 is applied)