### PR TITLE
[video_player_videohole] Fix getAudioTracks out of bounds issue

### DIFF
--- a/packages/video_player_videohole/CHANGELOG.md
+++ b/packages/video_player_videohole/CHANGELOG.md
@@ -1,7 +1,8 @@
-## NEXT
+## 0.5.2
 
 * Fix new lint warnings.
 * Update minimum Flutter and Dart version to 3.13 and 3.1.
+* Fix getAudioTracks out of bounds issue.
 
 ## 0.5.1
 

--- a/packages/video_player_videohole/README.md
+++ b/packages/video_player_videohole/README.md
@@ -12,7 +12,7 @@ To use this package, add `video_player_videohole` as a dependency in your `pubsp
 
 ```yaml
 dependencies:
-  video_player_videohole: ^0.5.1
+  video_player_videohole: ^0.5.2
 ```
 
 Then you can import `video_player_videohole` in your Dart code:

--- a/packages/video_player_videohole/lib/src/tracks.dart
+++ b/packages/video_player_videohole/lib/src/tracks.dart
@@ -14,18 +14,6 @@ enum TrackType {
   text,
 }
 
-/// Type of the track audio channel for [TrackType.audio].
-enum AudioTrackChannelType {
-  /// The mono channel.
-  mono,
-
-  /// The stereo channel.
-  stereo,
-
-  /// The surround channel.
-  surround,
-}
-
 /// Type of the track subtitle type for [TrackType.text].
 enum TextTrackSubtitleType {
   /// The text subtitle.
@@ -99,7 +87,7 @@ class AudioTrack extends Track {
   final String language;
 
   /// The channel of audio track.
-  final AudioTrackChannelType channel;
+  final int channel;
 
   /// The bitrate of audio track.
   final int bitrate;

--- a/packages/video_player_videohole/lib/src/video_player_tizen.dart
+++ b/packages/video_player_videohole/lib/src/video_player_tizen.dart
@@ -132,14 +132,13 @@ class VideoPlayerTizen extends VideoPlayerPlatform {
     for (final Map<Object?, Object?>? trackMap in response.tracks) {
       final int trackId = trackMap!['trackId']! as int;
       final String language = trackMap['language']! as String;
-      final AudioTrackChannelType channelType =
-          _intChannelTypeMap[trackMap['channel']]!;
+      final int channel = trackMap['channel']! as int;
       final int bitrate = trackMap['bitrate']! as int;
 
       audioTracks.add(AudioTrack(
         trackId: trackId,
         language: language,
-        channel: channelType,
+        channel: channel,
         bitrate: bitrate,
       ));
     }
@@ -273,12 +272,5 @@ class VideoPlayerTizen extends VideoPlayerPlatform {
     VideoFormat.hls: 'hls',
     VideoFormat.dash: 'dash',
     VideoFormat.other: 'other',
-  };
-
-  static const Map<int, AudioTrackChannelType> _intChannelTypeMap =
-      <int, AudioTrackChannelType>{
-    1: AudioTrackChannelType.mono,
-    2: AudioTrackChannelType.stereo,
-    3: AudioTrackChannelType.surround,
   };
 }

--- a/packages/video_player_videohole/pubspec.yaml
+++ b/packages/video_player_videohole/pubspec.yaml
@@ -2,7 +2,7 @@ name: video_player_videohole
 description: Flutter plugin for displaying inline video on Tizen TV devices.
 homepage: https://github.com/flutter-tizen/plugins
 repository: https://github.com/flutter-tizen/plugins/tree/master/packages/video_player_videohole
-version: 0.5.1
+version: 0.5.2
 
 environment:
   sdk: ">=3.1.0 <4.0.0"


### PR DESCRIPTION
Checked with MM team, the audio track channel range is 2 ~ 12, the AudioTrackChannelType is not suitable for use here, so return channel directly.
```dart
enum AudioTrackChannelType {
  /// The mono channel.
  mono,

  /// The stereo channel.
  stereo,

  /// The surround channel.
  surround,
}

```