### PR TITLE
[video_player_avplay] Automatically rotates video player based on device orientation

### DIFF
--- a/packages/video_player_avplay/CHANGELOG.md
+++ b/packages/video_player_avplay/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.5.16
+
+* Automatically rotates video player based on device orientation.
+
 ## 0.5.15
 
 * Fix dash player fail to seek issue.

--- a/packages/video_player_avplay/README.md
+++ b/packages/video_player_avplay/README.md
@@ -12,7 +12,7 @@ To use this package, add `video_player_avplay` as a dependency in your `pubspec.
 
 ```yaml
 dependencies:
-  video_player_avplay: ^0.5.15
+  video_player_avplay: ^0.5.16
 ```
 
 Then you can import `video_player_avplay` in your Dart code:

--- a/packages/video_player_avplay/pubspec.yaml
+++ b/packages/video_player_avplay/pubspec.yaml
@@ -2,7 +2,7 @@ name: video_player_avplay
 description: Flutter plugin for displaying inline video on Tizen TV devices.
 homepage: https://github.com/flutter-tizen/plugins
 repository: https://github.com/flutter-tizen/plugins/tree/master/packages/video_player_avplay
-version: 0.5.15
+version: 0.5.16
 
 environment:
   sdk: ">=3.1.0 <4.0.0"


### PR DESCRIPTION
We already provide rotate API for video player,
but it seems like a bug that the video player's video image doesn't rotate according to the device orientation. So we should automatically change this inside video_player. When user call the API, the video image may rotate, but when the device's orientation changes, the rotation may change again.