### PR TITLE
Change Tizen.NET API version of example apps to tizen80

### DIFF
--- a/packages/audioplayers/example/tizen/Runner.csproj
+++ b/packages/audioplayers/example/tizen/Runner.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>tizen40</TargetFramework>
+    <TargetFramework>tizen80</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/packages/battery_plus/example/tizen/Runner.csproj
+++ b/packages/battery_plus/example/tizen/Runner.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>tizen40</TargetFramework>
+    <TargetFramework>tizen80</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/packages/camera/example/tizen/Runner.csproj
+++ b/packages/camera/example/tizen/Runner.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>tizen40</TargetFramework>
+    <TargetFramework>tizen80</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/packages/connectivity_plus/example/tizen/Runner.csproj
+++ b/packages/connectivity_plus/example/tizen/Runner.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>tizen40</TargetFramework>
+    <TargetFramework>tizen80</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/packages/device_info_plus/example/tizen/Runner.csproj
+++ b/packages/device_info_plus/example/tizen/Runner.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>tizen40</TargetFramework>
+    <TargetFramework>tizen80</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/packages/firebase_core/example/tizen/Runner.csproj
+++ b/packages/firebase_core/example/tizen/Runner.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>tizen40</TargetFramework>
+    <TargetFramework>tizen80</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/packages/flutter_app_badger/example/tizen/Runner.csproj
+++ b/packages/flutter_app_badger/example/tizen/Runner.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>tizen40</TargetFramework>
+    <TargetFramework>tizen80</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/packages/flutter_secure_storage/example/tizen/Runner.csproj
+++ b/packages/flutter_secure_storage/example/tizen/Runner.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>tizen40</TargetFramework>
+    <TargetFramework>tizen80</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/packages/flutter_tts/example/tizen/Runner.csproj
+++ b/packages/flutter_tts/example/tizen/Runner.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>tizen40</TargetFramework>
+    <TargetFramework>tizen80</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/packages/flutter_webrtc/example/flutter_webrtc_demo/tizen/Runner.csproj
+++ b/packages/flutter_webrtc/example/flutter_webrtc_demo/tizen/Runner.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>tizen40</TargetFramework>
+    <TargetFramework>tizen80</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/packages/flutter_webrtc/example/flutter_webrtc_example/tizen/Runner.csproj
+++ b/packages/flutter_webrtc/example/flutter_webrtc_example/tizen/Runner.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>tizen40</TargetFramework>
+    <TargetFramework>tizen80</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/packages/geolocator/example/tizen/Runner.csproj
+++ b/packages/geolocator/example/tizen/Runner.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>tizen40</TargetFramework>
+    <TargetFramework>tizen80</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/packages/google_maps_flutter/example/tizen/Runner.csproj
+++ b/packages/google_maps_flutter/example/tizen/Runner.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>tizen40</TargetFramework>
+    <TargetFramework>tizen80</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/packages/google_sign_in/example/tizen/Runner.csproj
+++ b/packages/google_sign_in/example/tizen/Runner.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>tizen40</TargetFramework>
+    <TargetFramework>tizen80</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/packages/image_picker/example/tizen/Runner.csproj
+++ b/packages/image_picker/example/tizen/Runner.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>tizen40</TargetFramework>
+    <TargetFramework>tizen80</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/packages/in_app_purchase/example/tizen/Runner.csproj
+++ b/packages/in_app_purchase/example/tizen/Runner.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>tizen40</TargetFramework>
+    <TargetFramework>tizen80</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/packages/integration_test/example/tizen/Runner.csproj
+++ b/packages/integration_test/example/tizen/Runner.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>tizen40</TargetFramework>
+    <TargetFramework>tizen80</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/packages/messageport/example/tizen/Runner.csproj
+++ b/packages/messageport/example/tizen/Runner.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>tizen40</TargetFramework>
+    <TargetFramework>tizen80</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/packages/network_info_plus/example/tizen/Runner.csproj
+++ b/packages/network_info_plus/example/tizen/Runner.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>tizen40</TargetFramework>
+    <TargetFramework>tizen80</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/packages/package_info_plus/example/tizen/Runner.csproj
+++ b/packages/package_info_plus/example/tizen/Runner.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>tizen40</TargetFramework>
+    <TargetFramework>tizen80</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/packages/path_provider/example/tizen/Runner.csproj
+++ b/packages/path_provider/example/tizen/Runner.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>tizen40</TargetFramework>
+    <TargetFramework>tizen80</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/packages/permission_handler/example/tizen/Runner.csproj
+++ b/packages/permission_handler/example/tizen/Runner.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>tizen40</TargetFramework>
+    <TargetFramework>tizen80</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/packages/sensors_plus/example/tizen/Runner.csproj
+++ b/packages/sensors_plus/example/tizen/Runner.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>tizen40</TargetFramework>
+    <TargetFramework>tizen80</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/packages/shared_preferences/example/tizen/Runner.csproj
+++ b/packages/shared_preferences/example/tizen/Runner.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>tizen40</TargetFramework>
+    <TargetFramework>tizen80</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/packages/sqflite/example/tizen/Runner.csproj
+++ b/packages/sqflite/example/tizen/Runner.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>tizen40</TargetFramework>
+    <TargetFramework>tizen80</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/packages/tizen_app_control/example/tizen/service/RunnerService.csproj
+++ b/packages/tizen_app_control/example/tizen/service/RunnerService.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>tizen40</TargetFramework>
+    <TargetFramework>tizen80</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/packages/tizen_app_control/example/tizen/ui/Runner.csproj
+++ b/packages/tizen_app_control/example/tizen/ui/Runner.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>tizen40</TargetFramework>
+    <TargetFramework>tizen80</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/packages/tizen_app_manager/example/tizen/Runner.csproj
+++ b/packages/tizen_app_manager/example/tizen/Runner.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>tizen40</TargetFramework>
+    <TargetFramework>tizen80</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/packages/tizen_audio_manager/example/tizen/Runner.csproj
+++ b/packages/tizen_audio_manager/example/tizen/Runner.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>tizen40</TargetFramework>
+    <TargetFramework>tizen80</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/packages/tizen_bundle/example/tizen/Runner.csproj
+++ b/packages/tizen_bundle/example/tizen/Runner.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>tizen40</TargetFramework>
+    <TargetFramework>tizen80</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/packages/tizen_log/example/tizen/Runner.csproj
+++ b/packages/tizen_log/example/tizen/Runner.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>tizen40</TargetFramework>
+    <TargetFramework>tizen80</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/packages/tizen_notification/example/tizen/Runner.csproj
+++ b/packages/tizen_notification/example/tizen/Runner.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>tizen40</TargetFramework>
+    <TargetFramework>tizen80</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/packages/tizen_package_manager/example/tizen/Runner.csproj
+++ b/packages/tizen_package_manager/example/tizen/Runner.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>tizen40</TargetFramework>
+    <TargetFramework>tizen80</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/packages/tizen_rpc_port/example/client/tizen/Runner.csproj
+++ b/packages/tizen_rpc_port/example/client/tizen/Runner.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>tizen40</TargetFramework>
+    <TargetFramework>tizen80</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/packages/tizen_rpc_port/example/server/tizen/Runner.csproj
+++ b/packages/tizen_rpc_port/example/server/tizen/Runner.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>tizen40</TargetFramework>
+    <TargetFramework>tizen80</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/packages/url_launcher/example/tizen/Runner.csproj
+++ b/packages/url_launcher/example/tizen/Runner.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>tizen40</TargetFramework>
+    <TargetFramework>tizen80</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/packages/video_player/example/tizen/Runner.csproj
+++ b/packages/video_player/example/tizen/Runner.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>tizen40</TargetFramework>
+    <TargetFramework>tizen80</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/packages/video_player_avplay/example/tizen/Runner.csproj
+++ b/packages/video_player_avplay/example/tizen/Runner.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>tizen40</TargetFramework>
+    <TargetFramework>tizen80</TargetFramework>
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/packages/video_player_videohole/example/tizen/Runner.csproj
+++ b/packages/video_player_videohole/example/tizen/Runner.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>tizen40</TargetFramework>
+    <TargetFramework>tizen80</TargetFramework>
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/packages/wakelock_plus/example/tizen/Runner.csproj
+++ b/packages/wakelock_plus/example/tizen/Runner.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>tizen40</TargetFramework>
+    <TargetFramework>tizen80</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/packages/wearable_rotary/example/tizen/Runner.csproj
+++ b/packages/wearable_rotary/example/tizen/Runner.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>tizen40</TargetFramework>
+    <TargetFramework>tizen80</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/packages/webview_flutter/example/tizen/Runner.csproj
+++ b/packages/webview_flutter/example/tizen/Runner.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>tizen40</TargetFramework>
+    <TargetFramework>tizen80</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/packages/webview_flutter_lwe/example/tizen/Runner.csproj
+++ b/packages/webview_flutter_lwe/example/tizen/Runner.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>tizen40</TargetFramework>
+    <TargetFramework>tizen80</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tools/test_data/foo/example/tizen/Runner.csproj
+++ b/tools/test_data/foo/example/tizen/Runner.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>tizen40</TargetFramework>
+    <TargetFramework>tizen80</TargetFramework>
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">


### PR DESCRIPTION
flutter-tizen supports Tizen 6.0 or higher. Therefore, update the Tizen.NET API version.
(The [TargetFramework](https://github.com/Samsung/TizenFX) for Tizen 6.0 is tizen80.)
