### PR TITLE
[path_provider] Update path_provider to 2.1.4

### DIFF
--- a/packages/path_provider/CHANGELOG.md
+++ b/packages/path_provider/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 2.2.0
+
+* Update path_provider to 2.1.4.
+* Update path_provider_platform_interface to 2.1.2.
+* Adds getApplicationCachePath() for storing app-specific cache files.
+* Update minimum Flutter and Dart version to 3.19 and 3.3.
+
 ## 2.1.1
 
 * Fix new lint warnings.

--- a/packages/path_provider/README.md
+++ b/packages/path_provider/README.md
@@ -10,8 +10,8 @@ This package is not an _endorsed_ implementation of `path_provider`. Therefore, 
 
 ```yaml
 dependencies:
-  path_provider: ^2.0.7
-  path_provider_tizen: ^2.1.1
+  path_provider: ^2.1.4
+  path_provider_tizen: ^2.2.0
 ```
 
 Then you can import `path_provider` in your Dart code:
@@ -28,6 +28,7 @@ For detailed usage, see https://pub.dev/packages/path_provider#usage.
 - [x] `getApplicationSupportDirectory` (returns the app's data directory path)
 - [ ] `getLibraryDirectory` (iOS-only)
 - [x] `getApplicationDocumentsDirectory` (returns the app's data directory path)
+- [x] `getApplicationCachePath` (returns the app's cache directory path)
 - [x] `getExternalStorageDirectory` (requires an SD card)
 - [x] `getExternalCacheDirectories` (requires an SD card)
 - [x] `getExternalStorageDirectories` (returns shared media library paths such as `/home/owner/media/Music`)

--- a/packages/path_provider/example/lib/main.dart
+++ b/packages/path_provider/example/lib/main.dart
@@ -41,6 +41,7 @@ class _MyHomePageState extends State<MyHomePage> {
   Future<Directory?>? _appSupportDirectory;
   Future<Directory?>? _appLibraryDirectory;
   Future<Directory?>? _appDocumentsDirectory;
+  Future<Directory?>? _appCacheDirectory;
   Future<Directory?>? _externalDocumentsDirectory;
   Future<List<Directory>?>? _externalStorageDirectories;
   Future<List<Directory>?>? _externalCacheDirectories;
@@ -99,6 +100,12 @@ class _MyHomePageState extends State<MyHomePage> {
   void _requestAppLibraryDirectory() {
     setState(() {
       _appLibraryDirectory = getLibraryDirectory();
+    });
+  }
+
+  void _requestAppCacheDirectory() {
+    setState(() {
+      _appCacheDirectory = getApplicationCacheDirectory();
     });
   }
 
@@ -202,6 +209,23 @@ class _MyHomePageState extends State<MyHomePage> {
                 ),
                 FutureBuilder<Directory?>(
                   future: _appLibraryDirectory,
+                  builder: _buildDirectory,
+                ),
+              ],
+            ),
+            Column(
+              children: <Widget>[
+                Padding(
+                  padding: const EdgeInsets.all(16.0),
+                  child: ElevatedButton(
+                    onPressed: _requestAppCacheDirectory,
+                    child: const Text(
+                      'Get Application Cache Directory',
+                    ),
+                  ),
+                ),
+                FutureBuilder<Directory?>(
+                  future: _appCacheDirectory,
                   builder: _buildDirectory,
                 ),
               ],

--- a/packages/path_provider/example/pubspec.yaml
+++ b/packages/path_provider/example/pubspec.yaml
@@ -3,13 +3,13 @@ description: Demonstrates how to use the path_provider_tizen plugin.
 publish_to: "none"
 
 environment:
-  sdk: ">=3.1.0 <4.0.0"
-  flutter: ">=3.13.0"
+  sdk: ^3.3.0
+  flutter: ">=3.19.0"
 
 dependencies:
   flutter:
     sdk: flutter
-  path_provider: ^2.0.7
+  path_provider: ^2.1.4
   path_provider_tizen:
     path: ../
 

--- a/packages/path_provider/lib/path_provider_tizen.dart
+++ b/packages/path_provider/lib/path_provider_tizen.dart
@@ -23,6 +23,9 @@ class PathProviderPlugin extends PathProviderPlatform {
   Future<String> getApplicationDocumentsPath() async => appCommon.getDataPath();
 
   @override
+  Future<String> getApplicationCachePath() async => appCommon.getCachePath();
+
+  @override
   Future<String> getApplicationSupportPath() async => appCommon.getDataPath();
 
   @override

--- a/packages/path_provider/pubspec.yaml
+++ b/packages/path_provider/pubspec.yaml
@@ -2,11 +2,11 @@ name: path_provider_tizen
 description: Tizen implementation of the path_provider plugin.
 homepage: https://github.com/flutter-tizen/plugins
 repository: https://github.com/flutter-tizen/plugins/tree/master/packages/path_provider
-version: 2.1.1
+version: 2.2.0
 
 environment:
-  sdk: ">=3.1.0 <4.0.0"
-  flutter: ">=3.13.0"
+  sdk: ^3.3.0
+  flutter: ">=3.19.0"
 
 flutter:
   plugin:
@@ -18,5 +18,5 @@ dependencies:
   ffi: ^2.0.1
   flutter:
     sdk: flutter
-  path_provider_platform_interface: ^2.0.1
+  path_provider_platform_interface: ^2.1.2
   tizen_interop: ^0.3.0


### PR DESCRIPTION
* Update path_provider to 2.1.4.
* Update path_provider_platform_interface to 2.1.2.
* Adds getApplicationCachePath() for storing app-specific cache files.
* Update minimum Flutter and Dart version to 3.19 and 3.3.