### PR TITLE
[ci] Change ubuntu runner to 22.04

### DIFF
--- a/.github/workflows/analyze.yml
+++ b/.github/workflows/analyze.yml
@@ -4,7 +4,7 @@ on: [push, pull_request]
 
 jobs:
   dart_analyze:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3
       - uses: subosito/flutter-action@v2
@@ -14,7 +14,7 @@ jobs:
         run: ./tools/tools_runner.sh analyze --custom-analysis=$(ls packages | tr '\n' ',')
 
   format:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3
       - uses: subosito/flutter-action@v2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,7 +4,7 @@ on: [push, pull_request]
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3
         with:

--- a/.github/workflows/pull_request_label.yml
+++ b/.github/workflows/pull_request_label.yml
@@ -4,7 +4,7 @@ on: [pull_request_target]
 
 jobs:
   triage:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/labeler@v4
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   release:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     if: ${{ github.repository_owner == 'flutter-tizen' }}
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
Tizen studio requires python 2.7 and libncurses5. However, Ubuntu 24.04's apt no longer supports these packages. I considered options like deadsnake(24.04), but python 2.7 is no longer supported. Rather than installing this manually, I decided that tizen studio is not ready for 24.04 yet, so I fixed the version of ubuntu runnner to 22.04.