### PR TITLE
[audioplayers] Fix play() didn't work after setSource()

### DIFF
--- a/packages/audioplayers/CHANGELOG.md
+++ b/packages/audioplayers/CHANGELOG.md
@@ -1,6 +1,7 @@
-## NEXT
+## 3.0.2
 
 * Update minimum Flutter and Dart version to 3.13 and 3.1.
+* Fix play() didn't work after setSource().
 
 ## 3.0.1
 

--- a/packages/audioplayers/README.md
+++ b/packages/audioplayers/README.md
@@ -11,7 +11,7 @@ This package is not an _endorsed_ implementation of `audioplayers`. Therefore, y
 ```yaml
 dependencies:
   audioplayers: ^5.1.0
-  audioplayers_tizen: ^3.0.1
+  audioplayers_tizen: ^3.0.2
 
 ```
 

--- a/packages/audioplayers/pubspec.yaml
+++ b/packages/audioplayers/pubspec.yaml
@@ -2,7 +2,7 @@ name: audioplayers_tizen
 description: Tizen implementation of the audioplayers plugin.
 homepage: https://github.com/flutter-tizen/plugins
 repository: https://github.com/flutter-tizen/plugins/tree/master/packages/audioplayers
-version: 3.0.1
+version: 3.0.2
 
 environment:
   sdk: ">=3.1.0 <4.0.0"

--- a/packages/audioplayers/tizen/src/audio_player.cc
+++ b/packages/audioplayers/tizen/src/audio_player.cc
@@ -138,17 +138,15 @@ void AudioPlayer::Seek(int32_t position) {
 }
 
 void AudioPlayer::SetUrl(const std::string &url) {
-  if (url != url_) {
-    url_ = url;
-    ResetPlayer();
+  url_ = url;
+  ResetPlayer();
 
-    int ret = player_set_uri(player_, url.c_str());
-    if (ret != PLAYER_ERROR_NONE) {
-      throw AudioPlayerError("player_set_uri failed", get_error_message(ret));
-    }
-
-    PreparePlayer();
+  int ret = player_set_uri(player_, url.c_str());
+  if (ret != PLAYER_ERROR_NONE) {
+    throw AudioPlayerError("player_set_uri failed", get_error_message(ret));
   }
+
+  PreparePlayer();
   audio_data_.clear();
 }
 


### PR DESCRIPTION
When setSource() is called, or setSource() is called when play() is called,
it waits for the event of AudioEventType.prepared. If the url has not been set
or a different url is set than before, it calls the prepared event, but if the url is the same,
it does not call the event and waits for preparedCompeter. Therefore, regardless of whether the url is set,
it always resets the player and calls preparePlayer().