### PR TITLE
[ci] Fix python2.7 installation error

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,6 +24,8 @@ jobs:
       - name: Install Tizen Studio
         if: ${{ env.HAS_CHANGED_PACKAGES == 'true' }}
         run: |
+          sudo add-apt-repository ppa:deadsnakes/ppa
+          sudo apt update
           sudo apt install -y libncurses5 python2.7 libpython2.7 gettext \
             libkf5itemmodels5 libkf5kiowidgets5 libkchart2
           curl https://download.tizen.org/sdk/Installer/tizen-studio_5.6/web-cli_Tizen_Studio_5.6_ubuntu-64.bin -o install.bin


### PR DESCRIPTION
[ubuntu-latest(24.04)](https://github.com/actions/runner-images/issues/10636) no longer supports installing python 2.7 packages.
Tizen package manager still requires python2.7, so I add the python repository for this.
deadsnakes is an unofficial repository, but it is already being used by many users.

https://github.com/flutter-tizen/plugins/actions/runs/12707342335/job/35422168443#step:5:205