### PR TITLE
[video_player] Add ignore analyzer option to fix analyze warning

### DIFF
--- a/packages/video_player/CHANGELOG.md
+++ b/packages/video_player/CHANGELOG.md
@@ -1,3 +1,7 @@
+## NEXT
+
+* Add ignore analyzer option to fix analyze issue.
+
 ## 2.5.4
 
 * Update video_player to 2.9.2.

--- a/packages/video_player/lib/video_player_tizen.dart
+++ b/packages/video_player/lib/video_player_tizen.dart
@@ -10,6 +10,9 @@ import 'package:video_player_platform_interface/video_player_platform_interface.
 
 import 'src/messages.g.dart';
 
+// TODO(JSUYA): Remove the ignore and rename parameters when adding support for platform views.
+// ignore_for_file: avoid_renaming_method_parameters
+
 /// A Tizen implementation of [VideoPlayerPlatform] that uses the
 /// Pigeon-generated [TizenVideoPlayerApi].
 class VideoPlayerTizen extends VideoPlayerPlatform {


### PR DESCRIPTION
A parameter has been renamed in the platform interface, which causes an analyser issue. (https://github.com/flutter/packages/pull/8453)
This should be updated when platform view of video_player is supported.