### PR TITLE
[video_player_avplay] Add start position in player options when creating player

### DIFF
--- a/packages/video_player_avplay/CHANGELOG.md
+++ b/packages/video_player_avplay/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.5.2
+
+* Add start position in player options when creating player. This is useful for resuming playback from last viewed position.
+
 ## 0.5.1
 
 * Fix getVideoTracks out of bounds issue.

--- a/packages/video_player_avplay/README.md
+++ b/packages/video_player_avplay/README.md
@@ -12,7 +12,7 @@ To use this package, add `video_player_avplay` as a dependency in your `pubspec.
 
 ```yaml
 dependencies:
-  video_player_avplay: ^0.5.1
+  video_player_avplay: ^0.5.2
 ```
 
 Then you can import `video_player_avplay` in your Dart code:

--- a/packages/video_player_avplay/pubspec.yaml
+++ b/packages/video_player_avplay/pubspec.yaml
@@ -2,7 +2,7 @@ name: video_player_avplay
 description: Flutter plugin for displaying inline video on Tizen TV devices.
 homepage: https://github.com/flutter-tizen/plugins
 repository: https://github.com/flutter-tizen/plugins/tree/master/packages/video_player_avplay
-version: 0.5.1
+version: 0.5.2
 
 environment:
   sdk: ">=3.1.0 <4.0.0"

--- a/packages/video_player_avplay/tizen/src/plus_player.cc
+++ b/packages/video_player_avplay/tizen/src/plus_player.cc
@@ -141,7 +141,9 @@ int64_t PlusPlayer::Create(const std::string &uri,
       create_message.player_options(), "startPosition", 0);
   if (start_position > 0) {
     LOG_INFO("[PlusPlayer] Start position: %lld", start_position);
-    Seek(player_, start_position);
+    if (!Seek(player_, start_position)) {
+      LOG_INFO("[PlusPlayer] Fail to seek, it's a non-seekable content");
+    }
   }
 
   if (!PrepareAsync(player_)) {

--- a/packages/video_player_avplay/tizen/src/plus_player.cc
+++ b/packages/video_player_avplay/tizen/src/plus_player.cc
@@ -137,6 +137,13 @@ int64_t PlusPlayer::Create(const std::string &uri,
     is_prebuffer_mode_ = true;
   }
 
+  int64_t start_position = flutter_common::GetValue(
+      create_message.player_options(), "startPosition", 0);
+  if (start_position > 0) {
+    LOG_INFO("[PlusPlayer] Start position: %lld", start_position);
+    Seek(player_, start_position);
+  }
+
   if (!PrepareAsync(player_)) {
     LOG_ERROR("[PlusPlayer] Player fail to prepare.");
     return -1;


### PR DESCRIPTION
Add start position in player options when creating player,this is useful for resuming playback from last viewed position.
code sample:
```dart
    _controller = VideoPlayerController.network(
        'https://media.w3.org/2010/05/bunny/trailer.mp4',
         // startPosition in millisecond
        playerOptions: {'startPosition': 10 * 1000});
```