### PR TITLE
[video_player] Support httpHeaders option of VideoPlayerController.network

### DIFF
--- a/packages/video_player/CHANGELOG.md
+++ b/packages/video_player/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.5.3
+
+* Support `httpHeaders` option of `VideoPlayerController.network`.
+
 ## 2.5.2
 
 * Live streaming content starts playing immediately when SeekTo() is called.

--- a/packages/video_player/README.md
+++ b/packages/video_player/README.md
@@ -48,14 +48,14 @@ For detailed information on Tizen privileges, see [Tizen Docs: API Privileges](h
 
 This plugin is not supported on TV emulators.
 
-The following options are not supported on Tizen.
+The following options are not currently supported.
 
-- The `httpHeaders` option of `VideoPlayerController.networkUrl`
 - `VideoPlayerOptions.allowBackgroundPlayback`
 - `VideoPlayerOptions.mixWithOthers`
 
-This plugin has some limitations on TV devices.
+This plugin has the following limitations.
 
+- The `httpHeaders` option of `VideoPlayerController.networkUrl` only support `Cookie` and `User-Agent`.
 - The `setPlaybackSpeed` method will fail if triggered within the last 3 seconds of the video.
 - The playback speed will reset to 1.0 when the video is replayed in loop mode.
 - The `seekTo` method works only when the playback speed is 1.0, and it sets the video position to the nearest keyframe, not the exact value passed.

--- a/packages/video_player/pubspec.yaml
+++ b/packages/video_player/pubspec.yaml
@@ -2,7 +2,7 @@ name: video_player_tizen
 description: Tizen implementation of the video_player plugin.
 homepage: https://github.com/flutter-tizen/plugins
 repository: https://github.com/flutter-tizen/plugins/tree/master/packages/video_player
-version: 2.5.2
+version: 2.5.3
 
 environment:
   sdk: ">=3.3.0 <4.0.0"

--- a/packages/video_player/tizen/src/video_player.h
+++ b/packages/video_player/tizen/src/video_player.h
@@ -30,7 +30,8 @@ class VideoPlayer {
 
   explicit VideoPlayer(flutter::PluginRegistrar *plugin_registrar,
                        flutter::TextureRegistrar *texture_registrar,
-                       const std::string &uri, VideoPlayerOptions &options);
+                       const std::string &uri, VideoPlayerOptions &options,
+                       flutter::EncodableMap &http_headers);
   ~VideoPlayer();
 
   void Play();

--- a/packages/video_player/tizen/src/video_player_tizen_plugin.cc
+++ b/packages/video_player/tizen/src/video_player_tizen_plugin.cc
@@ -5,6 +5,7 @@
 #include "video_player_tizen_plugin.h"
 
 #include <app_common.h>
+#include <flutter/encodable_value.h>
 #include <flutter/plugin_registrar.h>
 
 #include <cstdint>
@@ -84,6 +85,8 @@ std::optional<FlutterError> VideoPlayerTizenPlugin::Initialize() {
 ErrorOr<TextureMessage> VideoPlayerTizenPlugin::Create(
     const CreateMessage &msg) {
   std::string uri;
+  flutter::EncodableMap http_headers = {};
+
   if (msg.asset() && !msg.asset()->empty()) {
     char *res_path = app_get_resource_path();
     if (res_path) {
@@ -94,6 +97,11 @@ ErrorOr<TextureMessage> VideoPlayerTizenPlugin::Create(
     }
   } else if (msg.uri() && !msg.uri()->empty()) {
     uri = *msg.uri();
+
+    const flutter::EncodableMap &http_headers_map = msg.http_headers();
+    if (!http_headers_map.empty()) {
+      http_headers = http_headers_map;
+    }
   } else {
     return FlutterError("Invalid argument", "Either asset or uri must be set.");
   }
@@ -102,7 +110,7 @@ ErrorOr<TextureMessage> VideoPlayerTizenPlugin::Create(
   int64_t texture_id = 0;
   try {
     auto player = std::make_unique<VideoPlayer>(
-        plugin_registrar_, texture_registrar_, uri, options_);
+        plugin_registrar_, texture_registrar_, uri, options_, http_headers);
     texture_id = player->GetTextureId();
     players_[texture_id] = std::move(player);
   } catch (const VideoPlayerError &error) {


### PR DESCRIPTION
Only support [`Cookie`](https://docs.tizen.org/application/native/api/common/8.0/group__CAPI__MEDIA__PLAYER__STREAMING__MODULE.html#ga47e7c7488b68d522a20cd8853096a339) and [`User-Agent`](https://docs.tizen.org/application/native/api/common/8.0/group__CAPI__MEDIA__PLAYER__STREAMING__MODULE.html#ga4e4bbf1511b9a7c560313ccf2f465cf0).