### PR TITLE
[video_player_avplay] Fix getAudioTracks out of bounds issue

### DIFF
--- a/packages/video_player_avplay/CHANGELOG.md
+++ b/packages/video_player_avplay/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.5.1
+
+* Fix getVideoTracks out of bounds issue.
+
 ## 0.5.0
 
 * Fix DashEngine crash issue.

--- a/packages/video_player_avplay/README.md
+++ b/packages/video_player_avplay/README.md
@@ -12,7 +12,7 @@ To use this package, add `video_player_avplay` as a dependency in your `pubspec.
 
 ```yaml
 dependencies:
-  video_player_avplay: ^0.5.0
+  video_player_avplay: ^0.5.1
 ```
 
 Then you can import `video_player_avplay` in your Dart code:

--- a/packages/video_player_avplay/lib/src/tracks.dart
+++ b/packages/video_player_avplay/lib/src/tracks.dart
@@ -14,18 +14,6 @@ enum TrackType {
   text,
 }
 
-/// Type of the track audio channel for [TrackType.audio].
-enum AudioTrackChannelType {
-  /// The mono channel.
-  mono,
-
-  /// The stereo channel.
-  stereo,
-
-  /// The surround channel.
-  surround,
-}
-
 /// Type of the track subtitle type for [TrackType.text].
 enum TextTrackSubtitleType {
   /// The text subtitle.
@@ -99,7 +87,7 @@ class AudioTrack extends Track {
   final String language;
 
   /// The channel of audio track.
-  final AudioTrackChannelType channel;
+  final int channel;
 
   /// The bitrate of audio track.
   final int bitrate;

--- a/packages/video_player_avplay/lib/src/video_player_tizen.dart
+++ b/packages/video_player_avplay/lib/src/video_player_tizen.dart
@@ -137,14 +137,13 @@ class VideoPlayerTizen extends VideoPlayerPlatform {
     for (final Map<Object?, Object?>? trackMap in response.tracks) {
       final int trackId = trackMap!['trackId']! as int;
       final String language = trackMap['language']! as String;
-      final AudioTrackChannelType channelType =
-          _intChannelTypeMap[trackMap['channel']]!;
+      final int channel = trackMap['channel']! as int;
       final int bitrate = trackMap['bitrate']! as int;
 
       audioTracks.add(AudioTrack(
         trackId: trackId,
         language: language,
-        channel: channelType,
+        channel: channel,
         bitrate: bitrate,
       ));
     }
@@ -304,13 +303,6 @@ class VideoPlayerTizen extends VideoPlayerPlatform {
     VideoFormat.hls: 'hls',
     VideoFormat.dash: 'dash',
     VideoFormat.other: 'other',
-  };
-
-  static const Map<int, AudioTrackChannelType> _intChannelTypeMap =
-      <int, AudioTrackChannelType>{
-    1: AudioTrackChannelType.mono,
-    2: AudioTrackChannelType.stereo,
-    3: AudioTrackChannelType.surround,
   };
 
   static const Map<StreamingPropertyType, String> _streamingPropertyType =

--- a/packages/video_player_avplay/pubspec.yaml
+++ b/packages/video_player_avplay/pubspec.yaml
@@ -2,7 +2,7 @@ name: video_player_avplay
 description: Flutter plugin for displaying inline video on Tizen TV devices.
 homepage: https://github.com/flutter-tizen/plugins
 repository: https://github.com/flutter-tizen/plugins/tree/master/packages/video_player_avplay
-version: 0.5.0
+version: 0.5.1
 
 environment:
   sdk: ">=3.1.0 <4.0.0"


### PR DESCRIPTION
Checked with MM team, the audio track channel range is 2 ~ 12, the AudioTrackChannelType is not suitable for use here, so return channel directly.
```dart
enum AudioTrackChannelType {
  /// The mono channel.
  mono,

  /// The stereo channel.
  stereo,

  /// The surround channel.
  surround,
}

```
