### PR TITLE
[google_maps_flutter] Fix memory leak and map initialization issue

### DIFF
--- a/packages/google_maps_flutter/lib/src/google_maps_controller.dart
+++ b/packages/google_maps_flutter/lib/src/google_maps_controller.dart
@@ -173,10 +173,10 @@ class GoogleMapsController {
     final String options = _createOptions();
     final String command = '''
       map = new google.maps.Map(document.getElementById('map'), $options);
-      map.addListener('bounds_changed', BoundChanged.postMessage);
-      map.addListener('idle', Idle.postMessage);
-      map.addListener('click', (event) => Click.postMessage(JSON.stringify(event)));
-      map.addListener('tilesloaded', Tilesloaded.postMessage);
+      map.addListener('bounds_changed', (event) => { BoundChanged.postMessage('') });
+      map.addListener('idle', (event) => { Idle.postMessage('') });
+      map.addListener('click', (event) => { Click.postMessage(JSON.stringify(event)) });
+      map.addListener('tilesloaded', (evnet) => { Tilesloaded.postMessage('') });
 
       let longPressTimeout;
       map.addListener('mousedown', (e) => {


### PR DESCRIPTION
When using a google map's addListener(), do not call the Javascript object directly. This causes a memory leak.

Do:
 map.addListener('bounds_changed', (event) => { BoundChanged.postMessage('') });
Do not:
 map.addListener('bounds_changed', BoundChanged.postMessage);