### PR TITLE
[video_player_avplay] Add check platform and api version

### DIFF
--- a/packages/video_player_avplay/CHANGELOG.md
+++ b/packages/video_player_avplay/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.5.11
+
+* Add check platform and api version.
+
 ## 0.5.10
 
 * Add setDisplayRotate API

--- a/packages/video_player_avplay/README.md
+++ b/packages/video_player_avplay/README.md
@@ -12,7 +12,7 @@ To use this package, add `video_player_avplay` as a dependency in your `pubspec.
 
 ```yaml
 dependencies:
-  video_player_avplay: ^0.5.10
+  video_player_avplay: ^0.5.11
 ```
 
 Then you can import `video_player_avplay` in your Dart code:

--- a/packages/video_player_avplay/lib/video_player.dart
+++ b/packages/video_player_avplay/lib/video_player.dart
@@ -6,9 +6,11 @@
 import 'dart:async';
 import 'dart:io';
 
+import 'package:device_info_plus_tizen/device_info_plus_tizen.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
+import 'package:flutter_tizen/flutter_tizen.dart';
 
 import 'src/closed_caption_file.dart';
 import 'src/drm_configs.dart';
@@ -369,8 +371,24 @@ class VideoPlayerController extends ValueNotifier<VideoPlayerValue> {
   final MethodChannel _channel =
       const MethodChannel('dev.flutter.videoplayer.drm');
 
+  Future<void> _checkPlatformAndApiVersion() async {
+    final DeviceInfoPluginTizen deviceInfoPlugin = DeviceInfoPluginTizen();
+    final TizenDeviceInfo deviceInfo = await deviceInfoPlugin.tizenInfo;
+
+    if (deviceInfo.platformVersion != apiVersion) {
+      throw Exception(
+          'The current TizenOS version(${deviceInfo.platformVersion}) '
+          'and the app API version($apiVersion) are different. '
+          'The avplay plugin does not guarantee compatibility with '
+          'other versions. Therefore, please set the "api-version" '
+          'in tizen-manifest.xml to match the TizenOS version and rebuild.');
+    }
+  }
+
   /// Attempts to open the given [dataSource] and load metadata about the video.
   Future<void> initialize() async {
+    await _checkPlatformAndApiVersion();
+
     final bool allowBackgroundPlayback =
         videoPlayerOptions?.allowBackgroundPlayback ?? false;
     if (!allowBackgroundPlayback) {

--- a/packages/video_player_avplay/lib/video_player.dart
+++ b/packages/video_player_avplay/lib/video_player.dart
@@ -375,7 +375,10 @@ class VideoPlayerController extends ValueNotifier<VideoPlayerValue> {
     final DeviceInfoPluginTizen deviceInfoPlugin = DeviceInfoPluginTizen();
     final TizenDeviceInfo deviceInfo = await deviceInfoPlugin.tizenInfo;
 
-    if (deviceInfo.platformVersion != apiVersion) {
+    if ((deviceInfo.platformVersion != null &&
+            deviceInfo.platformVersion!.isNotEmpty) &&
+        apiVersion != 'none' &&
+        (deviceInfo.platformVersion != apiVersion)) {
       throw Exception(
           'The current TizenOS version(${deviceInfo.platformVersion}) '
           'and the app API version($apiVersion) are different. '

--- a/packages/video_player_avplay/pubspec.yaml
+++ b/packages/video_player_avplay/pubspec.yaml
@@ -2,7 +2,7 @@ name: video_player_avplay
 description: Flutter plugin for displaying inline video on Tizen TV devices.
 homepage: https://github.com/flutter-tizen/plugins
 repository: https://github.com/flutter-tizen/plugins/tree/master/packages/video_player_avplay
-version: 0.5.10
+version: 0.5.11
 
 environment:
   sdk: ">=3.1.0 <4.0.0"
@@ -16,8 +16,10 @@ flutter:
         fileName: video_player_tizen_plugin.h
 
 dependencies:
+  device_info_plus_tizen: ^1.2.0
   flutter:
     sdk: flutter
+  flutter_tizen: ^0.2.4
   html: ^0.15.0
   plugin_platform_interface: ^2.1.0
 


### PR DESCRIPTION
Add a step to the initialization phase that compares the API version of the app using avplay with the version of TizenOS.
This prevents TPKs built with avplay from running on TizenOS versions for which they are not intended.

related issue: https://github.com/flutter-tizen/plugins/issues/786