### PR TITLE
[connectivity_plus] Clarify ConnectivityResult.none type

### DIFF
--- a/packages/connectivity_plus/CHANGELOG.md
+++ b/packages/connectivity_plus/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## 1.2.1
 
+* Clarify ConnectivityResult.none type.
 * Update plugin requirements version in README.
 
 ## 1.2.0

--- a/packages/connectivity_plus/CHANGELOG.md
+++ b/packages/connectivity_plus/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.2.1
+
+* Update plugin requirements version in README.
+
 ## 1.2.0
 
 * Update minimum Flutter and Dart version to 3.13 and 3.1.

--- a/packages/connectivity_plus/README.md
+++ b/packages/connectivity_plus/README.md
@@ -10,8 +10,8 @@ This package is not an _endorsed_ implementation of `connectivity_plus`. Therefo
 
 ```yaml
 dependencies:
-  connectivity_plus: ^4.0.1
-  connectivity_plus_tizen: ^1.2.0
+  connectivity_plus: ^6.1.0
+  connectivity_plus_tizen: ^1.2.1
 ```
 
 Then you can import `connectivity_plus` in your Dart code:

--- a/packages/connectivity_plus/pubspec.yaml
+++ b/packages/connectivity_plus/pubspec.yaml
@@ -2,7 +2,7 @@ name: connectivity_plus_tizen
 description: Tizen implementation of the connectivity_plus plugin.
 homepage: https://github.com/flutter-tizen/plugins
 repository: https://github.com/flutter-tizen/plugins/tree/master/packages/connectivity_plus
-version: 1.2.0
+version: 1.2.1
 
 environment:
   sdk: ">=3.1.0 <4.0.0"

--- a/packages/connectivity_plus/tizen/src/connection.cc
+++ b/packages/connectivity_plus/tizen/src/connection.cc
@@ -17,8 +17,10 @@ static ConnectionType ToConnectionType(connection_type_e type) {
     case CONNECTION_TYPE_BT:
       return ConnectionType::kBluetooth;
     case CONNECTION_TYPE_DISCONNECTED:
-    default:
       return ConnectionType::kNone;
+    case CONNECTION_TYPE_NET_PROXY:
+    default:
+      return ConnectionType::kOther;
   }
 }
 

--- a/packages/connectivity_plus/tizen/src/connection.h
+++ b/packages/connectivity_plus/tizen/src/connection.h
@@ -17,7 +17,8 @@ enum class ConnectionType {
   kWiFi,
   kMobile,
   kBluetooth,
-  kError
+  kError,
+  kOther,
 };
 
 typedef std::function<void(ConnectionType)> ConnectionTypeCallback;


### PR DESCRIPTION
- Clarify ConnectivityResult.none type
  - `ConnectivityResult.none type` is a disconnected situation, so make sure to only return the `connection_type_e.CONNECTION_TYPE_DISCONNECTED` type.
  
- Update plugin requirements version in README.
  - This change was missing in #764. If you use version ^4.0.1, you will get a version solving failed error.