### PR TITLE
[camera, in_app_purchase] Fix new lint warnings

### DIFF
--- a/packages/camera/example/lib/main.dart
+++ b/packages/camera/example/lib/main.dart
@@ -697,7 +697,6 @@ class _CameraExampleHomeState extends State<CameraExampleHome>
           showInSnackBar('Unknown permission error.');
         default:
           _showCameraException(e);
-          break;
       }
     }
 

--- a/packages/in_app_purchase/lib/src/billing_manager_wrappers/billing_manager_wrapper.dart
+++ b/packages/in_app_purchase/lib/src/billing_manager_wrappers/billing_manager_wrapper.dart
@@ -741,8 +741,6 @@ class PurchaseStateConverter {
         return PurchaseStatus.purchased;
       case true:
         return PurchaseStatus.canceled;
-      default:
-        return PurchaseStatus.error;
     }
   }
 }


### PR DESCRIPTION
camera - Remove unnecessary 'break' statement.
in_app_purchase - Remove unreachable siwtch default case.

https://github.com/flutter-tizen/plugins/actions/runs/12425999862/job/34693630064