### PR TITLE
Update flutter_tizen_plugin_tools and code format

### DIFF
--- a/.github/workflows/analyze.yml
+++ b/.github/workflows/analyze.yml
@@ -25,4 +25,5 @@ jobs:
           sudo apt-get update
           sudo apt-get install clang-format-11
       - name: Check format
-        run: ./tools/tools_runner.sh format --fail-on-change --clang-format=clang-format-11
+        run: |
+          ./tools/tools_runner.sh format --fail-on-change --no-kotlin --no-java --no-swift --clang-format-path=clang-format-11

--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,4 @@ build/
 
 # Downloaded by the plugin tools.
 google-java-format-1.3-all-deps.jar
+ktfmt-0.46-jar-with-dependencies.jar

--- a/packages/audioplayers/CHANGELOG.md
+++ b/packages/audioplayers/CHANGELOG.md
@@ -1,3 +1,7 @@
+## NEXT
+
+* Update code format.
+
 ## 3.1.1
 
 * Update audioplayers to 6.4.0.

--- a/packages/audioplayers/example/lib/components/drop_down.dart
+++ b/packages/audioplayers/example/lib/components/drop_down.dart
@@ -47,15 +47,14 @@ class CustomDropDown<T> extends StatelessWidget {
       isExpanded: isExpanded,
       value: selected,
       onChanged: onChange,
-      items:
-          options.entries
-              .map<DropdownMenuItem<T>>(
-                (entry) => DropdownMenuItem<T>(
-                  value: entry.key,
-                  child: Text(entry.value),
-                ),
-              )
-              .toList(),
+      items: options.entries
+          .map<DropdownMenuItem<T>>(
+            (entry) => DropdownMenuItem<T>(
+              value: entry.key,
+              child: Text(entry.value),
+            ),
+          )
+          .toList(),
     );
   }
 }

--- a/packages/audioplayers/example/lib/components/player_widget.dart
+++ b/packages/audioplayers/example/lib/components/player_widget.dart
@@ -41,15 +41,15 @@ class _PlayerWidgetState extends State<PlayerWidget> {
     // Use initial values from player
     _playerState = player.state;
     player.getDuration().then(
-      (value) => setState(() {
-        _duration = value;
-      }),
-    );
+          (value) => setState(() {
+            _duration = value;
+          }),
+        );
     player.getCurrentPosition().then(
-      (value) => setState(() {
-        _position = value;
-      }),
-    );
+          (value) => setState(() {
+            _position = value;
+          }),
+        );
     _initStreams();
   }
 
@@ -112,20 +112,19 @@ class _PlayerWidgetState extends State<PlayerWidget> {
             final position = value * duration.inMilliseconds;
             player.seek(Duration(milliseconds: position.round()));
           },
-          value:
-              (_position != null &&
-                      _duration != null &&
-                      _position!.inMilliseconds > 0 &&
-                      _position!.inMilliseconds < _duration!.inMilliseconds)
-                  ? _position!.inMilliseconds / _duration!.inMilliseconds
-                  : 0.0,
+          value: (_position != null &&
+                  _duration != null &&
+                  _position!.inMilliseconds > 0 &&
+                  _position!.inMilliseconds < _duration!.inMilliseconds)
+              ? _position!.inMilliseconds / _duration!.inMilliseconds
+              : 0.0,
         ),
         Text(
           _position != null
               ? '$_positionText / $_durationText'
               : _duration != null
-              ? _durationText
-              : '',
+                  ? _durationText
+                  : '',
           style: const TextStyle(fontSize: 16.0),
         ),
       ],

--- a/packages/audioplayers/example/lib/components/stream_widget.dart
+++ b/packages/audioplayers/example/lib/components/stream_widget.dart
@@ -28,8 +28,8 @@ class _StreamWidgetState extends State<StreamWidget> {
     streamState = player.state;
     player.getDuration().then((it) => setState(() => streamDuration = it));
     player.getCurrentPosition().then(
-      (it) => setState(() => streamPosition = it),
-    );
+          (it) => setState(() => streamPosition = it),
+        );
 
     streams = <StreamSubscription>[
       player.onDurationChanged.listen(

--- a/packages/audioplayers/example/lib/components/tabs.dart
+++ b/packages/audioplayers/example/lib/components/tabs.dart
@@ -15,15 +15,14 @@ class Tabs extends StatelessWidget {
           children: [
             TabBar(
               labelColor: Colors.black,
-              tabs:
-                  tabs
-                      .map(
-                        (tData) => Tab(
-                          key: tData.key != null ? Key(tData.key!) : null,
-                          text: tData.label,
-                        ),
-                      )
-                      .toList(),
+              tabs: tabs
+                  .map(
+                    (tData) => Tab(
+                      key: tData.key != null ? Key(tData.key!) : null,
+                      text: tData.label,
+                    ),
+                  )
+                  .toList(),
             ),
             Expanded(
               child: TabBarView(

--- a/packages/audioplayers/example/lib/components/tgl.dart
+++ b/packages/audioplayers/example/lib/components/tgl.dart
@@ -16,22 +16,20 @@ class Tgl extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return ToggleButtons(
-      isSelected:
-          options.entries
-              .mapIndexed((index, element) => index == selected)
-              .toList(),
+      isSelected: options.entries
+          .mapIndexed((index, element) => index == selected)
+          .toList(),
       onPressed: onChange,
       borderRadius: const BorderRadius.all(Radius.circular(8)),
       selectedBorderColor: Theme.of(context).primaryColor,
-      children:
-          options.entries
-              .map(
-                (entry) => Padding(
-                  padding: const EdgeInsets.all(8),
-                  child: Text(entry.value, key: Key(entry.key)),
-                ),
-              )
-              .toList(),
+      children: options.entries
+          .map(
+            (entry) => Padding(
+              padding: const EdgeInsets.all(8),
+              child: Text(entry.value, key: Key(entry.key)),
+            ),
+          )
+          .toList(),
     );
   }
 }

--- a/packages/audioplayers/example/lib/main.dart
+++ b/packages/audioplayers/example/lib/main.dart
@@ -144,47 +144,45 @@ class _ExampleAppState extends State<_ExampleApp> {
             ),
           ),
           Expanded(
-            child:
-                audioPlayers.isEmpty
-                    ? const Text('No AudioPlayer available!')
-                    : IndexedStack(
-                      index: selectedPlayerIdx,
-                      children:
-                          audioPlayers
-                              .map(
-                                (player) => Tabs(
-                                  key: GlobalObjectKey(player),
-                                  tabs: [
-                                    TabData(
-                                      key: 'sourcesTab',
-                                      label: 'Src',
-                                      content: SourcesTab(player: player),
-                                    ),
-                                    TabData(
-                                      key: 'controlsTab',
-                                      label: 'Ctrl',
-                                      content: ControlsTab(player: player),
-                                    ),
-                                    TabData(
-                                      key: 'streamsTab',
-                                      label: 'Stream',
-                                      content: StreamsTab(player: player),
-                                    ),
-                                    TabData(
-                                      key: 'audioContextTab',
-                                      label: 'Ctx',
-                                      content: AudioContextTab(player: player),
-                                    ),
-                                    TabData(
-                                      key: 'loggerTab',
-                                      label: 'Log',
-                                      content: LoggerTab(player: player),
-                                    ),
-                                  ],
-                                ),
-                              )
-                              .toList(),
-                    ),
+            child: audioPlayers.isEmpty
+                ? const Text('No AudioPlayer available!')
+                : IndexedStack(
+                    index: selectedPlayerIdx,
+                    children: audioPlayers
+                        .map(
+                          (player) => Tabs(
+                            key: GlobalObjectKey(player),
+                            tabs: [
+                              TabData(
+                                key: 'sourcesTab',
+                                label: 'Src',
+                                content: SourcesTab(player: player),
+                              ),
+                              TabData(
+                                key: 'controlsTab',
+                                label: 'Ctrl',
+                                content: ControlsTab(player: player),
+                              ),
+                              TabData(
+                                key: 'streamsTab',
+                                label: 'Stream',
+                                content: StreamsTab(player: player),
+                              ),
+                              TabData(
+                                key: 'audioContextTab',
+                                label: 'Ctx',
+                                content: AudioContextTab(player: player),
+                              ),
+                              TabData(
+                                key: 'loggerTab',
+                                label: 'Log',
+                                content: LoggerTab(player: player),
+                              ),
+                            ],
+                          ),
+                        )
+                        .toList(),
+                  ),
           ),
         ],
       ),

--- a/packages/audioplayers/example/lib/tabs/audio_context.dart
+++ b/packages/audioplayers/example/lib/tabs/audio_context.dart
@@ -190,61 +190,56 @@ class AudioContextTabState extends State<AudioContextTab>
           key: const Key('contentType'),
           options: {for (final e in AndroidContentType.values) e: e.name},
           selected: audioContext.android.contentType,
-          onChange:
-              (v) => updateAudioContextAndroid(
-                audioContext.android.copy(contentType: v),
-              ),
+          onChange: (v) => updateAudioContextAndroid(
+            audioContext.android.copy(contentType: v),
+          ),
         ),
         LabeledDropDown<AndroidUsageType>(
           label: 'usageType',
           key: const Key('usageType'),
           options: {for (final e in AndroidUsageType.values) e: e.name},
           selected: audioContext.android.usageType,
-          onChange:
-              (v) => updateAudioContextAndroid(
-                audioContext.android.copy(usageType: v),
-              ),
+          onChange: (v) => updateAudioContextAndroid(
+            audioContext.android.copy(usageType: v),
+          ),
         ),
         LabeledDropDown<AndroidAudioFocus?>(
           key: const Key('audioFocus'),
           label: 'audioFocus',
           options: {for (final e in AndroidAudioFocus.values) e: e.name},
           selected: audioContext.android.audioFocus,
-          onChange:
-              (v) => updateAudioContextAndroid(
-                audioContext.android.copy(audioFocus: v),
-              ),
+          onChange: (v) => updateAudioContextAndroid(
+            audioContext.android.copy(audioFocus: v),
+          ),
         ),
         LabeledDropDown<AndroidAudioMode>(
           key: const Key('audioMode'),
           label: 'audioMode',
           options: {for (final e in AndroidAudioMode.values) e: e.name},
           selected: audioContext.android.audioMode,
-          onChange:
-              (v) => updateAudioContextAndroid(
-                audioContext.android.copy(audioMode: v),
-              ),
+          onChange: (v) => updateAudioContextAndroid(
+            audioContext.android.copy(audioMode: v),
+          ),
         ),
       ],
     );
   }
 
   Widget _iosTab() {
-    final iosOptions =
-        AVAudioSessionOptions.values.map((option) {
-          final options = {...audioContext.iOS.options};
-          return Cbx(option.name, value: options.contains(option), ({value}) {
-            updateAudioContextIOS(() {
-              final iosContext = audioContext.iOS.copy(options: options);
-              if (value ?? false) {
-                options.add(option);
-              } else {
-                options.remove(option);
-              }
-              return iosContext;
-            });
-          });
-        }).toList();
+    final iosOptions = AVAudioSessionOptions.values.map((option) {
+      final options = {...audioContext.iOS.options};
+      return Cbx(option.name, value: options.contains(option), ({value}) {
+        updateAudioContextIOS(() {
+          final iosContext = audioContext.iOS.copy(options: options);
+          if (value ?? false) {
+            options.add(option);
+          } else {
+            options.remove(option);
+          }
+          return iosContext;
+        });
+      });
+    }).toList();
     return TabContent(
       children: <Widget>[
         LabeledDropDown<AVAudioSessionCategory>(
@@ -252,10 +247,9 @@ class AudioContextTabState extends State<AudioContextTab>
           label: 'category',
           options: {for (final e in AVAudioSessionCategory.values) e: e.name},
           selected: audioContext.iOS.category,
-          onChange:
-              (v) => updateAudioContextIOS(
-                () => audioContext.iOS.copy(category: v),
-              ),
+          onChange: (v) => updateAudioContextIOS(
+            () => audioContext.iOS.copy(category: v),
+          ),
         ),
         ...iosOptions,
       ],

--- a/packages/audioplayers/example/lib/tabs/controls.dart
+++ b/packages/audioplayers/example/lib/tabs/controls.dart
@@ -74,39 +74,36 @@ class _ControlsTabState extends State<ControlsTab>
         ),
         WrappedListTile(
           leading: const Text('Volume'),
-          children:
-              [0.0, 0.5, 1.0, 2.0].map((it) {
-                final formattedVal = it.toStringAsFixed(1);
-                return Btn(
-                  key: Key('control-volume-$formattedVal'),
-                  txt: formattedVal,
-                  onPressed: () => widget.player.setVolume(it),
-                );
-              }).toList(),
+          children: [0.0, 0.5, 1.0, 2.0].map((it) {
+            final formattedVal = it.toStringAsFixed(1);
+            return Btn(
+              key: Key('control-volume-$formattedVal'),
+              txt: formattedVal,
+              onPressed: () => widget.player.setVolume(it),
+            );
+          }).toList(),
         ),
         WrappedListTile(
           leading: const Text('Balance'),
-          children:
-              [-1.0, -0.5, 0.0, 1.0].map((it) {
-                final formattedVal = it.toStringAsFixed(1);
-                return Btn(
-                  key: Key('control-balance-$formattedVal'),
-                  txt: formattedVal,
-                  onPressed: () => widget.player.setBalance(it),
-                );
-              }).toList(),
+          children: [-1.0, -0.5, 0.0, 1.0].map((it) {
+            final formattedVal = it.toStringAsFixed(1);
+            return Btn(
+              key: Key('control-balance-$formattedVal'),
+              txt: formattedVal,
+              onPressed: () => widget.player.setBalance(it),
+            );
+          }).toList(),
         ),
         WrappedListTile(
           leading: const Text('Rate'),
-          children:
-              [0.0, 0.5, 1.0, 2.0].map((it) {
-                final formattedVal = it.toStringAsFixed(1);
-                return Btn(
-                  key: Key('control-rate-$formattedVal'),
-                  txt: formattedVal,
-                  onPressed: () => widget.player.setPlaybackRate(it),
-                );
-              }).toList(),
+          children: [0.0, 0.5, 1.0, 2.0].map((it) {
+            final formattedVal = it.toStringAsFixed(1);
+            return Btn(
+              key: Key('control-rate-$formattedVal'),
+              txt: formattedVal,
+              onPressed: () => widget.player.setPlaybackRate(it),
+            );
+          }).toList(),
         ),
         WrappedListTile(
           leading: const Text('Player Mode'),
@@ -158,12 +155,11 @@ class _ControlsTabState extends State<ControlsTab>
                   _SeekDialog(
                     value: modalInputSeek,
                     setValue: (it) => setState(() => modalInputSeek = it),
-                    seekDuration:
-                        () => _seekDuration(
-                          Duration(milliseconds: int.parse(modalInputSeek)),
-                        ),
-                    seekPercent:
-                        () => _seekPercent(double.parse(modalInputSeek)),
+                    seekDuration: () => _seekDuration(
+                      Duration(milliseconds: int.parse(modalInputSeek)),
+                    ),
+                    seekPercent: () =>
+                        _seekPercent(double.parse(modalInputSeek)),
                   ),
                 );
               },

--- a/packages/audioplayers/example/lib/tabs/logger.dart
+++ b/packages/audioplayers/example/lib/tabs/logger.dart
@@ -86,27 +86,25 @@ class LoggerTabState extends State<LoggerTab>
           ),
           Row(
             mainAxisAlignment: MainAxisAlignment.spaceEvenly,
-            children:
-                AudioLogLevel.values
-                    .map(
-                      (level) => Btn(
-                        txt: level.toString().replaceAll('AudioLogLevel.', ''),
-                        onPressed: () {
-                          setState(() => currentLogLevel = level);
-                        },
-                      ),
-                    )
-                    .toList(),
+            children: AudioLogLevel.values
+                .map(
+                  (level) => Btn(
+                    txt: level.toString().replaceAll('AudioLogLevel.', ''),
+                    onPressed: () {
+                      setState(() => currentLogLevel = level);
+                    },
+                  ),
+                )
+                .toList(),
           ),
           const Divider(color: Colors.black),
           Expanded(
             child: LogView(
               title: 'Player Logs:',
               logs: logs,
-              onDelete:
-                  () => setState(() {
-                    logs.clear();
-                  }),
+              onDelete: () => setState(() {
+                logs.clear();
+              }),
             ),
           ),
           const Divider(color: Colors.black),
@@ -114,10 +112,9 @@ class LoggerTabState extends State<LoggerTab>
             child: LogView(
               title: 'Global Logs:',
               logs: globalLogs,
-              onDelete:
-                  () => setState(() {
-                    globalLogs.clear();
-                  }),
+              onDelete: () => setState(() {
+                globalLogs.clear();
+              }),
             ),
           ),
         ],
@@ -154,24 +151,22 @@ class LogView extends StatelessWidget {
         ),
         Expanded(
           child: ListView(
-            children:
-                logs
-                    .map(
-                      (log) => Column(
-                        crossAxisAlignment: CrossAxisAlignment.start,
-                        children: [
-                          SelectableText(
-                            '${log.level}: ${log.message}',
-                            style:
-                                log.level == AudioLogLevel.error
-                                    ? const TextStyle(color: Colors.red)
-                                    : null,
-                          ),
-                          Divider(color: Colors.grey.shade400),
-                        ],
+            children: logs
+                .map(
+                  (log) => Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      SelectableText(
+                        '${log.level}: ${log.message}',
+                        style: log.level == AudioLogLevel.error
+                            ? const TextStyle(color: Colors.red)
+                            : null,
                       ),
-                    )
-                    .toList(),
+                      Divider(color: Colors.grey.shade400),
+                    ],
+                  ),
+                )
+                .toList(),
           ),
         ),
       ],

--- a/packages/audioplayers/example/lib/tabs/sources.dart
+++ b/packages/audioplayers/example/lib/tabs/sources.dart
@@ -21,14 +21,12 @@ final wavUrl2 = '$host/files/audio/laser.wav';
 final wavUrl3 = '$host/files/audio/coins_non_ascii_и.wav';
 final mp3Url1 = '$host/files/audio/ambient_c_motion.mp3';
 final mp3Url2 = '$host/files/audio/nasa_on_a_mission.mp3';
-final m3u8StreamUrl =
-    useLocalServer
-        ? '$host/files/live_streams/nasa_power_of_the_rovers.m3u8'
-        : 'https://ll-hls-test.cdn-apple.com/llhls4/ll-hls-test-04/multi.m3u8';
-final mpgaStreamUrl =
-    useLocalServer
-        ? '$host/stream/mpeg'
-        : 'https://timesradio.wireless.radio/stream';
+final m3u8StreamUrl = useLocalServer
+    ? '$host/files/live_streams/nasa_power_of_the_rovers.m3u8'
+    : 'https://ll-hls-test.cdn-apple.com/llhls4/ll-hls-test-04/multi.m3u8';
+final mpgaStreamUrl = useLocalServer
+    ? '$host/stream/mpeg'
+    : 'https://timesradio.wireless.radio/stream';
 
 const wavAsset1 = 'coins.wav';
 const wavAsset2 = 'laser.wav';
@@ -81,16 +79,17 @@ class _SourcesTabState extends State<SourcesTab>
     Key? setSourceKey,
     Color? buttonColor,
     Key? playKey,
-  }) => _SourceTile(
-    setSource: () => _setSource(source),
-    play: () => _play(source),
-    removeSource: _removeSourceWidget,
-    title: title,
-    subtitle: subtitle,
-    setSourceKey: setSourceKey,
-    playKey: playKey,
-    buttonColor: buttonColor,
-  );
+  }) =>
+      _SourceTile(
+        setSource: () => _setSource(source),
+        play: () => _play(source),
+        removeSource: _removeSourceWidget,
+        title: title,
+        subtitle: subtitle,
+        setSourceKey: setSourceKey,
+        playKey: playKey,
+        buttonColor: buttonColor,
+      );
 
   Future<void> _setSourceBytesAsset(
     Future<void> Function(Source) fun, {
@@ -175,37 +174,33 @@ class _SourcesTabState extends State<SourcesTab>
         source: AssetSource(mp3Asset),
       ),
       _SourceTile(
-        setSource:
-            () => _setSourceBytesAsset(
-              _setSource,
-              asset: wavAsset2,
-              mimeType: 'audio/wav',
-            ),
+        setSource: () => _setSourceBytesAsset(
+          _setSource,
+          asset: wavAsset2,
+          mimeType: 'audio/wav',
+        ),
         setSourceKey: const Key('setSource-bytes-local'),
-        play:
-            () => _setSourceBytesAsset(
-              _play,
-              asset: wavAsset2,
-              mimeType: 'audio/wav',
-            ),
+        play: () => _setSourceBytesAsset(
+          _play,
+          asset: wavAsset2,
+          mimeType: 'audio/wav',
+        ),
         removeSource: _removeSourceWidget,
         title: 'Bytes - Local',
         subtitle: 'laser.wav',
       ),
       _SourceTile(
-        setSource:
-            () => _setSourceBytesRemote(
-              _setSource,
-              url: mp3Url1,
-              mimeType: 'audio/mpeg',
-            ),
+        setSource: () => _setSourceBytesRemote(
+          _setSource,
+          url: mp3Url1,
+          mimeType: 'audio/mpeg',
+        ),
         setSourceKey: const Key('setSource-bytes-remote'),
-        play:
-            () => _setSourceBytesRemote(
-              _play,
-              url: mp3Url1,
-              mimeType: 'audio/mpeg',
-            ),
+        play: () => _setSourceBytesRemote(
+          _play,
+          url: mp3Url1,
+          mimeType: 'audio/mpeg',
+        ),
         removeSource: _removeSourceWidget,
         title: 'Bytes - Remote',
         subtitle: 'ambient.mp3',
@@ -227,10 +222,9 @@ class _SourcesTabState extends State<SourcesTab>
       alignment: Alignment.bottomCenter,
       children: [
         TabContent(
-          children:
-              sourceWidgets
-                  .expand((element) => [element, const Divider()])
-                  .toList(),
+          children: sourceWidgets
+              .expand((element) => [element, const Divider()])
+              .toList(),
         ),
         Padding(
           padding: const EdgeInsets.all(16),
@@ -362,10 +356,9 @@ class _SourceDialogState extends State<_SourceDialog> {
               child: CustomDropDown<String>(
                 options: assetsList,
                 selected: path,
-                onChange:
-                    (value) => setState(() {
-                      path = value ?? '';
-                    }),
+                onChange: (value) => setState(() {
+                  path = value ?? '';
+                }),
               ),
             ),
           ],

--- a/packages/battery_plus/CHANGELOG.md
+++ b/packages/battery_plus/CHANGELOG.md
@@ -1,3 +1,7 @@
+## NEXT
+
+* Update code format.
+
 ## 1.1.3
 
 * Update minimum Flutter and Dart version to 3.13 and 3.1.

--- a/packages/battery_plus/example/integration_test/battery_plus_test.dart
+++ b/packages/battery_plus/example/integration_test/battery_plus_test.dart
@@ -12,8 +12,7 @@ void main() {
 
   final bool batteryLevelIsImplemented =
       Platform.isAndroid || Platform.isMacOS || Platform.isLinux;
-  final bool batteryStateIsImplemented =
-      Platform.isAndroid ||
+  final bool batteryStateIsImplemented = Platform.isAndroid ||
       Platform.isIOS ||
       Platform.isMacOS ||
       Platform.isWindows ||

--- a/packages/battery_plus/example/lib/main.dart
+++ b/packages/battery_plus/example/lib/main.dart
@@ -74,18 +74,17 @@ class _MyHomePageState extends State<MyHomePage> {
                   if (!context.mounted) return;
                   showDialog<void>(
                     context: context,
-                    builder:
-                        (_) => AlertDialog(
-                          content: Text('Battery: $batteryLevel%'),
-                          actions: <Widget>[
-                            TextButton(
-                              onPressed: () {
-                                Navigator.pop(context);
-                              },
-                              child: const Text('OK'),
-                            ),
-                          ],
+                    builder: (_) => AlertDialog(
+                      content: Text('Battery: $batteryLevel%'),
+                      actions: <Widget>[
+                        TextButton(
+                          onPressed: () {
+                            Navigator.pop(context);
+                          },
+                          child: const Text('OK'),
                         ),
+                      ],
+                    ),
                   );
                 });
               },
@@ -98,25 +97,24 @@ class _MyHomePageState extends State<MyHomePage> {
                   if (!context.mounted) return;
                   showDialog<void>(
                     context: context,
-                    builder:
-                        (_) => AlertDialog(
-                          title: const Text(
-                            'Is in Battery Save mode?',
-                            style: TextStyle(fontSize: 20),
-                          ),
-                          content: Text(
-                            "$isInPowerSaveMode",
-                            style: const TextStyle(fontSize: 18),
-                          ),
-                          actions: <Widget>[
-                            TextButton(
-                              onPressed: () {
-                                Navigator.pop(context);
-                              },
-                              child: const Text('Close'),
-                            ),
-                          ],
+                    builder: (_) => AlertDialog(
+                      title: const Text(
+                        'Is in Battery Save mode?',
+                        style: TextStyle(fontSize: 20),
+                      ),
+                      content: Text(
+                        "$isInPowerSaveMode",
+                        style: const TextStyle(fontSize: 18),
+                      ),
+                      actions: <Widget>[
+                        TextButton(
+                          onPressed: () {
+                            Navigator.pop(context);
+                          },
+                          child: const Text('Close'),
                         ),
+                      ],
+                    ),
                   );
                 });
               },

--- a/packages/camera/CHANGELOG.md
+++ b/packages/camera/CHANGELOG.md
@@ -1,3 +1,7 @@
+## NEXT
+
+* Update code format.
+
 ## 0.3.5
 
 * Update minimum Flutter and Dart version to 3.13 and 3.1.

--- a/packages/camera/example/integration_test/camera_test.dart
+++ b/packages/camera/example/integration_test/camera_test.dart
@@ -28,9 +28,9 @@ void main() {
 
   final Map<ResolutionPreset, Size> presetExpectedSizes =
       <ResolutionPreset, Size>{
-        ResolutionPreset.medium: const Size(480, 720),
-        // Don't bother checking for max here since it could be anything.
-      };
+    ResolutionPreset.medium: const Size(480, 720),
+    // Don't bother checking for max here since it could be anything.
+  };
 
   /// Verify that [actual] has dimensions that are at least as large as
   /// [expectedSize]. Allows for a mismatch in portrait vs landscape. Returns

--- a/packages/camera/example/lib/main.dart
+++ b/packages/camera/example/lib/main.dart
@@ -187,9 +187,8 @@ class _CameraExampleHomeState extends State<CameraExampleHome>
                 behavior: HitTestBehavior.opaque,
                 onScaleStart: _handleScaleStart,
                 onScaleUpdate: _handleScaleUpdate,
-                onTapDown:
-                    (TapDownDetails details) =>
-                        onViewFinderTap(details, constraints),
+                onTapDown: (TapDownDetails details) =>
+                    onViewFinderTap(details, constraints),
               );
             },
           ),
@@ -232,9 +231,8 @@ class _CameraExampleHomeState extends State<CameraExampleHome>
               SizedBox(
                 width: 64.0,
                 height: 64.0,
-                child:
-                    (localVideoController == null)
-                        ? (
+                child: (localVideoController == null)
+                    ? (
                         // The captured image on the web contains a network-accessible URL
                         // pointing to a location within the browser. It may be displayed
                         // either with Image.network or Image.memory after loading the image
@@ -242,18 +240,17 @@ class _CameraExampleHomeState extends State<CameraExampleHome>
                         kIsWeb
                             ? Image.network(imageFile!.path)
                             : Image.file(File(imageFile!.path)))
-                        : Container(
-                          decoration: BoxDecoration(
-                            border: Border.all(color: Colors.pink),
-                          ),
-                          child: Center(
-                            child: AspectRatio(
-                              aspectRatio:
-                                  localVideoController.value.aspectRatio,
-                              child: VideoPlayer(localVideoController),
-                            ),
+                    : Container(
+                        decoration: BoxDecoration(
+                          border: Border.all(color: Colors.pink),
+                        ),
+                        child: Center(
+                          child: AspectRatio(
+                            aspectRatio: localVideoController.value.aspectRatio,
+                            child: VideoPlayer(localVideoController),
                           ),
                         ),
+                      ),
               ),
           ],
         ),
@@ -276,19 +273,20 @@ class _CameraExampleHomeState extends State<CameraExampleHome>
             // The exposure and focus mode are currently not supported on the web.
             ...!kIsWeb
                 ? <Widget>[
-                  IconButton(
-                    icon: const Icon(Icons.exposure),
-                    color: Colors.blue,
-                    onPressed:
-                        controller != null ? onExposureModeButtonPressed : null,
-                  ),
-                  IconButton(
-                    icon: const Icon(Icons.filter_center_focus),
-                    color: Colors.blue,
-                    onPressed:
-                        controller != null ? onFocusModeButtonPressed : null,
-                  ),
-                ]
+                    IconButton(
+                      icon: const Icon(Icons.exposure),
+                      color: Colors.blue,
+                      onPressed: controller != null
+                          ? onExposureModeButtonPressed
+                          : null,
+                    ),
+                    IconButton(
+                      icon: const Icon(Icons.filter_center_focus),
+                      color: Colors.blue,
+                      onPressed:
+                          controller != null ? onFocusModeButtonPressed : null,
+                    ),
+                  ]
                 : <Widget>[],
             IconButton(
               icon: Icon(enableAudio ? Icons.volume_up : Icons.volume_mute),
@@ -302,10 +300,9 @@ class _CameraExampleHomeState extends State<CameraExampleHome>
                     : Icons.screen_rotation,
               ),
               color: Colors.blue,
-              onPressed:
-                  controller != null
-                      ? onCaptureOrientationLockButtonPressed
-                      : null,
+              onPressed: controller != null
+                  ? onCaptureOrientationLockButtonPressed
+                  : null,
             ),
           ],
         ),
@@ -325,47 +322,39 @@ class _CameraExampleHomeState extends State<CameraExampleHome>
           children: <Widget>[
             IconButton(
               icon: const Icon(Icons.flash_off),
-              color:
-                  controller?.value.flashMode == FlashMode.off
-                      ? Colors.orange
-                      : Colors.blue,
-              onPressed:
-                  controller != null
-                      ? () => onSetFlashModeButtonPressed(FlashMode.off)
-                      : null,
+              color: controller?.value.flashMode == FlashMode.off
+                  ? Colors.orange
+                  : Colors.blue,
+              onPressed: controller != null
+                  ? () => onSetFlashModeButtonPressed(FlashMode.off)
+                  : null,
             ),
             IconButton(
               icon: const Icon(Icons.flash_auto),
-              color:
-                  controller?.value.flashMode == FlashMode.auto
-                      ? Colors.orange
-                      : Colors.blue,
-              onPressed:
-                  controller != null
-                      ? () => onSetFlashModeButtonPressed(FlashMode.auto)
-                      : null,
+              color: controller?.value.flashMode == FlashMode.auto
+                  ? Colors.orange
+                  : Colors.blue,
+              onPressed: controller != null
+                  ? () => onSetFlashModeButtonPressed(FlashMode.auto)
+                  : null,
             ),
             IconButton(
               icon: const Icon(Icons.flash_on),
-              color:
-                  controller?.value.flashMode == FlashMode.always
-                      ? Colors.orange
-                      : Colors.blue,
-              onPressed:
-                  controller != null
-                      ? () => onSetFlashModeButtonPressed(FlashMode.always)
-                      : null,
+              color: controller?.value.flashMode == FlashMode.always
+                  ? Colors.orange
+                  : Colors.blue,
+              onPressed: controller != null
+                  ? () => onSetFlashModeButtonPressed(FlashMode.always)
+                  : null,
             ),
             IconButton(
               icon: const Icon(Icons.highlight),
-              color:
-                  controller?.value.flashMode == FlashMode.torch
-                      ? Colors.orange
-                      : Colors.blue,
-              onPressed:
-                  controller != null
-                      ? () => onSetFlashModeButtonPressed(FlashMode.torch)
-                      : null,
+              color: controller?.value.flashMode == FlashMode.torch
+                  ? Colors.orange
+                  : Colors.blue,
+              onPressed: controller != null
+                  ? () => onSetFlashModeButtonPressed(FlashMode.torch)
+                  : null,
             ),
           ],
         ),
@@ -375,16 +364,14 @@ class _CameraExampleHomeState extends State<CameraExampleHome>
 
   Widget _exposureModeControlRowWidget() {
     final ButtonStyle styleAuto = TextButton.styleFrom(
-      backgroundColor:
-          controller?.value.exposureMode == ExposureMode.auto
-              ? Colors.orange
-              : Colors.blue,
+      backgroundColor: controller?.value.exposureMode == ExposureMode.auto
+          ? Colors.orange
+          : Colors.blue,
     );
     final ButtonStyle styleLocked = TextButton.styleFrom(
-      backgroundColor:
-          controller?.value.exposureMode == ExposureMode.locked
-              ? Colors.orange
-              : Colors.blue,
+      backgroundColor: controller?.value.exposureMode == ExposureMode.locked
+          ? Colors.orange
+          : Colors.blue,
     );
 
     return SizeTransition(
@@ -400,12 +387,11 @@ class _CameraExampleHomeState extends State<CameraExampleHome>
                 children: <Widget>[
                   TextButton(
                     style: styleAuto,
-                    onPressed:
-                        controller != null
-                            ? () => onSetExposureModeButtonPressed(
+                    onPressed: controller != null
+                        ? () => onSetExposureModeButtonPressed(
                               ExposureMode.auto,
                             )
-                            : null,
+                        : null,
                     onLongPress: () {
                       if (controller != null) {
                         controller!.setExposurePoint(null);
@@ -416,20 +402,18 @@ class _CameraExampleHomeState extends State<CameraExampleHome>
                   ),
                   TextButton(
                     style: styleLocked,
-                    onPressed:
-                        controller != null
-                            ? () => onSetExposureModeButtonPressed(
+                    onPressed: controller != null
+                        ? () => onSetExposureModeButtonPressed(
                               ExposureMode.locked,
                             )
-                            : null,
+                        : null,
                     child: const Text('LOCKED'),
                   ),
                   TextButton(
                     style: styleLocked,
-                    onPressed:
-                        controller != null
-                            ? () => controller!.setExposureOffset(0.0)
-                            : null,
+                    onPressed: controller != null
+                        ? () => controller!.setExposureOffset(0.0)
+                        : null,
                     child: const Text('RESET OFFSET'),
                   ),
                 ],
@@ -444,11 +428,10 @@ class _CameraExampleHomeState extends State<CameraExampleHome>
                     min: _minAvailableExposureOffset,
                     max: _maxAvailableExposureOffset,
                     label: _currentExposureOffset.toString(),
-                    onChanged:
-                        _minAvailableExposureOffset ==
-                                _maxAvailableExposureOffset
-                            ? null
-                            : setExposureOffset,
+                    onChanged: _minAvailableExposureOffset ==
+                            _maxAvailableExposureOffset
+                        ? null
+                        : setExposureOffset,
                   ),
                   Text(_maxAvailableExposureOffset.toString()),
                 ],
@@ -462,16 +445,14 @@ class _CameraExampleHomeState extends State<CameraExampleHome>
 
   Widget _focusModeControlRowWidget() {
     final ButtonStyle styleAuto = TextButton.styleFrom(
-      backgroundColor:
-          controller?.value.focusMode == FocusMode.auto
-              ? Colors.orange
-              : Colors.blue,
+      backgroundColor: controller?.value.focusMode == FocusMode.auto
+          ? Colors.orange
+          : Colors.blue,
     );
     final ButtonStyle styleLocked = TextButton.styleFrom(
-      backgroundColor:
-          controller?.value.focusMode == FocusMode.locked
-              ? Colors.orange
-              : Colors.blue,
+      backgroundColor: controller?.value.focusMode == FocusMode.locked
+          ? Colors.orange
+          : Colors.blue,
     );
 
     return SizeTransition(
@@ -487,10 +468,9 @@ class _CameraExampleHomeState extends State<CameraExampleHome>
                 children: <Widget>[
                   TextButton(
                     style: styleAuto,
-                    onPressed:
-                        controller != null
-                            ? () => onSetFocusModeButtonPressed(FocusMode.auto)
-                            : null,
+                    onPressed: controller != null
+                        ? () => onSetFocusModeButtonPressed(FocusMode.auto)
+                        : null,
                     onLongPress: () {
                       if (controller != null) {
                         controller!.setFocusPoint(null);
@@ -501,11 +481,9 @@ class _CameraExampleHomeState extends State<CameraExampleHome>
                   ),
                   TextButton(
                     style: styleLocked,
-                    onPressed:
-                        controller != null
-                            ? () =>
-                                onSetFocusModeButtonPressed(FocusMode.locked)
-                            : null,
+                    onPressed: controller != null
+                        ? () => onSetFocusModeButtonPressed(FocusMode.locked)
+                        : null,
                     child: const Text('LOCKED'),
                   ),
                 ],
@@ -527,48 +505,43 @@ class _CameraExampleHomeState extends State<CameraExampleHome>
         IconButton(
           icon: const Icon(Icons.camera_alt),
           color: Colors.blue,
-          onPressed:
-              cameraController != null &&
-                      cameraController.value.isInitialized &&
-                      !cameraController.value.isRecordingVideo
-                  ? onTakePictureButtonPressed
-                  : null,
+          onPressed: cameraController != null &&
+                  cameraController.value.isInitialized &&
+                  !cameraController.value.isRecordingVideo
+              ? onTakePictureButtonPressed
+              : null,
         ),
         IconButton(
           icon: const Icon(Icons.videocam),
           color: Colors.blue,
-          onPressed:
-              cameraController != null &&
-                      cameraController.value.isInitialized &&
-                      !cameraController.value.isRecordingVideo
-                  ? onVideoRecordButtonPressed
-                  : null,
+          onPressed: cameraController != null &&
+                  cameraController.value.isInitialized &&
+                  !cameraController.value.isRecordingVideo
+              ? onVideoRecordButtonPressed
+              : null,
         ),
         IconButton(
-          icon:
-              cameraController != null &&
-                      cameraController.value.isRecordingPaused
-                  ? const Icon(Icons.play_arrow)
-                  : const Icon(Icons.pause),
+          icon: cameraController != null &&
+                  cameraController.value.isRecordingPaused
+              ? const Icon(Icons.play_arrow)
+              : const Icon(Icons.pause),
           color: Colors.blue,
-          onPressed:
-              cameraController != null &&
-                      cameraController.value.isInitialized &&
-                      cameraController.value.isRecordingVideo
-                  ? (cameraController.value.isRecordingPaused)
-                      ? onResumeButtonPressed
-                      : onPauseButtonPressed
-                  : null,
+          onPressed: cameraController != null &&
+                  cameraController.value.isInitialized &&
+                  cameraController.value.isRecordingVideo
+              ? (cameraController.value.isRecordingPaused)
+                  ? onResumeButtonPressed
+                  : onPauseButtonPressed
+              : null,
         ),
         IconButton(
           icon: const Icon(Icons.stop),
           color: Colors.red,
-          onPressed:
-              cameraController != null &&
-                      cameraController.value.isInitialized &&
-                      cameraController.value.isRecordingVideo
-                  ? onStopButtonPressed
-                  : null,
+          onPressed: cameraController != null &&
+                  cameraController.value.isInitialized &&
+                  cameraController.value.isRecordingVideo
+              ? onStopButtonPressed
+              : null,
         ),
         IconButton(
           icon: const Icon(Icons.pause_presentation),
@@ -684,20 +657,20 @@ class _CameraExampleHomeState extends State<CameraExampleHome>
         // The exposure mode is currently not supported on the web.
         ...!kIsWeb
             ? <Future<Object?>>[
-              cameraController.getMinExposureOffset().then(
-                (double value) => _minAvailableExposureOffset = value,
-              ),
-              cameraController.getMaxExposureOffset().then(
-                (double value) => _maxAvailableExposureOffset = value,
-              ),
-            ]
+                cameraController.getMinExposureOffset().then(
+                      (double value) => _minAvailableExposureOffset = value,
+                    ),
+                cameraController.getMaxExposureOffset().then(
+                      (double value) => _maxAvailableExposureOffset = value,
+                    ),
+              ]
             : <Future<Object?>>[],
         cameraController.getMaxZoomLevel().then(
-          (double value) => _maxAvailableZoom = value,
-        ),
+              (double value) => _maxAvailableZoom = value,
+            ),
         cameraController.getMinZoomLevel().then(
-          (double value) => _minAvailableZoom = value,
-        ),
+              (double value) => _minAvailableZoom = value,
+            ),
       ]);
     } on CameraException catch (e) {
       switch (e.code) {
@@ -1012,10 +985,9 @@ class _CameraExampleHomeState extends State<CameraExampleHome>
       return;
     }
 
-    final VideoPlayerController vController =
-        kIsWeb
-            ? VideoPlayerController.network(videoFile!.path)
-            : VideoPlayerController.file(File(videoFile!.path));
+    final VideoPlayerController vController = kIsWeb
+        ? VideoPlayerController.network(videoFile!.path)
+        : VideoPlayerController.file(File(videoFile!.path));
 
     videoPlayerListener = () {
       if (videoController != null) {

--- a/packages/camera/lib/camera_tizen.dart
+++ b/packages/camera/lib/camera_tizen.dart
@@ -97,13 +97,12 @@ class CameraTizen extends CameraPlatform {
     try {
       final Map<String, dynamic>? reply = await _channel
           .invokeMapMethod<String, dynamic>('create', <String, dynamic>{
-            'cameraName': cameraDescription.name,
-            'resolutionPreset':
-                resolutionPreset != null
-                    ? _serializeResolutionPreset(resolutionPreset)
-                    : null,
-            'enableAudio': enableAudio,
-          });
+        'cameraName': cameraDescription.name,
+        'resolutionPreset': resolutionPreset != null
+            ? _serializeResolutionPreset(resolutionPreset)
+            : null,
+        'enableAudio': enableAudio,
+      });
 
       return reply!['cameraId']! as int;
     } on PlatformException catch (e) {
@@ -132,27 +131,25 @@ class CameraTizen extends CameraPlatform {
       completer.complete();
     });
 
-    _channel
-        .invokeMapMethod<String, dynamic>('initialize', <String, dynamic>{
-          'cameraId': cameraId,
-          'imageFormatGroup': imageFormatGroup.name(),
-        })
-        .catchError(
-          // TODO(srawlins): This should return a value of the future's type. This
-          // will fail upcoming analysis checks with
-          // https://github.com/flutter/flutter/issues/105750.
-          // ignore: body_might_complete_normally_catch_error
-          (Object error, StackTrace stackTrace) {
-            if (error is! PlatformException) {
-              // ignore: only_throw_errors
-              throw error;
-            }
-            completer.completeError(
-              CameraException(error.code, error.message),
-              stackTrace,
-            );
-          },
+    _channel.invokeMapMethod<String, dynamic>('initialize', <String, dynamic>{
+      'cameraId': cameraId,
+      'imageFormatGroup': imageFormatGroup.name(),
+    }).catchError(
+      // TODO(srawlins): This should return a value of the future's type. This
+      // will fail upcoming analysis checks with
+      // https://github.com/flutter/flutter/issues/105750.
+      // ignore: body_might_complete_normally_catch_error
+      (Object error, StackTrace stackTrace) {
+        if (error is! PlatformException) {
+          // ignore: only_throw_errors
+          throw error;
+        }
+        completer.completeError(
+          CameraException(error.code, error.message),
+          stackTrace,
         );
+      },
+    );
 
     return completer.future;
   }
@@ -274,9 +271,9 @@ class CameraTizen extends CameraPlatform {
 
   @override
   Future<void> pauseVideoRecording(int cameraId) => _channel.invokeMethod<void>(
-    'pauseVideoRecording',
-    <String, dynamic>{'cameraId': cameraId},
-  );
+        'pauseVideoRecording',
+        <String, dynamic>{'cameraId': cameraId},
+      );
 
   @override
   Future<void> resumeVideoRecording(int cameraId) =>
@@ -307,13 +304,12 @@ class CameraTizen extends CameraPlatform {
     const EventChannel cameraEventChannel = EventChannel(
       'plugins.flutter.io/camera_tizen/imageStream',
     );
-    _platformImageStreamSubscription = cameraEventChannel
-        .receiveBroadcastStream()
-        .listen((dynamic imageData) {
-          _frameStreamController!.add(
-            cameraImageFromPlatformData(imageData as Map<dynamic, dynamic>),
-          );
-        });
+    _platformImageStreamSubscription =
+        cameraEventChannel.receiveBroadcastStream().listen((dynamic imageData) {
+      _frameStreamController!.add(
+        cameraImageFromPlatformData(imageData as Map<dynamic, dynamic>),
+      );
+    });
   }
 
   FutureOr<void> _onFrameStreamCancel() async {

--- a/packages/device_info_plus/CHANGELOG.md
+++ b/packages/device_info_plus/CHANGELOG.md
@@ -1,3 +1,7 @@
+## NEXT
+
+* Update code format.
+
 ## 1.2.1
 
 * Update minimum Flutter and Dart version to 3.13 and 3.1.

--- a/packages/device_info_plus/example/lib/main.dart
+++ b/packages/device_info_plus/example/lib/main.dart
@@ -90,30 +90,29 @@ class _MyAppState extends State<MyApp> {
       home: Scaffold(
         appBar: AppBar(title: const Text('Tizen Device Info'), elevation: 4),
         body: ListView(
-          children:
-              _deviceData.keys.map((String property) {
-                return Row(
-                  children: <Widget>[
-                    Container(
-                      padding: const EdgeInsets.all(10),
-                      child: Text(
-                        property,
-                        style: const TextStyle(fontWeight: FontWeight.bold),
-                      ),
+          children: _deviceData.keys.map((String property) {
+            return Row(
+              children: <Widget>[
+                Container(
+                  padding: const EdgeInsets.all(10),
+                  child: Text(
+                    property,
+                    style: const TextStyle(fontWeight: FontWeight.bold),
+                  ),
+                ),
+                Expanded(
+                  child: Container(
+                    padding: const EdgeInsets.symmetric(vertical: 10),
+                    child: Text(
+                      '${_deviceData[property]}',
+                      maxLines: 10,
+                      overflow: TextOverflow.ellipsis,
                     ),
-                    Expanded(
-                      child: Container(
-                        padding: const EdgeInsets.symmetric(vertical: 10),
-                        child: Text(
-                          '${_deviceData[property]}',
-                          maxLines: 10,
-                          overflow: TextOverflow.ellipsis,
-                        ),
-                      ),
-                    ),
-                  ],
-                );
-              }).toList(),
+                  ),
+                ),
+              ],
+            );
+          }).toList(),
         ),
       ),
     );

--- a/packages/device_info_plus/lib/device_info_plus_tizen.dart
+++ b/packages/device_info_plus/lib/device_info_plus_tizen.dart
@@ -129,7 +129,8 @@ class _MethodChannelDeviceInfo {
     return TizenDeviceInfo.fromMap(
       (await channel.invokeMethod(
         'getTizenDeviceInfo',
-      )).cast<String, dynamic>(),
+      ))
+          .cast<String, dynamic>(),
     );
   }
 }

--- a/packages/firebase_core/CHANGELOG.md
+++ b/packages/firebase_core/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 * Update minimum Flutter and Dart version to 3.13 and 3.1.
 * Fix new lint warnings.
+* Update code format.
 
 ## 0.1.1
 

--- a/packages/firebase_core/example/lib/main.dart
+++ b/packages/firebase_core/example/lib/main.dart
@@ -17,11 +17,11 @@ class MyApp extends StatelessWidget {
   String get name => 'foo';
 
   FirebaseOptions get firebaseOptions => const FirebaseOptions(
-    appId: '1:448618578101:ios:0b650370bb29e29cac3efc',
-    apiKey: 'AIzaSyAgUhHU8wSJgO5MVNy95tMT07NEjzMOfz0',
-    projectId: 'react-native-firebase-testing',
-    messagingSenderId: '448618578101',
-  );
+        appId: '1:448618578101:ios:0b650370bb29e29cac3efc',
+        apiKey: 'AIzaSyAgUhHU8wSJgO5MVNy95tMT07NEjzMOfz0',
+        projectId: 'react-native-firebase-testing',
+        messagingSenderId: '448618578101',
+      );
 
   Future<void> initializeDefault() async {
     final FirebaseApp app = await Firebase.initializeApp(

--- a/packages/firebase_core/lib/firebase_core_tizen.dart
+++ b/packages/firebase_core/lib/firebase_core_tizen.dart
@@ -60,10 +60,11 @@ class FirebaseCore extends FirebasePlatform {
 
     try {
       // Initialize the app in firebase_core_dart
-      final core_dart.FirebaseOptions dartOptions = core_dart
-          .FirebaseOptions.fromMap(options!.asMap);
-      final core_dart.FirebaseApp dartApp = await core_dart
-          .Firebase.initializeApp(name: name, options: dartOptions);
+      final core_dart.FirebaseOptions dartOptions =
+          core_dart.FirebaseOptions.fromMap(options!.asMap);
+      final core_dart.FirebaseApp dartApp =
+          await core_dart.Firebase.initializeApp(
+              name: name, options: dartOptions);
 
       return _mapDartToPlatfromApp(dartApp);
     } on core_dart.FirebaseException catch (e) {

--- a/packages/flutter_secure_storage/CHANGELOG.md
+++ b/packages/flutter_secure_storage/CHANGELOG.md
@@ -1,3 +1,7 @@
+## NEXT
+
+* Update code format.
+
 ## 0.1.2
 
 * Fixed an issue causing crashes when encrypting or decrypting empty strings by adding appropriate checks and handling in `Encrypt` and `Decrypt` methods.

--- a/packages/flutter_secure_storage/example/lib/main.dart
+++ b/packages/flutter_secure_storage/example/lib/main.dart
@@ -73,93 +73,91 @@ class ItemsWidgetState extends State<ItemsWidget> {
   IOSOptions _getIOSOptions() => IOSOptions(accountName: _getAccountName());
 
   AndroidOptions _getAndroidOptions() => const AndroidOptions(
-    encryptedSharedPreferences: true,
-    // sharedPreferencesName: 'Test2',
-    // preferencesKeyPrefix: 'Test'
-  );
+        encryptedSharedPreferences: true,
+        // sharedPreferencesName: 'Test2',
+        // preferencesKeyPrefix: 'Test'
+      );
 
   String? _getAccountName() =>
       _accountNameController.text.isEmpty ? null : _accountNameController.text;
 
   @override
   Widget build(BuildContext context) => Scaffold(
-    appBar: AppBar(
-      title: const Text('Plugin example app'),
-      actions: <Widget>[
-        IconButton(
-          key: const Key('add_random'),
-          onPressed: _addNewItem,
-          icon: const Icon(Icons.add),
-        ),
-        PopupMenuButton<_Actions>(
-          key: const Key('popup_menu'),
-          onSelected: (action) {
-            switch (action) {
-              case _Actions.deleteAll:
-                _deleteAll();
-            }
-          },
-          itemBuilder:
-              (BuildContext context) => <PopupMenuEntry<_Actions>>[
+        appBar: AppBar(
+          title: const Text('Plugin example app'),
+          actions: <Widget>[
+            IconButton(
+              key: const Key('add_random'),
+              onPressed: _addNewItem,
+              icon: const Icon(Icons.add),
+            ),
+            PopupMenuButton<_Actions>(
+              key: const Key('popup_menu'),
+              onSelected: (action) {
+                switch (action) {
+                  case _Actions.deleteAll:
+                    _deleteAll();
+                }
+              },
+              itemBuilder: (BuildContext context) => <PopupMenuEntry<_Actions>>[
                 const PopupMenuItem(
                   key: Key('delete_all'),
                   value: _Actions.deleteAll,
                   child: Text('Delete all'),
                 ),
               ],
-        ),
-      ],
-    ),
-    body: Column(
-      children: [
-        if (!kIsWeb && Platform.isIOS)
-          Padding(
-            padding: const EdgeInsets.symmetric(horizontal: 16),
-            child: TextFormField(
-              controller: _accountNameController,
-              decoration: const InputDecoration(labelText: 'kSecAttrService'),
             ),
-          ),
-        Expanded(
-          child: ListView.builder(
-            itemCount: _items.length,
-            itemBuilder:
-                (BuildContext context, int index) => ListTile(
+          ],
+        ),
+        body: Column(
+          children: [
+            if (!kIsWeb && Platform.isIOS)
+              Padding(
+                padding: const EdgeInsets.symmetric(horizontal: 16),
+                child: TextFormField(
+                  controller: _accountNameController,
+                  decoration:
+                      const InputDecoration(labelText: 'kSecAttrService'),
+                ),
+              ),
+            Expanded(
+              child: ListView.builder(
+                itemCount: _items.length,
+                itemBuilder: (BuildContext context, int index) => ListTile(
                   trailing: PopupMenuButton(
                     key: Key('popup_row_$index'),
-                    onSelected:
-                        (_ItemActions action) =>
-                            _performAction(action, _items[index], context),
-                    itemBuilder:
-                        (
-                          BuildContext context,
-                        ) => <PopupMenuEntry<_ItemActions>>[
-                          PopupMenuItem(
-                            value: _ItemActions.delete,
-                            child: Text(
-                              'Delete',
-                              key: Key('delete_row_$index'),
-                            ),
-                          ),
-                          PopupMenuItem(
-                            value: _ItemActions.edit,
-                            child: Text('Edit', key: Key('edit_row_$index')),
-                          ),
-                          PopupMenuItem(
-                            value: _ItemActions.containsKey,
-                            child: Text(
-                              'Contains Key',
-                              key: Key('contains_row_$index'),
-                            ),
-                          ),
-                          PopupMenuItem(
-                            value: _ItemActions.read,
-                            child: Text(
-                              'Read',
-                              key: Key('contains_row_$index'),
-                            ),
-                          ),
-                        ],
+                    onSelected: (_ItemActions action) =>
+                        _performAction(action, _items[index], context),
+                    itemBuilder: (
+                      BuildContext context,
+                    ) =>
+                        <PopupMenuEntry<_ItemActions>>[
+                      PopupMenuItem(
+                        value: _ItemActions.delete,
+                        child: Text(
+                          'Delete',
+                          key: Key('delete_row_$index'),
+                        ),
+                      ),
+                      PopupMenuItem(
+                        value: _ItemActions.edit,
+                        child: Text('Edit', key: Key('edit_row_$index')),
+                      ),
+                      PopupMenuItem(
+                        value: _ItemActions.containsKey,
+                        child: Text(
+                          'Contains Key',
+                          key: Key('contains_row_$index'),
+                        ),
+                      ),
+                      PopupMenuItem(
+                        value: _ItemActions.read,
+                        child: Text(
+                          'Read',
+                          key: Key('contains_row_$index'),
+                        ),
+                      ),
+                    ],
                   ),
                   title: Text(
                     _items[index].value,
@@ -170,11 +168,11 @@ class ItemsWidgetState extends State<ItemsWidget> {
                     key: Key('subtitle_row_$index'),
                   ),
                 ),
-          ),
+              ),
+            ),
+          ],
         ),
-      ],
-    ),
-  );
+      );
 
   Future<void> _performAction(
     _ItemActions action,
@@ -266,7 +264,7 @@ class ItemsWidgetState extends State<ItemsWidget> {
 
 class _EditItemWidget extends StatelessWidget {
   _EditItemWidget(String text)
-    : _controller = TextEditingController(text: text);
+      : _controller = TextEditingController(text: text);
 
   final TextEditingController _controller;
 

--- a/packages/flutter_tts/CHANGELOG.md
+++ b/packages/flutter_tts/CHANGELOG.md
@@ -1,3 +1,7 @@
+## NEXT
+
+* Update code format.
+
 ## 1.5.0
 
 * Update minimum Flutter and Dart version to 3.13 and 3.1.

--- a/packages/flutter_tts/example/lib/main.dart
+++ b/packages/flutter_tts/example/lib/main.dart
@@ -184,29 +184,29 @@ class _MyAppState extends State<MyApp> {
   }
 
   Widget _futureBuilder() => FutureBuilder<dynamic>(
-    future: _getLanguages(),
-    builder: (BuildContext context, AsyncSnapshot<dynamic> snapshot) {
-      if (snapshot.hasData) {
-        return _languageDropDownSection(snapshot.data as List<dynamic>);
-      } else if (snapshot.hasError) {
-        return Text('Error loading languages...');
-      } else
-        return Text('Loading Languages...');
-    },
-  );
+        future: _getLanguages(),
+        builder: (BuildContext context, AsyncSnapshot<dynamic> snapshot) {
+          if (snapshot.hasData) {
+            return _languageDropDownSection(snapshot.data as List<dynamic>);
+          } else if (snapshot.hasError) {
+            return Text('Error loading languages...');
+          } else
+            return Text('Loading Languages...');
+        },
+      );
 
   Widget _inputSection() => Container(
-    alignment: Alignment.topCenter,
-    padding: EdgeInsets.only(top: 25.0, left: 25.0, right: 25.0),
-    child: TextField(
-      maxLines: 11,
-      minLines: 6,
-      onChanged: (String value) {
-        _onChange(value);
-      },
-      controller: TextEditingController(text: _newVoiceText),
-    ),
-  );
+        alignment: Alignment.topCenter,
+        padding: EdgeInsets.only(top: 25.0, left: 25.0, right: 25.0),
+        child: TextField(
+          maxLines: 11,
+          minLines: 6,
+          onChanged: (String value) {
+            _onChange(value);
+          },
+          controller: TextEditingController(text: _newVoiceText),
+        ),
+      );
 
   Widget _btnSection() {
     return Container(
@@ -241,18 +241,18 @@ class _MyAppState extends State<MyApp> {
   }
 
   Widget _languageDropDownSection(List<dynamic> languages) => Container(
-    padding: EdgeInsets.only(top: 10.0),
-    child: Row(
-      mainAxisAlignment: MainAxisAlignment.center,
-      children: [
-        DropdownButton(
-          value: language,
-          items: getLanguageDropDownMenuItems(languages),
-          onChanged: changedLanguageDropDownItem,
+        padding: EdgeInsets.only(top: 10.0),
+        child: Row(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            DropdownButton(
+              value: language,
+              items: getLanguageDropDownMenuItems(languages),
+              onChanged: changedLanguageDropDownItem,
+            ),
+          ],
         ),
-      ],
-    ),
-  );
+      );
 
   Column _buildButtonColumn(
     Color color,

--- a/packages/flutter_webrtc/CHANGELOG.md
+++ b/packages/flutter_webrtc/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 * Update minimum Flutter and Dart version to 3.13 and 3.1.
 * Fix analyze issue.
+* Update code format.
 
 ## 0.1.3
 

--- a/packages/flutter_webrtc/example/flutter_webrtc_demo/lib/main.dart
+++ b/packages/flutter_webrtc/example/flutter_webrtc_demo/lib/main.dart
@@ -81,11 +81,9 @@ class _MyAppState extends State<MyApp> {
           Navigator.push(
             context,
             MaterialPageRoute(
-              builder:
-                  (BuildContext context) =>
-                      _datachannel
-                          ? DataChannelSample(host: _server)
-                          : CallSample(host: _server),
+              builder: (BuildContext context) => _datachannel
+                  ? DataChannelSample(host: _server)
+                  : CallSample(host: _server),
             ),
           );
         }

--- a/packages/flutter_webrtc/example/flutter_webrtc_demo/lib/src/call_sample/call_sample.dart
+++ b/packages/flutter_webrtc/example/flutter_webrtc_demo/lib/src/call_sample/call_sample.dart
@@ -298,78 +298,76 @@ class _CallSampleState extends State<CallSample> {
         ],
       ),
       floatingActionButtonLocation: FloatingActionButtonLocation.centerFloat,
-      floatingActionButton:
-          _inCalling
-              ? SizedBox(
-                width: 240.0,
-                child: Row(
-                  mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                  children: <Widget>[
-                    FloatingActionButton(
-                      tooltip: 'Camera',
-                      onPressed: _switchCamera,
-                      child: const Icon(Icons.switch_camera),
-                    ),
-                    FloatingActionButton(
-                      tooltip: 'Screen Sharing',
-                      onPressed: () => selectScreenSourceDialog(context),
-                      child: const Icon(Icons.desktop_mac),
-                    ),
-                    FloatingActionButton(
-                      onPressed: _hangUp,
-                      tooltip: 'Hangup',
-                      backgroundColor: Colors.pink,
-                      child: Icon(Icons.call_end),
-                    ),
-                    FloatingActionButton(
-                      tooltip: 'Mute Mic',
-                      onPressed: _muteMic,
-                      child: const Icon(Icons.mic_off),
-                    ),
-                  ],
-                ),
-              )
-              : null,
-      body:
-          _inCalling
-              ? OrientationBuilder(
-                builder: (context, orientation) {
-                  return Container(
-                    width: MediaQuery.of(context).size.width,
-                    height: MediaQuery.of(context).size.height,
-                    child: Row(
-                      children: <Widget>[
-                        Expanded(
-                          flex: 1,
-                          child: Container(
-                            alignment: Alignment.center,
-                            padding: const EdgeInsets.all(8.0),
-                            decoration: BoxDecoration(color: Colors.black54),
-                            child: RTCVideoView(_localRenderer),
-                          ),
-                        ),
-                        Expanded(
-                          flex: 1,
-                          child: Container(
-                            alignment: Alignment.center,
-                            padding: const EdgeInsets.all(8.0),
-                            decoration: BoxDecoration(color: Colors.black54),
-                            child: RTCVideoView(_remoteRenderer),
-                          ),
-                        ),
-                      ],
-                    ),
-                  );
-                },
-              )
-              : ListView.builder(
-                shrinkWrap: true,
-                padding: const EdgeInsets.all(0.0),
-                itemCount: _peers.length,
-                itemBuilder: (context, i) {
-                  return _buildRow(context, _peers[i]);
-                },
+      floatingActionButton: _inCalling
+          ? SizedBox(
+              width: 240.0,
+              child: Row(
+                mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                children: <Widget>[
+                  FloatingActionButton(
+                    tooltip: 'Camera',
+                    onPressed: _switchCamera,
+                    child: const Icon(Icons.switch_camera),
+                  ),
+                  FloatingActionButton(
+                    tooltip: 'Screen Sharing',
+                    onPressed: () => selectScreenSourceDialog(context),
+                    child: const Icon(Icons.desktop_mac),
+                  ),
+                  FloatingActionButton(
+                    onPressed: _hangUp,
+                    tooltip: 'Hangup',
+                    backgroundColor: Colors.pink,
+                    child: Icon(Icons.call_end),
+                  ),
+                  FloatingActionButton(
+                    tooltip: 'Mute Mic',
+                    onPressed: _muteMic,
+                    child: const Icon(Icons.mic_off),
+                  ),
+                ],
               ),
+            )
+          : null,
+      body: _inCalling
+          ? OrientationBuilder(
+              builder: (context, orientation) {
+                return Container(
+                  width: MediaQuery.of(context).size.width,
+                  height: MediaQuery.of(context).size.height,
+                  child: Row(
+                    children: <Widget>[
+                      Expanded(
+                        flex: 1,
+                        child: Container(
+                          alignment: Alignment.center,
+                          padding: const EdgeInsets.all(8.0),
+                          decoration: BoxDecoration(color: Colors.black54),
+                          child: RTCVideoView(_localRenderer),
+                        ),
+                      ),
+                      Expanded(
+                        flex: 1,
+                        child: Container(
+                          alignment: Alignment.center,
+                          padding: const EdgeInsets.all(8.0),
+                          decoration: BoxDecoration(color: Colors.black54),
+                          child: RTCVideoView(_remoteRenderer),
+                        ),
+                      ),
+                    ],
+                  ),
+                );
+              },
+            )
+          : ListView.builder(
+              shrinkWrap: true,
+              padding: const EdgeInsets.all(0.0),
+              itemCount: _peers.length,
+              itemBuilder: (context, i) {
+                return _buildRow(context, _peers[i]);
+              },
+            ),
     );
   }
 }

--- a/packages/flutter_webrtc/example/flutter_webrtc_demo/lib/src/call_sample/data_channel_sample.dart
+++ b/packages/flutter_webrtc/example/flutter_webrtc_demo/lib/src/call_sample/data_channel_sample.dart
@@ -233,25 +233,23 @@ class _DataChannelSampleState extends State<DataChannelSample> {
           ),
         ],
       ),
-      floatingActionButton:
-          _inCalling
-              ? FloatingActionButton(
-                onPressed: _hangUp,
-                tooltip: 'Hangup',
-                child: Icon(Icons.call_end),
-              )
-              : null,
-      body:
-          _inCalling
-              ? Center(child: Container(child: Text('Received => $_text')))
-              : ListView.builder(
-                shrinkWrap: true,
-                padding: const EdgeInsets.all(0.0),
-                itemCount: _peers.length,
-                itemBuilder: (context, i) {
-                  return _buildRow(context, _peers[i]);
-                },
-              ),
+      floatingActionButton: _inCalling
+          ? FloatingActionButton(
+              onPressed: _hangUp,
+              tooltip: 'Hangup',
+              child: Icon(Icons.call_end),
+            )
+          : null,
+      body: _inCalling
+          ? Center(child: Container(child: Text('Received => $_text')))
+          : ListView.builder(
+              shrinkWrap: true,
+              padding: const EdgeInsets.all(0.0),
+              itemCount: _peers.length,
+              itemBuilder: (context, i) {
+                return _buildRow(context, _peers[i]);
+              },
+            ),
     );
   }
 }

--- a/packages/flutter_webrtc/example/flutter_webrtc_demo/lib/src/call_sample/signaling.dart
+++ b/packages/flutter_webrtc/example/flutter_webrtc_demo/lib/src/call_sample/signaling.dart
@@ -57,7 +57,7 @@ class Signaling {
   Function(Session session, MediaStream stream)? onRemoveRemoteStream;
   Function(dynamic event)? onPeersUpdate;
   Function(Session session, RTCDataChannel dc, RTCDataChannelMessage data)?
-  onDataChannelMessage;
+      onDataChannelMessage;
   Function(Session session, RTCDataChannel dc)? onDataChannel;
 
   String get sdpSemantics => 'unified-plan';
@@ -342,19 +342,18 @@ class Signaling {
   }) async {
     final mediaConstraints = <String, dynamic>{
       'audio': userScreen ? false : true,
-      'video':
-          userScreen
-              ? true
-              : {
-                'mandatory': {
-                  'minWidth':
-                      '640', // Provide your own width, height and frame rate here
-                  'minHeight': '480',
-                  'minFrameRate': '30',
-                },
-                'facingMode': 'user',
-                'optional': [],
+      'video': userScreen
+          ? true
+          : {
+              'mandatory': {
+                'minWidth':
+                    '640', // Provide your own width, height and frame rate here
+                'minHeight': '480',
+                'minFrameRate': '30',
               },
+              'facingMode': 'user',
+              'optional': [],
+            },
     };
     late MediaStream stream;
     if (userScreen) {
@@ -364,13 +363,12 @@ class Signaling {
           builder: (context) => ScreenSelectDialog(),
         );
         stream = await navigator.mediaDevices.getDisplayMedia(<String, dynamic>{
-          'video':
-              source == null
-                  ? true
-                  : {
-                    'deviceId': {'exact': source.id},
-                    'mandatory': {'frameRate': 30.0},
-                  },
+          'video': source == null
+              ? true
+              : {
+                  'deviceId': {'exact': source.id},
+                  'mandatory': {'frameRate': 30.0},
+                },
         });
       } else {
         stream = await navigator.mediaDevices.getDisplayMedia(mediaConstraints);

--- a/packages/flutter_webrtc/example/flutter_webrtc_demo/lib/src/utils/screen_select_dialog.dart
+++ b/packages/flutter_webrtc/example/flutter_webrtc_demo/lib/src/utils/screen_select_dialog.dart
@@ -50,25 +50,23 @@ class _ThumbnailWidgetState extends State<ThumbnailWidget> {
       children: [
         Expanded(
           child: Container(
-            decoration:
-                widget.selected
-                    ? BoxDecoration(
-                      border: Border.all(width: 2, color: Colors.blueAccent),
-                    )
-                    : null,
+            decoration: widget.selected
+                ? BoxDecoration(
+                    border: Border.all(width: 2, color: Colors.blueAccent),
+                  )
+                : null,
             child: InkWell(
               onTap: () {
                 print('Selected source id => ${widget.source.id}');
                 widget.onTap(widget.source);
               },
-              child:
-                  widget.source.thumbnail != null
-                      ? Image.memory(
-                        widget.source.thumbnail!,
-                        gaplessPlayback: true,
-                        alignment: Alignment.center,
-                      )
-                      : Container(),
+              child: widget.source.thumbnail != null
+                  ? Image.memory(
+                      widget.source.thumbnail!,
+                      gaplessPlayback: true,
+                      alignment: Alignment.center,
+                    )
+                  : Container(),
             ),
           ),
         ),
@@ -204,17 +202,15 @@ class ScreenSelectDialog extends Dialog {
                             Container(
                               constraints: BoxConstraints.expand(height: 24),
                               child: TabBar(
-                                onTap:
-                                    (value) => Future.delayed(
-                                      Duration(milliseconds: 300),
-                                      () {
-                                        _sourceType =
-                                            value == 0
-                                                ? SourceType.Screen
-                                                : SourceType.Window;
-                                        _getSources();
-                                      },
-                                    ),
+                                onTap: (value) => Future.delayed(
+                                  Duration(milliseconds: 300),
+                                  () {
+                                    _sourceType = value == 0
+                                        ? SourceType.Screen
+                                        : SourceType.Window;
+                                    _getSources();
+                                  },
+                                ),
                                 tabs: [
                                   Tab(
                                     child: Text(
@@ -242,28 +238,26 @@ class ScreenSelectDialog extends Dialog {
                                         child: GridView.count(
                                           crossAxisSpacing: 8,
                                           crossAxisCount: 2,
-                                          children:
-                                              _sources.entries
-                                                  .where(
-                                                    (element) =>
-                                                        element.value.type ==
-                                                        SourceType.Screen,
-                                                  )
-                                                  .map(
-                                                    (e) => ThumbnailWidget(
-                                                      onTap: (source) {
-                                                        setState(() {
-                                                          _selectedSource =
-                                                              source;
-                                                        });
-                                                      },
-                                                      source: e.value,
-                                                      selected:
-                                                          _selectedSource?.id ==
+                                          children: _sources.entries
+                                              .where(
+                                                (element) =>
+                                                    element.value.type ==
+                                                    SourceType.Screen,
+                                              )
+                                              .map(
+                                                (e) => ThumbnailWidget(
+                                                  onTap: (source) {
+                                                    setState(() {
+                                                      _selectedSource = source;
+                                                    });
+                                                  },
+                                                  source: e.value,
+                                                  selected:
+                                                      _selectedSource?.id ==
                                                           e.value.id,
-                                                    ),
-                                                  )
-                                                  .toList(),
+                                                ),
+                                              )
+                                              .toList(),
                                         ),
                                       ),
                                     ),
@@ -273,28 +267,26 @@ class ScreenSelectDialog extends Dialog {
                                         child: GridView.count(
                                           crossAxisSpacing: 8,
                                           crossAxisCount: 3,
-                                          children:
-                                              _sources.entries
-                                                  .where(
-                                                    (element) =>
-                                                        element.value.type ==
-                                                        SourceType.Window,
-                                                  )
-                                                  .map(
-                                                    (e) => ThumbnailWidget(
-                                                      onTap: (source) {
-                                                        setState(() {
-                                                          _selectedSource =
-                                                              source;
-                                                        });
-                                                      },
-                                                      source: e.value,
-                                                      selected:
-                                                          _selectedSource?.id ==
+                                          children: _sources.entries
+                                              .where(
+                                                (element) =>
+                                                    element.value.type ==
+                                                    SourceType.Window,
+                                              )
+                                              .map(
+                                                (e) => ThumbnailWidget(
+                                                  onTap: (source) {
+                                                    setState(() {
+                                                      _selectedSource = source;
+                                                    });
+                                                  },
+                                                  source: e.value,
+                                                  selected:
+                                                      _selectedSource?.id ==
                                                           e.value.id,
-                                                    ),
-                                                  )
-                                                  .toList(),
+                                                ),
+                                              )
+                                              .toList(),
                                         ),
                                       ),
                                     ),

--- a/packages/flutter_webrtc/example/flutter_webrtc_demo/lib/src/widgets/screen_select_dialog.dart
+++ b/packages/flutter_webrtc/example/flutter_webrtc_demo/lib/src/widgets/screen_select_dialog.dart
@@ -50,25 +50,23 @@ class _ThumbnailWidgetState extends State<ThumbnailWidget> {
       children: [
         Expanded(
           child: Container(
-            decoration:
-                widget.selected
-                    ? BoxDecoration(
-                      border: Border.all(width: 2, color: Colors.blueAccent),
-                    )
-                    : null,
+            decoration: widget.selected
+                ? BoxDecoration(
+                    border: Border.all(width: 2, color: Colors.blueAccent),
+                  )
+                : null,
             child: InkWell(
               onTap: () {
                 print('Selected source id => ${widget.source.id}');
                 widget.onTap(widget.source);
               },
-              child:
-                  widget.source.thumbnail != null
-                      ? Image.memory(
-                        widget.source.thumbnail!,
-                        gaplessPlayback: true,
-                        alignment: Alignment.center,
-                      )
-                      : Container(),
+              child: widget.source.thumbnail != null
+                  ? Image.memory(
+                      widget.source.thumbnail!,
+                      gaplessPlayback: true,
+                      alignment: Alignment.center,
+                    )
+                  : Container(),
             ),
           ),
         ),
@@ -204,17 +202,15 @@ class ScreenSelectDialog extends Dialog {
                             Container(
                               constraints: BoxConstraints.expand(height: 24),
                               child: TabBar(
-                                onTap:
-                                    (value) => Future.delayed(
-                                      Duration(milliseconds: 300),
-                                      () {
-                                        _sourceType =
-                                            value == 0
-                                                ? SourceType.Screen
-                                                : SourceType.Window;
-                                        _getSources();
-                                      },
-                                    ),
+                                onTap: (value) => Future.delayed(
+                                  Duration(milliseconds: 300),
+                                  () {
+                                    _sourceType = value == 0
+                                        ? SourceType.Screen
+                                        : SourceType.Window;
+                                    _getSources();
+                                  },
+                                ),
                                 tabs: [
                                   Tab(
                                     child: Text(
@@ -242,28 +238,26 @@ class ScreenSelectDialog extends Dialog {
                                         child: GridView.count(
                                           crossAxisSpacing: 8,
                                           crossAxisCount: 2,
-                                          children:
-                                              _sources.entries
-                                                  .where(
-                                                    (element) =>
-                                                        element.value.type ==
-                                                        SourceType.Screen,
-                                                  )
-                                                  .map(
-                                                    (e) => ThumbnailWidget(
-                                                      onTap: (source) {
-                                                        setState(() {
-                                                          _selectedSource =
-                                                              source;
-                                                        });
-                                                      },
-                                                      source: e.value,
-                                                      selected:
-                                                          _selectedSource?.id ==
+                                          children: _sources.entries
+                                              .where(
+                                                (element) =>
+                                                    element.value.type ==
+                                                    SourceType.Screen,
+                                              )
+                                              .map(
+                                                (e) => ThumbnailWidget(
+                                                  onTap: (source) {
+                                                    setState(() {
+                                                      _selectedSource = source;
+                                                    });
+                                                  },
+                                                  source: e.value,
+                                                  selected:
+                                                      _selectedSource?.id ==
                                                           e.value.id,
-                                                    ),
-                                                  )
-                                                  .toList(),
+                                                ),
+                                              )
+                                              .toList(),
                                         ),
                                       ),
                                     ),
@@ -273,28 +267,26 @@ class ScreenSelectDialog extends Dialog {
                                         child: GridView.count(
                                           crossAxisSpacing: 8,
                                           crossAxisCount: 3,
-                                          children:
-                                              _sources.entries
-                                                  .where(
-                                                    (element) =>
-                                                        element.value.type ==
-                                                        SourceType.Window,
-                                                  )
-                                                  .map(
-                                                    (e) => ThumbnailWidget(
-                                                      onTap: (source) {
-                                                        setState(() {
-                                                          _selectedSource =
-                                                              source;
-                                                        });
-                                                      },
-                                                      source: e.value,
-                                                      selected:
-                                                          _selectedSource?.id ==
+                                          children: _sources.entries
+                                              .where(
+                                                (element) =>
+                                                    element.value.type ==
+                                                    SourceType.Window,
+                                              )
+                                              .map(
+                                                (e) => ThumbnailWidget(
+                                                  onTap: (source) {
+                                                    setState(() {
+                                                      _selectedSource = source;
+                                                    });
+                                                  },
+                                                  source: e.value,
+                                                  selected:
+                                                      _selectedSource?.id ==
                                                           e.value.id,
-                                                    ),
-                                                  )
-                                                  .toList(),
+                                                ),
+                                              )
+                                              .toList(),
                                         ),
                                       ),
                                     ),

--- a/packages/flutter_webrtc/example/flutter_webrtc_example/lib/src/device_enumeration_sample.dart
+++ b/packages/flutter_webrtc/example/flutter_webrtc_example/lib/src/device_enumeration_sample.dart
@@ -54,9 +54,9 @@ class _DeviceEnumerationSampleState extends State<DeviceEnumerationSample> {
   String? _selectedAudioInputId;
 
   MediaDeviceInfo get selectedAudioInput => audioInputs.firstWhere(
-    (device) => device.deviceId == _selectedVideoInputId,
-    orElse: () => audioInputs.first,
-  );
+        (device) => device.deviceId == _selectedVideoInputId,
+        orElse: () => audioInputs.first,
+      );
 
   String? _selectedVideoFPS = '30';
 
@@ -330,12 +330,11 @@ class _DeviceEnumerationSampleState extends State<DeviceEnumerationSample> {
               return _devices
                   .where((device) => device.kind == 'audioinput')
                   .map((device) {
-                    return PopupMenuItem<String>(
-                      value: device.deviceId,
-                      child: Text(device.label),
-                    );
-                  })
-                  .toList();
+                return PopupMenuItem<String>(
+                  value: device.deviceId,
+                  child: Text(device.label),
+                );
+              }).toList();
             },
           ),
           if (!WebRTC.platformIsMobile)
@@ -346,12 +345,11 @@ class _DeviceEnumerationSampleState extends State<DeviceEnumerationSample> {
                 return _devices
                     .where((device) => device.kind == 'audiooutput')
                     .map((device) {
-                      return PopupMenuItem<String>(
-                        value: device.deviceId,
-                        child: Text(device.label),
-                      );
-                    })
-                    .toList();
+                  return PopupMenuItem<String>(
+                    value: device.deviceId,
+                    child: Text(device.label),
+                  );
+                }).toList();
               },
             ),
           if (!kIsWeb && WebRTC.platformIsMobile)
@@ -370,12 +368,11 @@ class _DeviceEnumerationSampleState extends State<DeviceEnumerationSample> {
               return _devices
                   .where((device) => device.kind == 'videoinput')
                   .map((device) {
-                    return PopupMenuItem<String>(
-                      value: device.deviceId,
-                      child: Text(device.label),
-                    );
-                  })
-                  .toList();
+                return PopupMenuItem<String>(
+                  value: device.deviceId,
+                  child: Text(device.label),
+                );
+              }).toList();
             },
           ),
           PopupMenuButton<String>(

--- a/packages/flutter_webrtc/example/flutter_webrtc_example/lib/src/get_display_media_sample.dart
+++ b/packages/flutter_webrtc/example/flutter_webrtc_example/lib/src/get_display_media_sample.dart
@@ -101,13 +101,12 @@ class _GetDisplayMediaSampleState extends State<GetDisplayMediaSample> {
     try {
       var stream = await navigator.mediaDevices.getDisplayMedia(
         <String, dynamic>{
-          'video':
-              selected_source_ == null
-                  ? true
-                  : {
-                    'deviceId': {'exact': selected_source_!.id},
-                    'mandatory': {'frameRate': 30.0},
-                  },
+          'video': selected_source_ == null
+              ? true
+              : {
+                  'deviceId': {'exact': selected_source_!.id},
+                  'mandatory': {'frameRate': 30.0},
+                },
         },
       );
       stream.getVideoTracks()[0].onEnded = () {

--- a/packages/flutter_webrtc/example/flutter_webrtc_example/lib/src/get_user_media_sample.dart
+++ b/packages/flutter_webrtc/example/flutter_webrtc_example/lib/src/get_user_media_sample.dart
@@ -112,8 +112,8 @@ class _GetUserMediaSampleState extends State<GetUserMediaSample> {
     setState(() {});
 
     final videoTrack = _localStream!.getVideoTracks().firstWhere(
-      (track) => track.kind == 'video',
-    );
+          (track) => track.kind == 'video',
+        );
     await _mediaRecorder!.start(filePath, videoTrack: videoTrack);
   }
 
@@ -128,8 +128,8 @@ class _GetUserMediaSampleState extends State<GetUserMediaSample> {
     if (_localStream == null) throw Exception('Stream is not initialized');
 
     final videoTrack = _localStream!.getVideoTracks().firstWhere(
-      (track) => track.kind == 'video',
-    );
+          (track) => track.kind == 'video',
+        );
     final has = await videoTrack.hasTorch();
     if (has) {
       print('[TORCH] Current camera supports torch mode');
@@ -147,8 +147,8 @@ class _GetUserMediaSampleState extends State<GetUserMediaSample> {
 
     // before the release, use can just call native method directly.
     final videoTrack = _localStream!.getVideoTracks().firstWhere(
-      (track) => track.kind == 'video',
-    );
+          (track) => track.kind == 'video',
+        );
     await WebRTC.invokeMethod('mediaStreamTrackSetZoom', <String, dynamic>{
       'trackId': videoTrack.id,
       'zoomLevel': zoomLevel,
@@ -159,8 +159,8 @@ class _GetUserMediaSampleState extends State<GetUserMediaSample> {
     if (_localStream == null) throw Exception('Stream is not initialized');
 
     final videoTrack = _localStream!.getVideoTracks().firstWhere(
-      (track) => track.kind == 'video',
-    );
+          (track) => track.kind == 'video',
+        );
     await Helper.switchCamera(videoTrack);
   }
 
@@ -168,25 +168,24 @@ class _GetUserMediaSampleState extends State<GetUserMediaSample> {
     if (_localStream == null) throw Exception('Stream is not initialized');
 
     final videoTrack = _localStream!.getVideoTracks().firstWhere(
-      (track) => track.kind == 'video',
-    );
+          (track) => track.kind == 'video',
+        );
     final frame = await videoTrack.captureFrame();
     await showDialog(
       context: context,
-      builder:
-          (context) => AlertDialog(
-            content: Image.memory(
-              frame.asUint8List(),
-              height: 720,
-              width: 1280,
-            ),
-            actions: <Widget>[
-              TextButton(
-                onPressed: Navigator.of(context, rootNavigator: true).pop,
-                child: Text('OK'),
-              ),
-            ],
+      builder: (context) => AlertDialog(
+        content: Image.memory(
+          frame.asUint8List(),
+          height: 720,
+          width: 1280,
+        ),
+        actions: <Widget>[
+          TextButton(
+            onPressed: Navigator.of(context, rootNavigator: true).pop,
+            child: Text('OK'),
           ),
+        ],
+      ),
     );
   }
 
@@ -195,44 +194,42 @@ class _GetUserMediaSampleState extends State<GetUserMediaSample> {
     return Scaffold(
       appBar: AppBar(
         title: Text('GetUserMedia API Test'),
-        actions:
-            _inCalling
-                ? <Widget>[
-                  IconButton(
-                    icon: Icon(_isTorchOn ? Icons.flash_off : Icons.flash_on),
-                    onPressed: _toggleTorch,
-                  ),
-                  IconButton(
-                    icon: Icon(Icons.switch_video),
-                    onPressed: _toggleCamera,
-                  ),
-                  IconButton(
-                    icon: Icon(Icons.camera),
-                    onPressed: _captureFrame,
-                  ),
-                  IconButton(
-                    icon: Icon(_isRec ? Icons.stop : Icons.fiber_manual_record),
-                    onPressed: _isRec ? _stopRecording : _startRecording,
-                  ),
-                  PopupMenuButton<String>(
-                    onSelected: _selectAudioOutput,
-                    itemBuilder: (BuildContext context) {
-                      if (_mediaDevicesList != null) {
-                        return _mediaDevicesList!
-                            .where((device) => device.kind == 'audiooutput')
-                            .map((device) {
-                              return PopupMenuItem<String>(
-                                value: device.deviceId,
-                                child: Text(device.label),
-                              );
-                            })
-                            .toList();
-                      }
-                      return [];
-                    },
-                  ),
-                ]
-                : null,
+        actions: _inCalling
+            ? <Widget>[
+                IconButton(
+                  icon: Icon(_isTorchOn ? Icons.flash_off : Icons.flash_on),
+                  onPressed: _toggleTorch,
+                ),
+                IconButton(
+                  icon: Icon(Icons.switch_video),
+                  onPressed: _toggleCamera,
+                ),
+                IconButton(
+                  icon: Icon(Icons.camera),
+                  onPressed: _captureFrame,
+                ),
+                IconButton(
+                  icon: Icon(_isRec ? Icons.stop : Icons.fiber_manual_record),
+                  onPressed: _isRec ? _stopRecording : _startRecording,
+                ),
+                PopupMenuButton<String>(
+                  onSelected: _selectAudioOutput,
+                  itemBuilder: (BuildContext context) {
+                    if (_mediaDevicesList != null) {
+                      return _mediaDevicesList!
+                          .where((device) => device.kind == 'audiooutput')
+                          .map((device) {
+                        return PopupMenuItem<String>(
+                          value: device.deviceId,
+                          child: Text(device.label),
+                        );
+                      }).toList();
+                    }
+                    return [];
+                  },
+                ),
+              ]
+            : null,
       ),
       body: OrientationBuilder(
         builder: (context, orientation) {

--- a/packages/flutter_webrtc/example/flutter_webrtc_example/lib/src/get_user_media_sample_web.dart
+++ b/packages/flutter_webrtc/example/flutter_webrtc_example/lib/src/get_user_media_sample_web.dart
@@ -120,25 +120,24 @@ class _GetUserMediaSampleState extends State<GetUserMediaSample> {
   void _captureFrame() async {
     if (_localStream == null) throw Exception('Can\'t record without a stream');
     final videoTrack = _localStream!.getVideoTracks().firstWhere(
-      (track) => track.kind == 'video',
-    );
+          (track) => track.kind == 'video',
+        );
     final frame = await videoTrack.captureFrame();
     await showDialog(
       context: context,
-      builder:
-          (context) => AlertDialog(
-            content: Image.memory(
-              frame.asUint8List(),
-              height: 720,
-              width: 1280,
-            ),
-            actions: <Widget>[
-              TextButton(
-                onPressed: Navigator.of(context, rootNavigator: true).pop,
-                child: Text('OK'),
-              ),
-            ],
+      builder: (context) => AlertDialog(
+        content: Image.memory(
+          frame.asUint8List(),
+          height: 720,
+          width: 1280,
+        ),
+        actions: <Widget>[
+          TextButton(
+            onPressed: Navigator.of(context, rootNavigator: true).pop,
+            child: Text('OK'),
           ),
+        ],
+      ),
     );
   }
 
@@ -147,38 +146,37 @@ class _GetUserMediaSampleState extends State<GetUserMediaSample> {
     return Scaffold(
       appBar: AppBar(
         title: Text('GetUserMedia API Test Web'),
-        actions:
-            _inCalling
-                ? <Widget>[
-                  IconButton(
-                    icon: Icon(Icons.camera),
-                    onPressed: _captureFrame,
-                  ),
-                  IconButton(
-                    icon: Icon(_isRec ? Icons.stop : Icons.fiber_manual_record),
-                    onPressed: _isRec ? _stopRecording : _startRecording,
-                  ),
-                  PopupMenuButton<String>(
-                    onSelected: _switchCamera,
-                    itemBuilder: (BuildContext context) {
-                      if (_cameras != null) {
-                        return _cameras!.map((device) {
-                          return PopupMenuItem<String>(
-                            value: device.deviceId,
-                            child: Text(device.label),
-                          );
-                        }).toList();
-                      } else {
-                        return [];
-                      }
-                    },
-                  ),
-                  // IconButton(
-                  //   icon: Icon(Icons.settings),
-                  //   onPressed: _switchCamera,
-                  // )
-                ]
-                : null,
+        actions: _inCalling
+            ? <Widget>[
+                IconButton(
+                  icon: Icon(Icons.camera),
+                  onPressed: _captureFrame,
+                ),
+                IconButton(
+                  icon: Icon(_isRec ? Icons.stop : Icons.fiber_manual_record),
+                  onPressed: _isRec ? _stopRecording : _startRecording,
+                ),
+                PopupMenuButton<String>(
+                  onSelected: _switchCamera,
+                  itemBuilder: (BuildContext context) {
+                    if (_cameras != null) {
+                      return _cameras!.map((device) {
+                        return PopupMenuItem<String>(
+                          value: device.deviceId,
+                          child: Text(device.label),
+                        );
+                      }).toList();
+                    } else {
+                      return [];
+                    }
+                  },
+                ),
+                // IconButton(
+                //   icon: Icon(Icons.settings),
+                //   onPressed: _switchCamera,
+                // )
+              ]
+            : null,
       ),
       body: OrientationBuilder(
         builder: (context, orientation) {

--- a/packages/flutter_webrtc/example/flutter_webrtc_example/lib/src/loopback_data_channel_sample.dart
+++ b/packages/flutter_webrtc/example/flutter_webrtc_example/lib/src/loopback_data_channel_sample.dart
@@ -74,8 +74,7 @@ class _DataChannelLoopBackSampleState extends State<DataChannelLoopBackSample> {
         }
       };
 
-      _dc1!.onMessage =
-          (data) => setState(() {
+      _dc1!.onMessage = (data) => setState(() {
             _dc1Status += '\ndc1: Received message: ${data.text}';
           });
 

--- a/packages/flutter_webrtc/example/flutter_webrtc_example/lib/src/loopback_sample_unified_tracks.dart
+++ b/packages/flutter_webrtc/example/flutter_webrtc_example/lib/src/loopback_sample_unified_tracks.dart
@@ -339,16 +339,15 @@ class _MyAppState extends State<LoopBackSampleUnifiedTracks> {
       var trackId = element.track?.id;
       var id = kind + '_' + trackId! + '_sender';
       if (!_frameCyrptors.containsKey(id)) {
-        var frameCyrptor = await _frameCyrptorFactory
-            .createFrameCryptorForRtpSender(
-              participantId: id,
-              sender: element,
-              algorithm: Algorithm.kAesGcm,
-              keyProvider: _keySharedProvider!,
-            );
-        frameCyrptor.onFrameCryptorStateChanged =
-            (participantId, state) =>
-                print('EN onFrameCryptorStateChanged $participantId $state');
+        var frameCyrptor =
+            await _frameCyrptorFactory.createFrameCryptorForRtpSender(
+          participantId: id,
+          sender: element,
+          algorithm: Algorithm.kAesGcm,
+          keyProvider: _keySharedProvider!,
+        );
+        frameCyrptor.onFrameCryptorStateChanged = (participantId, state) =>
+            print('EN onFrameCryptorStateChanged $participantId $state');
         _frameCyrptors[id] = frameCyrptor;
         await frameCyrptor.setKeyIndex(0);
       }
@@ -369,16 +368,15 @@ class _MyAppState extends State<LoopBackSampleUnifiedTracks> {
       var trackId = element.track?.id;
       var id = kind + '_' + trackId! + '_receiver';
       if (!_frameCyrptors.containsKey(id)) {
-        var frameCyrptor = await _frameCyrptorFactory
-            .createFrameCryptorForRtpReceiver(
-              participantId: id,
-              receiver: element,
-              algorithm: Algorithm.kAesGcm,
-              keyProvider: _keySharedProvider!,
-            );
-        frameCyrptor.onFrameCryptorStateChanged =
-            (participantId, state) =>
-                print('DE onFrameCryptorStateChanged $participantId $state');
+        var frameCyrptor =
+            await _frameCyrptorFactory.createFrameCryptorForRtpReceiver(
+          participantId: id,
+          receiver: element,
+          algorithm: Algorithm.kAesGcm,
+          keyProvider: _keySharedProvider!,
+        );
+        frameCyrptor.onFrameCryptorStateChanged = (participantId, state) =>
+            print('DE onFrameCryptorStateChanged $participantId $state');
         _frameCyrptors[id] = frameCyrptor;
         await frameCyrptor.setKeyIndex(0);
       }
@@ -413,18 +411,17 @@ class _MyAppState extends State<LoopBackSampleUnifiedTracks> {
   Map<String, dynamic> _getMediaConstraints({audio = true, video = true}) {
     return {
       'audio': audio ? true : false,
-      'video':
-          video
-              ? {
-                'mandatory': {
-                  'minWidth': '640',
-                  'minHeight': '480',
-                  'minFrameRate': '30',
-                },
-                'facingMode': 'user',
-                'optional': [],
-              }
-              : false,
+      'video': video
+          ? {
+              'mandatory': {
+                'minWidth': '640',
+                'minHeight': '480',
+                'minFrameRate': '30',
+              },
+              'facingMode': 'user',
+              'optional': [],
+            }
+          : false,
     };
   }
 
@@ -452,12 +449,11 @@ class _MyAppState extends State<LoopBackSampleUnifiedTracks> {
     var transceivers = await _localPeerConnection?.getTransceivers();
     transceivers?.forEach((transceiver) {
       if (transceiver.sender.senderId != _videoSender?.senderId) return;
-      var codecs =
-          vcaps?.codecs
+      var codecs = vcaps?.codecs
               ?.where(
                 (element) => element.mimeType.toLowerCase().contains(
-                  videoDropdownValue.toLowerCase(),
-                ),
+                      videoDropdownValue.toLowerCase(),
+                    ),
               )
               .toList() ??
           [];
@@ -519,12 +515,11 @@ class _MyAppState extends State<LoopBackSampleUnifiedTracks> {
     var transceivers = await _localPeerConnection?.getTransceivers();
     transceivers?.forEach((transceiver) {
       if (transceiver.sender.senderId != _audioSender?.senderId) return;
-      var codecs =
-          acaps?.codecs
+      var codecs = acaps?.codecs
               ?.where(
                 (element) => element.mimeType.toLowerCase().contains(
-                  audioDropdownValue.toLowerCase(),
-                ),
+                      audioDropdownValue.toLowerCase(),
+                    ),
               )
               .toList() ??
           [];
@@ -696,15 +691,14 @@ class _MyAppState extends State<LoopBackSampleUnifiedTracks> {
                         audioDropdownValue = value!;
                       });
                     },
-                    items:
-                        audioCodecList.map<DropdownMenuItem<String>>((
-                          String value,
-                        ) {
-                          return DropdownMenuItem<String>(
-                            value: value,
-                            child: Text(value),
-                          );
-                        }).toList(),
+                    items: audioCodecList.map<DropdownMenuItem<String>>((
+                      String value,
+                    ) {
+                      return DropdownMenuItem<String>(
+                        value: value,
+                        child: Text(value),
+                      );
+                    }).toList(),
                   ),
                   Text('video codec:'),
                   DropdownButton<String>(
@@ -719,15 +713,14 @@ class _MyAppState extends State<LoopBackSampleUnifiedTracks> {
                         videoDropdownValue = value!;
                       });
                     },
-                    items:
-                        videoCodecList.map<DropdownMenuItem<String>>((
-                          String value,
-                        ) {
-                          return DropdownMenuItem<String>(
-                            value: value,
-                            child: Text(value),
-                          );
-                        }).toList(),
+                    items: videoCodecList.map<DropdownMenuItem<String>>((
+                      String value,
+                    ) {
+                      return DropdownMenuItem<String>(
+                        value: value,
+                        child: Text(value),
+                      );
+                    }).toList(),
                   ),
                   TextButton(
                     onPressed: _ratchetKey,
@@ -812,12 +805,11 @@ class _MyAppState extends State<LoopBackSampleUnifiedTracks> {
                 return _mediaDevicesList!
                     .where((device) => device.kind == 'audioinput')
                     .map((device) {
-                      return PopupMenuItem<String>(
-                        value: device.deviceId,
-                        child: Text(device.label),
-                      );
-                    })
-                    .toList();
+                  return PopupMenuItem<String>(
+                    value: device.deviceId,
+                    child: Text(device.label),
+                  );
+                }).toList();
               }
               return [];
             },
@@ -830,12 +822,11 @@ class _MyAppState extends State<LoopBackSampleUnifiedTracks> {
                 return _mediaDevicesList!
                     .where((device) => device.kind == 'audiooutput')
                     .map((device) {
-                      return PopupMenuItem<String>(
-                        value: device.deviceId,
-                        child: Text(device.label),
-                      );
-                    })
-                    .toList();
+                  return PopupMenuItem<String>(
+                    value: device.deviceId,
+                    child: Text(device.label),
+                  );
+                }).toList();
               }
               return [];
             },
@@ -848,16 +839,15 @@ class _MyAppState extends State<LoopBackSampleUnifiedTracks> {
             children: [
               Container(
                 decoration: BoxDecoration(color: Colors.black54),
-                child:
-                    orientation == Orientation.portrait
-                        ? Column(
-                          mainAxisAlignment: MainAxisAlignment.spaceEvenly,
-                          children: widgets,
-                        )
-                        : Row(
-                          mainAxisAlignment: MainAxisAlignment.spaceEvenly,
-                          children: widgets,
-                        ),
+                child: orientation == Orientation.portrait
+                    ? Column(
+                        mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+                        children: widgets,
+                      )
+                    : Row(
+                        mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+                        children: widgets,
+                      ),
               ),
               Align(
                 alignment: Alignment.bottomCenter,

--- a/packages/flutter_webrtc/example/flutter_webrtc_example/lib/src/loopback_sample_with_get_stats.dart
+++ b/packages/flutter_webrtc/example/flutter_webrtc_example/lib/src/loopback_sample_with_get_stats.dart
@@ -135,16 +135,15 @@ class _MyAppState extends State<LoopBackSampleWithGetStats> {
           return Center(
             child: Container(
               decoration: BoxDecoration(color: Colors.black54),
-              child:
-                  orientation == Orientation.portrait
-                      ? Column(
-                        mainAxisAlignment: MainAxisAlignment.spaceEvenly,
-                        children: widgets,
-                      )
-                      : Row(
-                        mainAxisAlignment: MainAxisAlignment.spaceEvenly,
-                        children: widgets,
-                      ),
+              child: orientation == Orientation.portrait
+                  ? Column(
+                      mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+                      children: widgets,
+                    )
+                  : Row(
+                      mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+                      children: widgets,
+                    ),
             ),
           );
         },

--- a/packages/flutter_webrtc/example/flutter_webrtc_example/lib/src/widgets/screen_select_dialog.dart
+++ b/packages/flutter_webrtc/example/flutter_webrtc_example/lib/src/widgets/screen_select_dialog.dart
@@ -50,25 +50,23 @@ class _ThumbnailWidgetState extends State<ThumbnailWidget> {
       children: [
         Expanded(
           child: Container(
-            decoration:
-                widget.selected
-                    ? BoxDecoration(
-                      border: Border.all(width: 2, color: Colors.blueAccent),
-                    )
-                    : null,
+            decoration: widget.selected
+                ? BoxDecoration(
+                    border: Border.all(width: 2, color: Colors.blueAccent),
+                  )
+                : null,
             child: InkWell(
               onTap: () {
                 print('Selected source id => ${widget.source.id}');
                 widget.onTap(widget.source);
               },
-              child:
-                  widget.source.thumbnail != null
-                      ? Image.memory(
-                        widget.source.thumbnail!,
-                        gaplessPlayback: true,
-                        alignment: Alignment.center,
-                      )
-                      : Container(),
+              child: widget.source.thumbnail != null
+                  ? Image.memory(
+                      widget.source.thumbnail!,
+                      gaplessPlayback: true,
+                      alignment: Alignment.center,
+                    )
+                  : Container(),
             ),
           ),
         ),
@@ -204,17 +202,15 @@ class ScreenSelectDialog extends Dialog {
                             Container(
                               constraints: BoxConstraints.expand(height: 24),
                               child: TabBar(
-                                onTap:
-                                    (value) => Future.delayed(
-                                      Duration(milliseconds: 300),
-                                      () {
-                                        _sourceType =
-                                            value == 0
-                                                ? SourceType.Screen
-                                                : SourceType.Window;
-                                        _getSources();
-                                      },
-                                    ),
+                                onTap: (value) => Future.delayed(
+                                  Duration(milliseconds: 300),
+                                  () {
+                                    _sourceType = value == 0
+                                        ? SourceType.Screen
+                                        : SourceType.Window;
+                                    _getSources();
+                                  },
+                                ),
                                 tabs: [
                                   Tab(
                                     child: Text(
@@ -242,29 +238,26 @@ class ScreenSelectDialog extends Dialog {
                                         child: GridView.count(
                                           crossAxisSpacing: 8,
                                           crossAxisCount: 2,
-                                          children:
-                                              _sources.entries
-                                                  .where(
-                                                    (element) =>
-                                                        element.value.type ==
-                                                        SourceType.Screen,
-                                                  )
-                                                  .map(
-                                                    (e) => ThumbnailWidget(
-                                                      onTap: (source) {
-                                                        setState(() {
-                                                          _selected_source =
-                                                              source;
-                                                        });
-                                                      },
-                                                      source: e.value,
-                                                      selected:
-                                                          _selected_source
-                                                              ?.id ==
+                                          children: _sources.entries
+                                              .where(
+                                                (element) =>
+                                                    element.value.type ==
+                                                    SourceType.Screen,
+                                              )
+                                              .map(
+                                                (e) => ThumbnailWidget(
+                                                  onTap: (source) {
+                                                    setState(() {
+                                                      _selected_source = source;
+                                                    });
+                                                  },
+                                                  source: e.value,
+                                                  selected:
+                                                      _selected_source?.id ==
                                                           e.value.id,
-                                                    ),
-                                                  )
-                                                  .toList(),
+                                                ),
+                                              )
+                                              .toList(),
                                         ),
                                       ),
                                     ),
@@ -274,29 +267,26 @@ class ScreenSelectDialog extends Dialog {
                                         child: GridView.count(
                                           crossAxisSpacing: 8,
                                           crossAxisCount: 3,
-                                          children:
-                                              _sources.entries
-                                                  .where(
-                                                    (element) =>
-                                                        element.value.type ==
-                                                        SourceType.Window,
-                                                  )
-                                                  .map(
-                                                    (e) => ThumbnailWidget(
-                                                      onTap: (source) {
-                                                        setState(() {
-                                                          _selected_source =
-                                                              source;
-                                                        });
-                                                      },
-                                                      source: e.value,
-                                                      selected:
-                                                          _selected_source
-                                                              ?.id ==
+                                          children: _sources.entries
+                                              .where(
+                                                (element) =>
+                                                    element.value.type ==
+                                                    SourceType.Window,
+                                              )
+                                              .map(
+                                                (e) => ThumbnailWidget(
+                                                  onTap: (source) {
+                                                    setState(() {
+                                                      _selected_source = source;
+                                                    });
+                                                  },
+                                                  source: e.value,
+                                                  selected:
+                                                      _selected_source?.id ==
                                                           e.value.id,
-                                                    ),
-                                                  )
-                                                  .toList(),
+                                                ),
+                                              )
+                                              .toList(),
                                         ),
                                       ),
                                     ),

--- a/packages/geolocator/CHANGELOG.md
+++ b/packages/geolocator/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## NEXT
 
 * Update minimum Flutter and Dart version to 3.13 and 3.1.
+* Update code format.
 
 ## 1.0.6
 

--- a/packages/geolocator/example/integration_test/geolocator_test.dart
+++ b/packages/geolocator/example/integration_test/geolocator_test.dart
@@ -37,15 +37,15 @@ Future<void> main() async {
     final Completer<Object> completer = Completer<Object>();
     final StreamSubscription<Position> subscription =
         Geolocator.getPositionStream().listen(
-          (position) {
-            if (!completer.isCompleted) {
-              completer.complete(position);
-            }
-          },
-          onError: (Object error) {
-            completer.completeError(error);
-          },
-        );
+      (position) {
+        if (!completer.isCompleted) {
+          completer.complete(position);
+        }
+      },
+      onError: (Object error) {
+        completer.completeError(error);
+      },
+    );
     expect(await completer.future, isA<Position>());
     await subscription.cancel();
   }, timeout: const Timeout(Duration(seconds: 10)));

--- a/packages/geolocator/example/lib/main.dart
+++ b/packages/geolocator/example/lib/main.dart
@@ -8,8 +8,8 @@ import 'package:geolocator/geolocator.dart';
 /// Defines the main theme color.
 final MaterialColor themeMaterialColor =
     BaseflowPluginExample.createMaterialColor(
-      const Color.fromRGBO(48, 49, 60, 1),
-    );
+  const Color.fromRGBO(48, 49, 60, 1),
+);
 
 void main() {
   runApp(const GeolocatorWidget());
@@ -76,25 +76,24 @@ class _GeolocatorWidgetState extends State<GeolocatorWidget> {
             break;
         }
       },
-      itemBuilder:
-          (context) => [
-            if (Platform.isIOS)
-              const PopupMenuItem(
-                child: Text("Get Location Accuracy"),
-                value: 1,
-              ),
-            if (Platform.isIOS)
-              const PopupMenuItem(
-                child: Text("Request Temporary Full Accuracy"),
-                value: 2,
-              ),
-            const PopupMenuItem(child: Text("Open App Settings"), value: 3),
-            const PopupMenuItem(
-              child: Text("Open Location Settings"),
-              value: 4,
-            ),
-            const PopupMenuItem(child: Text("Clear"), value: 5),
-          ],
+      itemBuilder: (context) => [
+        if (Platform.isIOS)
+          const PopupMenuItem(
+            child: Text("Get Location Accuracy"),
+            value: 1,
+          ),
+        if (Platform.isIOS)
+          const PopupMenuItem(
+            child: Text("Request Temporary Full Accuracy"),
+            value: 2,
+          ),
+        const PopupMenuItem(child: Text("Open App Settings"), value: 3),
+        const PopupMenuItem(
+          child: Text("Open Location Settings"),
+          value: 4,
+        ),
+        const PopupMenuItem(child: Text("Clear"), value: 5),
+      ],
     );
   }
 
@@ -151,19 +150,17 @@ class _GeolocatorWidgetState extends State<GeolocatorWidget> {
               mainAxisAlignment: MainAxisAlignment.end,
               children: [
                 FloatingActionButton(
-                  child:
-                      (_positionStreamSubscription == null ||
-                              _positionStreamSubscription!.isPaused)
-                          ? const Icon(Icons.play_arrow)
-                          : const Icon(Icons.pause),
+                  child: (_positionStreamSubscription == null ||
+                          _positionStreamSubscription!.isPaused)
+                      ? const Icon(Icons.play_arrow)
+                      : const Icon(Icons.pause),
                   onPressed: () {
                     positionStreamStarted = !positionStreamStarted;
                     _toggleListening();
                   },
-                  tooltip:
-                      (_positionStreamSubscription == null)
-                          ? 'Start position updates'
-                          : _positionStreamSubscription!.isPaused
+                  tooltip: (_positionStreamSubscription == null)
+                      ? 'Start position updates'
+                      : _positionStreamSubscription!.isPaused
                           ? 'Resume'
                           : 'Pause',
                   backgroundColor: _determineButtonColor(),
@@ -251,9 +248,8 @@ class _GeolocatorWidgetState extends State<GeolocatorWidget> {
     setState(() {});
   }
 
-  bool _isListening() =>
-      !(_positionStreamSubscription == null ||
-          _positionStreamSubscription!.isPaused);
+  bool _isListening() => !(_positionStreamSubscription == null ||
+      _positionStreamSubscription!.isPaused);
 
   Color _determineButtonColor() {
     return _isListening() ? Colors.green : Colors.red;
@@ -262,53 +258,50 @@ class _GeolocatorWidgetState extends State<GeolocatorWidget> {
   void _toggleServiceStatusStream() {
     if (_serviceStatusStreamSubscription == null) {
       final serviceStatusStream = _geolocatorPlatform.getServiceStatusStream();
-      _serviceStatusStreamSubscription = serviceStatusStream
-          .handleError((error) {
-            _serviceStatusStreamSubscription?.cancel();
-            _serviceStatusStreamSubscription = null;
-          })
-          .listen((serviceStatus) {
-            String serviceStatusValue;
-            if (serviceStatus == ServiceStatus.enabled) {
-              if (positionStreamStarted) {
-                _toggleListening();
-              }
-              serviceStatusValue = 'enabled';
-            } else {
-              if (_positionStreamSubscription != null) {
-                setState(() {
-                  _positionStreamSubscription?.cancel();
-                  _positionStreamSubscription = null;
-                  _updatePositionList(
-                    _PositionItemType.log,
-                    'Position Stream has been canceled',
-                  );
-                });
-              }
-              serviceStatusValue = 'disabled';
-            }
-            _updatePositionList(
-              _PositionItemType.log,
-              'Location service has been $serviceStatusValue',
-            );
-          });
+      _serviceStatusStreamSubscription =
+          serviceStatusStream.handleError((error) {
+        _serviceStatusStreamSubscription?.cancel();
+        _serviceStatusStreamSubscription = null;
+      }).listen((serviceStatus) {
+        String serviceStatusValue;
+        if (serviceStatus == ServiceStatus.enabled) {
+          if (positionStreamStarted) {
+            _toggleListening();
+          }
+          serviceStatusValue = 'enabled';
+        } else {
+          if (_positionStreamSubscription != null) {
+            setState(() {
+              _positionStreamSubscription?.cancel();
+              _positionStreamSubscription = null;
+              _updatePositionList(
+                _PositionItemType.log,
+                'Position Stream has been canceled',
+              );
+            });
+          }
+          serviceStatusValue = 'disabled';
+        }
+        _updatePositionList(
+          _PositionItemType.log,
+          'Location service has been $serviceStatusValue',
+        );
+      });
     }
   }
 
   void _toggleListening() {
     if (_positionStreamSubscription == null) {
       final positionStream = _geolocatorPlatform.getPositionStream();
-      _positionStreamSubscription = positionStream
-          .handleError((error) {
-            _positionStreamSubscription?.cancel();
-            _positionStreamSubscription = null;
-          })
-          .listen(
-            (position) => _updatePositionList(
-              _PositionItemType.position,
-              position.toString(),
-            ),
-          );
+      _positionStreamSubscription = positionStream.handleError((error) {
+        _positionStreamSubscription?.cancel();
+        _positionStreamSubscription = null;
+      }).listen(
+        (position) => _updatePositionList(
+          _PositionItemType.position,
+          position.toString(),
+        ),
+      );
       _positionStreamSubscription?.pause();
     }
 

--- a/packages/google_maps_flutter/CHANGELOG.md
+++ b/packages/google_maps_flutter/CHANGELOG.md
@@ -1,3 +1,7 @@
+## NEXT
+
+* Update code format.
+
 ## 0.1.13
 
 * Update the LICENSE file so that it is recognized by pub.dev.

--- a/packages/google_maps_flutter/example/integration_test/src/maps_controller.dart
+++ b/packages/google_maps_flutter/example/integration_test/src/maps_controller.dart
@@ -106,11 +106,11 @@ void runTests() {
       // Wait for the visible region to be non-zero.
       final LatLngBounds firstVisibleRegion =
           await waitForValueMatchingPredicate<LatLngBounds>(
-            tester,
-            () => mapController.getVisibleRegion(),
-            (LatLngBounds bounds) => bounds != zeroLatLngBounds,
-          ) ??
-          zeroLatLngBounds;
+                tester,
+                () => mapController.getVisibleRegion(),
+                (LatLngBounds bounds) => bounds != zeroLatLngBounds,
+              ) ??
+              zeroLatLngBounds;
       expect(firstVisibleRegion, isNot(zeroLatLngBounds));
       expect(firstVisibleRegion.contains(kInitialMapCenter), isTrue);
 
@@ -422,8 +422,7 @@ void runTests() {
     await controller.showMarkerInfoWindow(marker.markerId);
     // The Maps SDK doesn't always return true for whether it is shown
     // immediately after showing it, so wait for it to report as shown.
-    iwVisibleStatus =
-        await waitForValueMatchingPredicate<bool>(
+    iwVisibleStatus = await waitForValueMatchingPredicate<bool>(
           tester,
           () => controller.isMarkerInfoWindowShown(marker.markerId),
           (bool visible) => visible,

--- a/packages/google_maps_flutter/example/integration_test/src/maps_inspector.dart
+++ b/packages/google_maps_flutter/example/integration_test/src/maps_inspector.dart
@@ -127,8 +127,8 @@ void runTests() {
     final GoogleMapController controller = await controllerCompleter.future;
 
     if (isIOS) {
-      final MinMaxZoomPreference zoomLevel = await inspector
-          .getMinMaxZoomLevels(mapId: controller.mapId);
+      final MinMaxZoomPreference zoomLevel =
+          await inspector.getMinMaxZoomLevels(mapId: controller.mapId);
       expect(zoomLevel, equals(initialZoomLevel));
     } else if (isAndroid) {
       await controller.moveCamera(CameraUpdate.zoomTo(15));
@@ -155,8 +155,8 @@ void runTests() {
     );
 
     if (isIOS) {
-      final MinMaxZoomPreference zoomLevel = await inspector
-          .getMinMaxZoomLevels(mapId: controller.mapId);
+      final MinMaxZoomPreference zoomLevel =
+          await inspector.getMinMaxZoomLevels(mapId: controller.mapId);
       expect(zoomLevel, equals(finalZoomLevel));
     } else {
       await controller.moveCamera(CameraUpdate.zoomTo(15));
@@ -518,8 +518,8 @@ void runTests() {
       );
       final int mapId = await mapIdCompleter.future;
 
-      final bool myLocationButtonEnabled = await inspector
-          .isMyLocationButtonEnabled(mapId: mapId);
+      final bool myLocationButtonEnabled =
+          await inspector.isMyLocationButtonEnabled(mapId: mapId);
       expect(myLocationButtonEnabled, false);
     });
 
@@ -541,8 +541,8 @@ void runTests() {
       );
       final int mapId = await mapIdCompleter.future;
 
-      final bool myLocationButtonEnabled = await inspector
-          .isMyLocationButtonEnabled(mapId: mapId);
+      final bool myLocationButtonEnabled =
+          await inspector.isMyLocationButtonEnabled(mapId: mapId);
       expect(myLocationButtonEnabled, true);
     });
   }, skip: !isIOS);

--- a/packages/google_maps_flutter/example/integration_test/src/tiles_inspector.dart
+++ b/packages/google_maps_flutter/example/integration_test/src/tiles_inspector.dart
@@ -63,16 +63,14 @@ void runTests() {
 
       final int mapId = await mapIdCompleter.future;
 
-      final TileOverlay tileOverlayInfo1 =
-          (await inspector.getTileOverlayInfo(
-            tileOverlay1.mapsId,
-            mapId: mapId,
-          ))!;
-      final TileOverlay tileOverlayInfo2 =
-          (await inspector.getTileOverlayInfo(
-            tileOverlay2.mapsId,
-            mapId: mapId,
-          ))!;
+      final TileOverlay tileOverlayInfo1 = (await inspector.getTileOverlayInfo(
+        tileOverlay1.mapsId,
+        mapId: mapId,
+      ))!;
+      final TileOverlay tileOverlayInfo2 = (await inspector.getTileOverlayInfo(
+        tileOverlay2.mapsId,
+        mapId: mapId,
+      ))!;
 
       expect(tileOverlayInfo1.visible, isTrue);
       expect(tileOverlayInfo1.fadeIn, isTrue);
@@ -148,11 +146,10 @@ void runTests() {
 
       await tester.pumpAndSettle(const Duration(seconds: 3));
 
-      final TileOverlay tileOverlayInfo1 =
-          (await inspector.getTileOverlayInfo(
-            tileOverlay1.mapsId,
-            mapId: mapId,
-          ))!;
+      final TileOverlay tileOverlayInfo1 = (await inspector.getTileOverlayInfo(
+        tileOverlay1.mapsId,
+        mapId: mapId,
+      ))!;
       final TileOverlay? tileOverlayInfo2 = await inspector.getTileOverlayInfo(
         tileOverlay2.mapsId,
         mapId: mapId,

--- a/packages/google_maps_flutter/example/lib/animate_camera.dart
+++ b/packages/google_maps_flutter/example/lib/animate_camera.dart
@@ -11,7 +11,7 @@ import 'page.dart';
 
 class AnimateCameraPage extends GoogleMapExampleAppPage {
   const AnimateCameraPage({Key? key})
-    : super(const Icon(Icons.map), 'Camera control, animated', key: key);
+      : super(const Icon(Icons.map), 'Camera control, animated', key: key);
 
   @override
   Widget build(BuildContext context) {

--- a/packages/google_maps_flutter/example/lib/clustering.dart
+++ b/packages/google_maps_flutter/example/lib/clustering.dart
@@ -13,7 +13,7 @@ import 'page.dart';
 class ClusteringPage extends GoogleMapExampleAppPage {
   /// Default Constructor.
   const ClusteringPage({Key? key})
-    : super(const Icon(Icons.place), 'Manage clustering', key: key);
+      : super(const Icon(Icons.place), 'Manage clustering', key: key);
 
   @override
   Widget build(BuildContext context) {
@@ -125,10 +125,9 @@ class ClusteringBodyState extends State<ClusteringBody> {
 
     final ClusterManager clusterManager = ClusterManager(
       clusterManagerId: clusterManagerId,
-      onClusterTap:
-          (Cluster cluster) => setState(() {
-            lastCluster = cluster;
-          }),
+      onClusterTap: (Cluster cluster) => setState(() {
+        lastCluster = cluster;
+      }),
     );
 
     setState(() {
@@ -157,8 +156,8 @@ class ClusteringBodyState extends State<ClusteringBody> {
       final MarkerId markerId = MarkerId(markerIdVal);
 
       final int clusterManagerIndex = clusterManagers.values.toList().indexOf(
-        clusterManager,
-      );
+            clusterManager,
+          );
 
       // Add additional offset to longitude for each cluster manager to space
       // out markers in different cluster managers.
@@ -197,10 +196,9 @@ class ClusteringBodyState extends State<ClusteringBody> {
       final Marker marker = markers[markerId]!;
       final double current = marker.alpha;
       markers[markerId] = marker.copyWith(
-        alphaParam:
-            current == _fullyVisibleAlpha
-                ? _halfVisibleAlpha
-                : _fullyVisibleAlpha,
+        alphaParam: current == _fullyVisibleAlpha
+            ? _halfVisibleAlpha
+            : _fullyVisibleAlpha,
       );
     }
     setState(() {});
@@ -230,17 +228,15 @@ class ClusteringBodyState extends State<ClusteringBody> {
               mainAxisAlignment: MainAxisAlignment.spaceEvenly,
               children: <Widget>[
                 TextButton(
-                  onPressed:
-                      clusterManagers.length >= _clusterManagerMaxCount
-                          ? null
-                          : () => _addClusterManager(),
+                  onPressed: clusterManagers.length >= _clusterManagerMaxCount
+                      ? null
+                      : () => _addClusterManager(),
                   child: const Text('Add cluster manager'),
                 ),
                 TextButton(
-                  onPressed:
-                      clusterManagers.isEmpty
-                          ? null
-                          : () => _removeClusterManager(
+                  onPressed: clusterManagers.isEmpty
+                      ? null
+                      : () => _removeClusterManager(
                             clusterManagers.values.last,
                           ),
                   child: const Text('Remove cluster manager'),
@@ -250,9 +246,8 @@ class ClusteringBodyState extends State<ClusteringBody> {
             Wrap(
               alignment: WrapAlignment.spaceEvenly,
               children: <Widget>[
-                for (final MapEntry<ClusterManagerId, ClusterManager>
-                    clusterEntry
-                    in clusterManagers.entries)
+                for (final MapEntry<ClusterManagerId,
+                    ClusterManager> clusterEntry in clusterManagers.entries)
                   TextButton(
                     onPressed: () => _addMarkersToCluster(clusterEntry.value),
                     child: Text('Add markers to ${clusterEntry.key.value}'),
@@ -263,15 +258,14 @@ class ClusteringBodyState extends State<ClusteringBody> {
               alignment: WrapAlignment.spaceEvenly,
               children: <Widget>[
                 TextButton(
-                  onPressed:
-                      selectedId == null
-                          ? null
-                          : () {
-                            _remove(selectedId);
-                            setState(() {
-                              selectedMarker = null;
-                            });
-                          },
+                  onPressed: selectedId == null
+                      ? null
+                      : () {
+                          _remove(selectedId);
+                          setState(() {
+                            selectedMarker = null;
+                          });
+                        },
                   child: const Text('Remove selected marker'),
                 ),
                 TextButton(

--- a/packages/google_maps_flutter/example/lib/custom_marker_icon.dart
+++ b/packages/google_maps_flutter/example/lib/custom_marker_icon.dart
@@ -16,9 +16,9 @@ Future<ByteData> createCustomMarkerIconImage({required Size size}) async {
   painter.paint(canvas, size);
 
   final ui.Image image = await recorder.endRecording().toImage(
-    size.width.floor(),
-    size.height.floor(),
-  );
+        size.width.floor(),
+        size.height.floor(),
+      );
 
   final ByteData? bytes = await image.toByteData(
     format: ui.ImageByteFormat.png,

--- a/packages/google_maps_flutter/example/lib/heatmap.dart
+++ b/packages/google_maps_flutter/example/lib/heatmap.dart
@@ -11,7 +11,7 @@ import 'page.dart';
 
 class HeatmapPage extends GoogleMapExampleAppPage {
   const HeatmapPage({Key? key})
-    : super(const Icon(Icons.map), 'Heatmaps', key: key);
+      : super(const Icon(Icons.map), 'Heatmaps', key: key);
 
   @override
   Widget build(BuildContext context) {

--- a/packages/google_maps_flutter/example/lib/lite_mode.dart
+++ b/packages/google_maps_flutter/example/lib/lite_mode.dart
@@ -15,7 +15,7 @@ const CameraPosition _kInitialPosition = CameraPosition(
 
 class LiteModePage extends GoogleMapExampleAppPage {
   const LiteModePage({Key? key})
-    : super(const Icon(Icons.map), 'Lite mode', key: key);
+      : super(const Icon(Icons.map), 'Lite mode', key: key);
 
   @override
   Widget build(BuildContext context) {

--- a/packages/google_maps_flutter/example/lib/main.dart
+++ b/packages/google_maps_flutter/example/lib/main.dart
@@ -53,9 +53,8 @@ class MapsDemo extends StatelessWidget {
   void _pushPage(BuildContext context, GoogleMapExampleAppPage page) {
     Navigator.of(context).push(
       MaterialPageRoute<void>(
-        builder:
-            (_) =>
-                Scaffold(appBar: AppBar(title: Text(page.title)), body: page),
+        builder: (_) =>
+            Scaffold(appBar: AppBar(title: Text(page.title)), body: page),
       ),
     );
   }
@@ -66,12 +65,11 @@ class MapsDemo extends StatelessWidget {
       appBar: AppBar(title: const Text('GoogleMaps examples')),
       body: ListView.builder(
         itemCount: _allPages.length,
-        itemBuilder:
-            (_, int index) => ListTile(
-              leading: _allPages[index].leading,
-              title: Text(_allPages[index].title),
-              onTap: () => _pushPage(context, _allPages[index]),
-            ),
+        itemBuilder: (_, int index) => ListTile(
+          leading: _allPages[index].leading,
+          title: Text(_allPages[index].title),
+          onTap: () => _pushPage(context, _allPages[index]),
+        ),
       ),
     );
   }

--- a/packages/google_maps_flutter/example/lib/map_click.dart
+++ b/packages/google_maps_flutter/example/lib/map_click.dart
@@ -15,7 +15,7 @@ const CameraPosition _kInitialPosition = CameraPosition(
 
 class MapClickPage extends GoogleMapExampleAppPage {
   const MapClickPage({Key? key})
-    : super(const Icon(Icons.mouse), 'Map click', key: key);
+      : super(const Icon(Icons.mouse), 'Map click', key: key);
 
   @override
   Widget build(BuildContext context) {

--- a/packages/google_maps_flutter/example/lib/map_coordinates.dart
+++ b/packages/google_maps_flutter/example/lib/map_coordinates.dart
@@ -15,7 +15,7 @@ const CameraPosition _kInitialPosition = CameraPosition(
 
 class MapCoordinatesPage extends GoogleMapExampleAppPage {
   const MapCoordinatesPage({Key? key})
-    : super(const Icon(Icons.map), 'Map coordinates', key: key);
+      : super(const Icon(Icons.map), 'Map coordinates', key: key);
 
   @override
   Widget build(BuildContext context) {

--- a/packages/google_maps_flutter/example/lib/map_map_id.dart
+++ b/packages/google_maps_flutter/example/lib/map_map_id.dart
@@ -9,7 +9,7 @@ import 'page.dart';
 
 class MapIdPage extends GoogleMapExampleAppPage {
   const MapIdPage({Key? key})
-    : super(const Icon(Icons.map), 'Cloud-based maps styling', key: key);
+      : super(const Icon(Icons.map), 'Cloud-based maps styling', key: key);
 
   @override
   Widget build(BuildContext context) {

--- a/packages/google_maps_flutter/example/lib/map_ui.dart
+++ b/packages/google_maps_flutter/example/lib/map_ui.dart
@@ -18,7 +18,7 @@ final LatLngBounds sydneyBounds = LatLngBounds(
 
 class MapUiPage extends GoogleMapExampleAppPage {
   const MapUiPage({Key? key})
-    : super(const Icon(Icons.map), 'User interface', key: key);
+      : super(const Icon(Icons.map), 'User interface', key: key);
 
   @override
   Widget build(BuildContext context) {
@@ -103,10 +103,9 @@ class MapUiBodyState extends State<MapUiBody> {
       ),
       onPressed: () {
         setState(() {
-          _cameraTargetBounds =
-              _cameraTargetBounds.bounds == null
-                  ? CameraTargetBounds(sydneyBounds)
-                  : CameraTargetBounds.unbounded;
+          _cameraTargetBounds = _cameraTargetBounds.bounds == null
+              ? CameraTargetBounds(sydneyBounds)
+              : CameraTargetBounds.unbounded;
         });
       },
     );
@@ -119,10 +118,9 @@ class MapUiBodyState extends State<MapUiBody> {
       ),
       onPressed: () {
         setState(() {
-          _minMaxZoomPreference =
-              _minMaxZoomPreference.minZoom == null
-                  ? const MinMaxZoomPreference(12.0, 16.0)
-                  : MinMaxZoomPreference.unbounded;
+          _minMaxZoomPreference = _minMaxZoomPreference.minZoom == null
+              ? const MinMaxZoomPreference(12.0, 16.0)
+              : MinMaxZoomPreference.unbounded;
         });
       },
     );

--- a/packages/google_maps_flutter/example/lib/marker_icons.dart
+++ b/packages/google_maps_flutter/example/lib/marker_icons.dart
@@ -16,7 +16,7 @@ import 'page.dart';
 
 class MarkerIconsPage extends GoogleMapExampleAppPage {
   const MarkerIconsPage({Key? key})
-    : super(const Icon(Icons.image), 'Marker icons', key: key);
+      : super(const Icon(Icons.image), 'Marker icons', key: key);
 
   @override
   Widget build(BuildContext context) {
@@ -111,15 +111,14 @@ class MarkerIconsBodyState extends State<MarkerIconsBody> {
                         });
                       }
                     },
-                    items:
-                        _MarkerSizeOption.values.map((
-                          _MarkerSizeOption option,
-                        ) {
-                          return DropdownMenuItem<_MarkerSizeOption>(
-                            value: option,
-                            child: Text(_getMarkerSizeOptionName(option)),
-                          );
-                        }).toList(),
+                    items: _MarkerSizeOption.values.map((
+                      _MarkerSizeOption option,
+                    ) {
+                      return DropdownMenuItem<_MarkerSizeOption>(
+                        value: option,
+                        child: Text(_getMarkerSizeOptionName(option)),
+                      );
+                    }).toList(),
                   ),
                 ],
               ),

--- a/packages/google_maps_flutter/example/lib/move_camera.dart
+++ b/packages/google_maps_flutter/example/lib/move_camera.dart
@@ -11,7 +11,7 @@ import 'page.dart';
 
 class MoveCameraPage extends GoogleMapExampleAppPage {
   const MoveCameraPage({Key? key})
-    : super(const Icon(Icons.map), 'Camera control', key: key);
+      : super(const Icon(Icons.map), 'Camera control', key: key);
 
   @override
   Widget build(BuildContext context) {

--- a/packages/google_maps_flutter/example/lib/padding.dart
+++ b/packages/google_maps_flutter/example/lib/padding.dart
@@ -10,7 +10,7 @@ import 'page.dart';
 
 class PaddingPage extends GoogleMapExampleAppPage {
   const PaddingPage({Key? key})
-    : super(const Icon(Icons.map), 'Add padding to the map', key: key);
+      : super(const Icon(Icons.map), 'Add padding to the map', key: key);
 
   @override
   Widget build(BuildContext context) {

--- a/packages/google_maps_flutter/example/lib/place_circle.dart
+++ b/packages/google_maps_flutter/example/lib/place_circle.dart
@@ -11,7 +11,7 @@ import 'page.dart';
 
 class PlaceCirclePage extends GoogleMapExampleAppPage {
   const PlaceCirclePage({Key? key})
-    : super(const Icon(Icons.linear_scale), 'Place circle', key: key);
+      : super(const Icon(Icons.linear_scale), 'Place circle', key: key);
 
   @override
   Widget build(BuildContext context) {
@@ -170,17 +170,15 @@ class PlaceCircleBodyState extends State<PlaceCircleBody> {
                       children: <Widget>[
                         TextButton(onPressed: _add, child: const Text('add')),
                         TextButton(
-                          onPressed:
-                              (selectedId == null)
-                                  ? null
-                                  : () => _remove(selectedId),
+                          onPressed: (selectedId == null)
+                              ? null
+                              : () => _remove(selectedId),
                           child: const Text('remove'),
                         ),
                         TextButton(
-                          onPressed:
-                              (selectedId == null)
-                                  ? null
-                                  : () => _toggleVisible(selectedId),
+                          onPressed: (selectedId == null)
+                              ? null
+                              : () => _toggleVisible(selectedId),
                           child: const Text('toggle visible'),
                         ),
                       ],
@@ -188,24 +186,21 @@ class PlaceCircleBodyState extends State<PlaceCircleBody> {
                     Column(
                       children: <Widget>[
                         TextButton(
-                          onPressed:
-                              (selectedId == null)
-                                  ? null
-                                  : () => _changeStrokeWidth(selectedId),
+                          onPressed: (selectedId == null)
+                              ? null
+                              : () => _changeStrokeWidth(selectedId),
                           child: const Text('change stroke width'),
                         ),
                         TextButton(
-                          onPressed:
-                              (selectedId == null)
-                                  ? null
-                                  : () => _changeStrokeColor(selectedId),
+                          onPressed: (selectedId == null)
+                              ? null
+                              : () => _changeStrokeColor(selectedId),
                           child: const Text('change stroke color'),
                         ),
                         TextButton(
-                          onPressed:
-                              (selectedId == null)
-                                  ? null
-                                  : () => _changeFillColor(selectedId),
+                          onPressed: (selectedId == null)
+                              ? null
+                              : () => _changeFillColor(selectedId),
                           child: const Text('change fill color'),
                         ),
                       ],

--- a/packages/google_maps_flutter/example/lib/place_marker.dart
+++ b/packages/google_maps_flutter/example/lib/place_marker.dart
@@ -16,7 +16,7 @@ import 'page.dart';
 
 class PlaceMarkerPage extends GoogleMapExampleAppPage {
   const PlaceMarkerPage({Key? key})
-    : super(const Icon(Icons.place), 'Place marker', key: key);
+      : super(const Icon(Icons.place), 'Place marker', key: key);
 
   @override
   Widget build(BuildContext context) {
@@ -301,31 +301,27 @@ class PlaceMarkerBodyState extends State<PlaceMarkerBody> {
                   child: const Text('change info'),
                 ),
                 TextButton(
-                  onPressed:
-                      selectedId == null
-                          ? null
-                          : () => _changeInfoAnchor(selectedId),
+                  onPressed: selectedId == null
+                      ? null
+                      : () => _changeInfoAnchor(selectedId),
                   child: const Text('change info anchor'),
                 ),
                 TextButton(
-                  onPressed:
-                      selectedId == null
-                          ? null
-                          : () => _changeAlpha(selectedId),
+                  onPressed: selectedId == null
+                      ? null
+                      : () => _changeAlpha(selectedId),
                   child: const Text('change alpha'),
                 ),
                 TextButton(
-                  onPressed:
-                      selectedId == null
-                          ? null
-                          : () => _changeAnchor(selectedId),
+                  onPressed: selectedId == null
+                      ? null
+                      : () => _changeAnchor(selectedId),
                   child: const Text('change anchor'),
                 ),
                 TextButton(
-                  onPressed:
-                      selectedId == null
-                          ? null
-                          : () => _toggleDraggable(selectedId),
+                  onPressed: selectedId == null
+                      ? null
+                      : () => _toggleDraggable(selectedId),
                   child: const Text('toggle draggable'),
                 ),
                 TextButton(
@@ -334,44 +330,39 @@ class PlaceMarkerBodyState extends State<PlaceMarkerBody> {
                   child: const Text('toggle flat'),
                 ),
                 TextButton(
-                  onPressed:
-                      selectedId == null
-                          ? null
-                          : () => _changePosition(selectedId),
+                  onPressed: selectedId == null
+                      ? null
+                      : () => _changePosition(selectedId),
                   child: const Text('change position'),
                 ),
                 TextButton(
-                  onPressed:
-                      selectedId == null
-                          ? null
-                          : () => _changeRotation(selectedId),
+                  onPressed: selectedId == null
+                      ? null
+                      : () => _changeRotation(selectedId),
                   child: const Text('change rotation'),
                 ),
                 TextButton(
-                  onPressed:
-                      selectedId == null
-                          ? null
-                          : () => _toggleVisible(selectedId),
+                  onPressed: selectedId == null
+                      ? null
+                      : () => _toggleVisible(selectedId),
                   child: const Text('toggle visible'),
                 ),
                 TextButton(
-                  onPressed:
-                      selectedId == null
-                          ? null
-                          : () => _changeZIndex(selectedId),
+                  onPressed: selectedId == null
+                      ? null
+                      : () => _changeZIndex(selectedId),
                   child: const Text('change zIndex'),
                 ),
                 TextButton(
-                  onPressed:
-                      selectedId == null
-                          ? null
-                          : () {
-                            _getMarkerIcon(context).then((
-                              BitmapDescriptor icon,
-                            ) {
-                              _setMarkerIcon(selectedId, icon);
-                            });
-                          },
+                  onPressed: selectedId == null
+                      ? null
+                      : () {
+                          _getMarkerIcon(context).then((
+                            BitmapDescriptor icon,
+                          ) {
+                            _setMarkerIcon(selectedId, icon);
+                          });
+                        },
                   child: const Text('set marker icon'),
                 ),
               ],

--- a/packages/google_maps_flutter/example/lib/place_polygon.dart
+++ b/packages/google_maps_flutter/example/lib/place_polygon.dart
@@ -11,7 +11,7 @@ import 'page.dart';
 
 class PlacePolygonPage extends GoogleMapExampleAppPage {
   const PlacePolygonPage({Key? key})
-    : super(const Icon(Icons.linear_scale), 'Place polygon', key: key);
+      : super(const Icon(Icons.linear_scale), 'Place polygon', key: key);
 
   @override
   Widget build(BuildContext context) {
@@ -193,24 +193,21 @@ class PlacePolygonBodyState extends State<PlacePolygonBody> {
                       children: <Widget>[
                         TextButton(onPressed: _add, child: const Text('add')),
                         TextButton(
-                          onPressed:
-                              (selectedId == null)
-                                  ? null
-                                  : () => _remove(selectedId),
+                          onPressed: (selectedId == null)
+                              ? null
+                              : () => _remove(selectedId),
                           child: const Text('remove'),
                         ),
                         TextButton(
-                          onPressed:
-                              (selectedId == null)
-                                  ? null
-                                  : () => _toggleVisible(selectedId),
+                          onPressed: (selectedId == null)
+                              ? null
+                              : () => _toggleVisible(selectedId),
                           child: const Text('toggle visible'),
                         ),
                         TextButton(
-                          onPressed:
-                              (selectedId == null)
-                                  ? null
-                                  : () => _toggleGeodesic(selectedId),
+                          onPressed: (selectedId == null)
+                              ? null
+                              : () => _toggleGeodesic(selectedId),
                           child: const Text('toggle geodesic'),
                         ),
                       ],
@@ -218,42 +215,37 @@ class PlacePolygonBodyState extends State<PlacePolygonBody> {
                     Column(
                       children: <Widget>[
                         TextButton(
-                          onPressed:
-                              (selectedId == null)
+                          onPressed: (selectedId == null)
+                              ? null
+                              : (polygons[selectedId]!.holes.isNotEmpty
                                   ? null
-                                  : (polygons[selectedId]!.holes.isNotEmpty
-                                      ? null
-                                      : () => _addHoles(selectedId)),
+                                  : () => _addHoles(selectedId)),
                           child: const Text('add holes'),
                         ),
                         TextButton(
-                          onPressed:
-                              (selectedId == null)
+                          onPressed: (selectedId == null)
+                              ? null
+                              : (polygons[selectedId]!.holes.isEmpty
                                   ? null
-                                  : (polygons[selectedId]!.holes.isEmpty
-                                      ? null
-                                      : () => _removeHoles(selectedId)),
+                                  : () => _removeHoles(selectedId)),
                           child: const Text('remove holes'),
                         ),
                         TextButton(
-                          onPressed:
-                              (selectedId == null)
-                                  ? null
-                                  : () => _changeWidth(selectedId),
+                          onPressed: (selectedId == null)
+                              ? null
+                              : () => _changeWidth(selectedId),
                           child: const Text('change stroke width'),
                         ),
                         TextButton(
-                          onPressed:
-                              (selectedId == null)
-                                  ? null
-                                  : () => _changeStrokeColor(selectedId),
+                          onPressed: (selectedId == null)
+                              ? null
+                              : () => _changeStrokeColor(selectedId),
                           child: const Text('change stroke color'),
                         ),
                         TextButton(
-                          onPressed:
-                              (selectedId == null)
-                                  ? null
-                                  : () => _changeFillColor(selectedId),
+                          onPressed: (selectedId == null)
+                              ? null
+                              : () => _changeFillColor(selectedId),
                           child: const Text('change fill color'),
                         ),
                       ],

--- a/packages/google_maps_flutter/example/lib/place_polyline.dart
+++ b/packages/google_maps_flutter/example/lib/place_polyline.dart
@@ -12,7 +12,7 @@ import 'page.dart';
 
 class PlacePolylinePage extends GoogleMapExampleAppPage {
   const PlacePolylinePage({Key? key})
-    : super(const Icon(Icons.linear_scale), 'Place polyline', key: key);
+      : super(const Icon(Icons.linear_scale), 'Place polyline', key: key);
 
   @override
   Widget build(BuildContext context) {
@@ -236,24 +236,21 @@ class PlacePolylineBodyState extends State<PlacePolylineBody> {
                       children: <Widget>[
                         TextButton(onPressed: _add, child: const Text('add')),
                         TextButton(
-                          onPressed:
-                              (selectedId == null)
-                                  ? null
-                                  : () => _remove(selectedId),
+                          onPressed: (selectedId == null)
+                              ? null
+                              : () => _remove(selectedId),
                           child: const Text('remove'),
                         ),
                         TextButton(
-                          onPressed:
-                              (selectedId == null)
-                                  ? null
-                                  : () => _toggleVisible(selectedId),
+                          onPressed: (selectedId == null)
+                              ? null
+                              : () => _toggleVisible(selectedId),
                           child: const Text('toggle visible'),
                         ),
                         TextButton(
-                          onPressed:
-                              (selectedId == null)
-                                  ? null
-                                  : () => _toggleGeodesic(selectedId),
+                          onPressed: (selectedId == null)
+                              ? null
+                              : () => _toggleGeodesic(selectedId),
                           child: const Text('toggle geodesic'),
                         ),
                       ],
@@ -261,45 +258,39 @@ class PlacePolylineBodyState extends State<PlacePolylineBody> {
                     Column(
                       children: <Widget>[
                         TextButton(
-                          onPressed:
-                              (selectedId == null)
-                                  ? null
-                                  : () => _changeWidth(selectedId),
+                          onPressed: (selectedId == null)
+                              ? null
+                              : () => _changeWidth(selectedId),
                           child: const Text('change width'),
                         ),
                         TextButton(
-                          onPressed:
-                              (selectedId == null)
-                                  ? null
-                                  : () => _changeColor(selectedId),
+                          onPressed: (selectedId == null)
+                              ? null
+                              : () => _changeColor(selectedId),
                           child: const Text('change color'),
                         ),
                         TextButton(
-                          onPressed:
-                              isIOS || (selectedId == null)
-                                  ? null
-                                  : () => _changeStartCap(selectedId),
+                          onPressed: isIOS || (selectedId == null)
+                              ? null
+                              : () => _changeStartCap(selectedId),
                           child: const Text('change start cap [Android only]'),
                         ),
                         TextButton(
-                          onPressed:
-                              isIOS || (selectedId == null)
-                                  ? null
-                                  : () => _changeEndCap(selectedId),
+                          onPressed: isIOS || (selectedId == null)
+                              ? null
+                              : () => _changeEndCap(selectedId),
                           child: const Text('change end cap [Android only]'),
                         ),
                         TextButton(
-                          onPressed:
-                              isIOS || (selectedId == null)
-                                  ? null
-                                  : () => _changeJointType(selectedId),
+                          onPressed: isIOS || (selectedId == null)
+                              ? null
+                              : () => _changeJointType(selectedId),
                           child: const Text('change joint type [Android only]'),
                         ),
                         TextButton(
-                          onPressed:
-                              (selectedId == null)
-                                  ? null
-                                  : () => _changePattern(selectedId),
+                          onPressed: (selectedId == null)
+                              ? null
+                              : () => _changePattern(selectedId),
                           child: const Text('change pattern'),
                         ),
                       ],

--- a/packages/google_maps_flutter/example/lib/scrolling_map.dart
+++ b/packages/google_maps_flutter/example/lib/scrolling_map.dart
@@ -15,7 +15,7 @@ const LatLng _center = LatLng(32.080664, 34.9563837);
 
 class ScrollingMapPage extends GoogleMapExampleAppPage {
   const ScrollingMapPage({Key? key})
-    : super(const Icon(Icons.map), 'Scrolling map', key: key);
+      : super(const Icon(Icons.map), 'Scrolling map', key: key);
 
   @override
   Widget build(BuildContext context) {
@@ -92,12 +92,12 @@ class ScrollingMapBody extends StatelessWidget {
                           ),
                         ),
                       },
-                      gestureRecognizers:
-                          <Factory<OneSequenceGestureRecognizer>>{
-                            Factory<OneSequenceGestureRecognizer>(
-                              () => ScaleGestureRecognizer(),
-                            ),
-                          },
+                      gestureRecognizers: <Factory<
+                          OneSequenceGestureRecognizer>>{
+                        Factory<OneSequenceGestureRecognizer>(
+                          () => ScaleGestureRecognizer(),
+                        ),
+                      },
                     ),
                   ),
                 ),

--- a/packages/google_maps_flutter/example/lib/snapshot.dart
+++ b/packages/google_maps_flutter/example/lib/snapshot.dart
@@ -18,11 +18,11 @@ const CameraPosition _kInitialPosition = CameraPosition(
 
 class SnapshotPage extends GoogleMapExampleAppPage {
   const SnapshotPage({Key? key})
-    : super(
-        const Icon(Icons.camera_alt),
-        'Take a snapshot of the map',
-        key: key,
-      );
+      : super(
+          const Icon(Icons.camera_alt),
+          'Take a snapshot of the map',
+          key: key,
+        );
 
   @override
   Widget build(BuildContext context) {

--- a/packages/google_maps_flutter/example/lib/tile_overlay.dart
+++ b/packages/google_maps_flutter/example/lib/tile_overlay.dart
@@ -14,7 +14,7 @@ import 'page.dart';
 
 class TileOverlayPage extends GoogleMapExampleAppPage {
   const TileOverlayPage({Key? key})
-    : super(const Icon(Icons.map), 'Tile overlay', key: key);
+      : super(const Icon(Icons.map), 'Tile overlay', key: key);
 
   @override
   Widget build(BuildContext context) {

--- a/packages/google_maps_flutter/lib/src/circle.dart
+++ b/packages/google_maps_flutter/lib/src/circle.dart
@@ -13,9 +13,9 @@ class CircleController {
     bool consumeTapEvents = false,
     ui.VoidCallback? onTap,
     WebViewController? controller,
-  }) : _circle = circle,
-       _consumeTapEvents = consumeTapEvents,
-       tapEvent = onTap {
+  })  : _circle = circle,
+        _consumeTapEvents = consumeTapEvents,
+        tapEvent = onTap {
     _addCircleEvent(controller);
   }
 

--- a/packages/google_maps_flutter/lib/src/circles.dart
+++ b/packages/google_maps_flutter/lib/src/circles.dart
@@ -9,9 +9,9 @@ part of '../google_maps_flutter_tizen.dart';
 class CirclesController extends GeometryController {
   /// Initialize the cache. The [StreamController] comes from the [GoogleMapController], and is shared with other controllers.
   CirclesController({required StreamController<MapEvent<Object?>> stream})
-    : _streamController = stream,
-      _circleIdToController = <CircleId, CircleController>{},
-      _idToCircleId = <int, CircleId>{};
+      : _streamController = stream,
+        _circleIdToController = <CircleId, CircleController>{},
+        _idToCircleId = <int, CircleId>{};
 
   // A cache of [CircleController]s indexed by their [CircleId].
   final Map<CircleId, CircleController> _circleIdToController;

--- a/packages/google_maps_flutter/lib/src/convert.dart
+++ b/packages/google_maps_flutter/lib/src/convert.dart
@@ -136,25 +136,23 @@ String _mapStyles(String? mapStyleJson) {
   if (mapStyleJson != null) {
     try {
       json
-              .decode(
-                mapStyleJson,
-                reviver: (Object? key, Object? value) {
-                  if (value is Map &&
-                      _isJsonMapStyle(value as Map<String, Object?>)) {
-                    return MapTypeStyle()
-                      ..elementType = value['elementType'] as String?
-                      ..featureType = value['featureType'] as String?
-                      ..stylers =
-                          (value['stylers']! as List<dynamic>)
-                              .map<dynamic>((dynamic e) => e)
-                              .toList();
-                  }
-                  return value;
-                },
-              )
-              .cast<MapTypeStyle>()
-              .toList()
-          as List<MapTypeStyle>;
+          .decode(
+            mapStyleJson,
+            reviver: (Object? key, Object? value) {
+              if (value is Map &&
+                  _isJsonMapStyle(value as Map<String, Object?>)) {
+                return MapTypeStyle()
+                  ..elementType = value['elementType'] as String?
+                  ..featureType = value['featureType'] as String?
+                  ..stylers = (value['stylers']! as List<dynamic>)
+                      .map<dynamic>((dynamic e) => e)
+                      .toList();
+              }
+              return value;
+            },
+          )
+          .cast<MapTypeStyle>()
+          .toList() as List<MapTypeStyle>;
     } catch (e) {
       throw MapStyleException('Invalid Map Style JSON: $e');
     }
@@ -203,14 +201,12 @@ ScreenCoordinate _convertToPoint(String value) {
     int x = 0, y = 0;
 
     if (latlng is Map<String, dynamic>) {
-      x =
-          latlng['x'] is int
-              ? latlng['x'] as int
-              : (latlng['x'] as double).toInt();
-      y =
-          latlng['y'] is int
-              ? latlng['y'] as int
-              : (latlng['y'] as double).toInt();
+      x = latlng['x'] is int
+          ? latlng['x'] as int
+          : (latlng['x'] as double).toInt();
+      y = latlng['y'] is int
+          ? latlng['y'] as int
+          : (latlng['y'] as double).toInt();
 
       return ScreenCoordinate(x: x, y: y);
     }
@@ -281,10 +277,9 @@ util.GMarkerOptions _markerOptionsFromMarker(
       assert(iconConfig.length >= 2);
       final Map<String, Object?> assetConfig =
           iconConfig[1]! as Map<String, Object?>;
-      icon =
-          util.GIcon()
-            ..url =
-                'data:image/png;base64,${base64Encode(assetConfig['byteData']! as List<int>)}';
+      icon = util.GIcon()
+        ..url =
+            'data:image/png;base64,${base64Encode(assetConfig['byteData']! as List<int>)}';
       if (assetConfig['width'] != null || assetConfig['height'] != null) {
         icon.size = util.GSize(
           assetConfig['width'] != null
@@ -386,8 +381,7 @@ util.GPolygonOptions _polygonOptionsFromPolygon(Polygon polygon) {
 bool _isPolygonClockwise(List<LatLng> path) {
   double direction = 0.0;
   for (int i = 0; i < path.length; i++) {
-    direction =
-        direction +
+    direction = direction +
         ((path[(i + 1) % path.length].latitude - path[i].latitude) *
             (path[(i + 1) % path.length].longitude + path[i].longitude));
   }

--- a/packages/google_maps_flutter/lib/src/google_maps_controller.dart
+++ b/packages/google_maps_flutter/lib/src/google_maps_controller.dart
@@ -23,15 +23,15 @@ class GoogleMapsController {
     Set<Circle> circles = const <Circle>{},
     Set<ClusterManager> clusterManagers = const <ClusterManager>{},
     Map<String, dynamic> mapOptions = const <String, dynamic>{},
-  }) : _mapId = mapId,
-       _streamController = streamController,
-       _initialCameraPosition = initialCameraPosition,
-       _markers = markers,
-       _polygons = polygons,
-       _polylines = polylines,
-       _circles = circles,
-       _clusterManagers = clusterManagers,
-       _rawMapOptions = mapOptions {
+  })  : _mapId = mapId,
+        _streamController = streamController,
+        _initialCameraPosition = initialCameraPosition,
+        _markers = markers,
+        _polygons = polygons,
+        _polylines = polylines,
+        _circles = circles,
+        _clusterManagers = clusterManagers,
+        _rawMapOptions = mapOptions {
     _circlesController = CirclesController(stream: _streamController);
     _polygonsController = PolygonsController(stream: _streamController);
     _polylinesController = PolylinesController(stream: _streamController);
@@ -70,25 +70,21 @@ class GoogleMapsController {
   /// Returns min-max zoom levels. Test only.
   @visibleForTesting
   Future<MinMaxZoomPreference> getMinMaxZoomLevels() async {
-    final String value =
-        await controller.runJavaScriptReturningResult(
-              'JSON.stringify([map.minZoom, map.maxZoom])',
-            )
-            as String;
+    final String value = await controller.runJavaScriptReturningResult(
+      'JSON.stringify([map.minZoom, map.maxZoom])',
+    ) as String;
     final dynamic bound = json.decode(value);
     double min = 0, max = 0;
     if (bound is List<dynamic>) {
       if (bound[0] is num) {
-        min =
-            (bound[0] is double)
-                ? (bound[0] as double)
-                : (bound[0] as int).toDouble();
+        min = (bound[0] is double)
+            ? (bound[0] as double)
+            : (bound[0] as int).toDouble();
       }
       if (bound[1] is num) {
-        max =
-            (bound[1] is double)
-                ? (bound[1] as double)
-                : (bound[1] as int).toDouble();
+        max = (bound[1] is double)
+            ? (bound[1] as double)
+            : (bound[1] as int).toDouble();
       }
       return MinMaxZoomPreference(min, max);
     }
@@ -98,27 +94,24 @@ class GoogleMapsController {
   /// Returns if zoomGestures property is enabled. Test only.
   @visibleForTesting
   Future<bool> isZoomGesturesEnabled() async {
-    final String value =
-        await controller.runJavaScriptReturningResult('map.gestureHandling')
-            as String;
+    final String value = await controller
+        .runJavaScriptReturningResult('map.gestureHandling') as String;
     return value != 'none';
   }
 
   /// Returns if zoomControls property is enabled. Test only.
   @visibleForTesting
   Future<bool> isZoomControlsEnabled() async {
-    final String value =
-        await controller.runJavaScriptReturningResult('map.zoomControl')
-            as String;
+    final String value = await controller
+        .runJavaScriptReturningResult('map.zoomControl') as String;
     return value != 'false';
   }
 
   /// Returns if scrollGestures property is enabled. Test only.
   @visibleForTesting
   Future<bool> isScrollGesturesEnabled() async {
-    final String value =
-        await controller.runJavaScriptReturningResult('map.gestureHandling')
-            as String;
+    final String value = await controller
+        .runJavaScriptReturningResult('map.gestureHandling') as String;
     return value != 'none';
   }
 

--- a/packages/google_maps_flutter/lib/src/marker.dart
+++ b/packages/google_maps_flutter/lib/src/marker.dart
@@ -18,14 +18,14 @@ class MarkerController {
     ui.VoidCallback? onTap,
     ClusterManagerId? clusterManagerId,
     WebViewController? controller,
-  }) : _marker = marker,
-       _infoWindow = infoWindow,
-       _consumeTapEvents = consumeTapEvents,
-       _clusterManagerId = clusterManagerId,
-       tapEvent = onTap,
-       dragStartEvent = onDragStart,
-       dragEvent = onDrag,
-       dragEndEvent = onDragEnd {
+  })  : _marker = marker,
+        _infoWindow = infoWindow,
+        _consumeTapEvents = consumeTapEvents,
+        _clusterManagerId = clusterManagerId,
+        tapEvent = onTap,
+        dragStartEvent = onDragStart,
+        dragEvent = onDrag,
+        dragEndEvent = onDragEnd {
     if (controller != null) {
       _addMarkerEvent(controller);
     }

--- a/packages/google_maps_flutter/lib/src/marker_clustering.dart
+++ b/packages/google_maps_flutter/lib/src/marker_clustering.dart
@@ -17,17 +17,17 @@ class ClusterManagersController extends GeometryController {
   /// emitting map events.
   ClusterManagersController({
     required StreamController<MapEvent<Object?>> stream,
-  }) : _streamController = stream,
-       _idToClusterManagerId = <String, ClusterManagerId>{},
-       _clusterManagerIdToMarkerClusterer =
-           <ClusterManagerId, util.GMarkerClusterer>{};
+  })  : _streamController = stream,
+        _idToClusterManagerId = <String, ClusterManagerId>{},
+        _clusterManagerIdToMarkerClusterer =
+            <ClusterManagerId, util.GMarkerClusterer>{};
 
   // The stream over which cluster managers broadcast their events
   final StreamController<MapEvent<Object?>> _streamController;
 
   // A cache of [MarkerClusterer]s indexed by their [ClusterManagerId].
   final Map<ClusterManagerId, util.GMarkerClusterer>
-  _clusterManagerIdToMarkerClusterer;
+      _clusterManagerIdToMarkerClusterer;
   final Map<String, ClusterManagerId> _idToClusterManagerId;
 
   /// A cache of [ClusterManagerId]s indexed by [GMarkerClusterer.id].

--- a/packages/google_maps_flutter/lib/src/markers.dart
+++ b/packages/google_maps_flutter/lib/src/markers.dart
@@ -11,10 +11,10 @@ class MarkersController extends GeometryController {
   MarkersController({
     required StreamController<MapEvent<Object?>> stream,
     required ClusterManagersController clusterManagersController,
-  }) : _streamController = stream,
-       _clusterManagersController = clusterManagersController,
-       _idToMarkerId = <int, MarkerId>{},
-       _markerIdToController = <MarkerId, MarkerController>{};
+  })  : _streamController = stream,
+        _clusterManagersController = clusterManagersController,
+        _idToMarkerId = <int, MarkerId>{},
+        _markerIdToController = <MarkerId, MarkerController>{};
 
   // A cache of [MarkerController]s indexed by their [MarkerId].
   final Map<MarkerId, MarkerController> _markerIdToController;
@@ -174,11 +174,10 @@ class MarkersController extends GeometryController {
   void _hideAllMarkerInfoWindow() {
     _markerIdToController.values
         .where(
-          (MarkerController? controller) =>
-              controller?.infoWindowShown ?? false,
-        )
+      (MarkerController? controller) => controller?.infoWindowShown ?? false,
+    )
         .forEach((MarkerController controller) {
-          controller.hideInfoWindow();
-        });
+      controller.hideInfoWindow();
+    });
   }
 }

--- a/packages/google_maps_flutter/lib/src/polygon.dart
+++ b/packages/google_maps_flutter/lib/src/polygon.dart
@@ -13,9 +13,9 @@ class PolygonController {
     bool consumeTapEvents = false,
     ui.VoidCallback? onTap,
     WebViewController? controller,
-  }) : _polygon = polygon,
-       _consumeTapEvents = consumeTapEvents,
-       tapEvent = onTap {
+  })  : _polygon = polygon,
+        _consumeTapEvents = consumeTapEvents,
+        tapEvent = onTap {
     _addPolygonEvent(controller);
   }
 

--- a/packages/google_maps_flutter/lib/src/polygons.dart
+++ b/packages/google_maps_flutter/lib/src/polygons.dart
@@ -9,9 +9,9 @@ part of '../google_maps_flutter_tizen.dart';
 class PolygonsController extends GeometryController {
   /// Initializes the cache. The [StreamController] comes from the [GoogleMapController], and is shared with other controllers.
   PolygonsController({required StreamController<MapEvent<Object?>> stream})
-    : _streamController = stream,
-      _polygonIdToController = <PolygonId, PolygonController>{},
-      _idToPolygonId = <int, PolygonId>{};
+      : _streamController = stream,
+        _polygonIdToController = <PolygonId, PolygonController>{},
+        _idToPolygonId = <int, PolygonId>{};
 
   // A cache of [PolygonController]s indexed by their [PolygonId].
   final Map<PolygonId, PolygonController> _polygonIdToController;

--- a/packages/google_maps_flutter/lib/src/polyline.dart
+++ b/packages/google_maps_flutter/lib/src/polyline.dart
@@ -13,9 +13,9 @@ class PolylineController {
     bool consumeTapEvents = false,
     ui.VoidCallback? onTap,
     WebViewController? controller,
-  }) : _polyline = polyline,
-       _consumeTapEvents = consumeTapEvents,
-       tapEvent = onTap {
+  })  : _polyline = polyline,
+        _consumeTapEvents = consumeTapEvents,
+        tapEvent = onTap {
     _addPolylineEvent(controller);
   }
 

--- a/packages/google_maps_flutter/lib/src/polylines.dart
+++ b/packages/google_maps_flutter/lib/src/polylines.dart
@@ -9,9 +9,9 @@ part of '../google_maps_flutter_tizen.dart';
 class PolylinesController extends GeometryController {
   /// Initializes the cache. The [StreamController] comes from the [GoogleMapController], and is shared with other controllers.
   PolylinesController({required StreamController<MapEvent<Object?>> stream})
-    : _streamController = stream,
-      _polylineIdToController = <PolylineId, PolylineController>{},
-      _idToPolylineId = <int, PolylineId>{};
+      : _streamController = stream,
+        _polylineIdToController = <PolylineId, PolylineController>{},
+        _idToPolylineId = <int, PolylineId>{};
 
   // A cache of [PolylineController]s indexed by their [PolylineId].
   final Map<PolylineId, PolylineController> _polylineIdToController;

--- a/packages/google_maps_flutter/lib/src/util.dart
+++ b/packages/google_maps_flutter/lib/src/util.dart
@@ -138,10 +138,9 @@ class GInfoWindowOptions {
 
   @override
   String toString() {
-    final String pos =
-        position != null
-            ? '{lat:${position?.latitude}, lng:${position?.longitude}}'
-            : 'null';
+    final String pos = position != null
+        ? '{lat:${position?.latitude}, lng:${position?.longitude}}'
+        : 'null';
     return '{content:$content, pixelOffset:null , position:$pos, zIndex:$zIndex}';
   }
 }
@@ -205,7 +204,9 @@ class GInfoWindow {
 /// This class represents a geographical location on the map as a Marker.
 class GMarker {
   /// GMarker Constructor.
-  GMarker([GMarkerOptions? opts]) : id = _gid++, _options = opts {
+  GMarker([GMarkerOptions? opts])
+      : id = _gid++,
+        _options = opts {
     _createMarker(opts);
   }
 
@@ -619,11 +620,9 @@ class GMarkerClusterer {
 
   /// Removes a marker from the [GMarkerClusterer].
   Future<bool> removeMarker(GMarker marker, bool? noDraw) async {
-    final bool result =
-        await webController!.runJavaScriptReturningResult(
-              '${toString()}.removeMarker($marker, $noDraw);',
-            )
-            as bool;
+    final bool result = await webController!.runJavaScriptReturningResult(
+      '${toString()}.removeMarker($marker, $noDraw);',
+    ) as bool;
 
     return result;
   }

--- a/packages/google_sign_in/CHANGELOG.md
+++ b/packages/google_sign_in/CHANGELOG.md
@@ -1,3 +1,7 @@
+## NEXT
+
+* Update code format.
+
 ## 0.1.4
 
 * Update minimum Flutter and Dart version to 3.13 and 3.1.

--- a/packages/google_sign_in/example/lib/main.dart
+++ b/packages/google_sign_in/example/lib/main.dart
@@ -68,8 +68,7 @@ class SignInDemoState extends State<SignInDemo> {
     );
     if (response.statusCode != 200) {
       setState(() {
-        _contactText =
-            'People API gave a ${response.statusCode} '
+        _contactText = 'People API gave a ${response.statusCode} '
             'response. Check logs for details.';
       });
       print('People API ${response.statusCode} response: ${response.body}');
@@ -89,22 +88,17 @@ class SignInDemoState extends State<SignInDemo> {
 
   String? _pickFirstNamedContact(Map<String, dynamic> data) {
     final List<dynamic>? connections = data['connections'] as List<dynamic>?;
-    final Map<String, dynamic>? contact =
-        connections?.firstWhere(
-              (dynamic contact) =>
-                  (contact as Map<Object?, dynamic>)['names'] != null,
-              orElse: () => null,
-            )
-            as Map<String, dynamic>?;
+    final Map<String, dynamic>? contact = connections?.firstWhere(
+      (dynamic contact) => (contact as Map<Object?, dynamic>)['names'] != null,
+      orElse: () => null,
+    ) as Map<String, dynamic>?;
     if (contact != null) {
       final List<dynamic> names = contact['names'] as List<dynamic>;
-      final Map<String, dynamic>? name =
-          names.firstWhere(
-                (dynamic name) =>
-                    (name as Map<Object?, dynamic>)['displayName'] != null,
-                orElse: () => null,
-              )
-              as Map<String, dynamic>?;
+      final Map<String, dynamic>? name = names.firstWhere(
+        (dynamic name) =>
+            (name as Map<Object?, dynamic>)['displayName'] != null,
+        orElse: () => null,
+      ) as Map<String, dynamic>?;
       if (name != null) {
         return name['displayName'] as String?;
       }

--- a/packages/google_sign_in/lib/google_sign_in_tizen.dart
+++ b/packages/google_sign_in/lib/google_sign_in_tizen.dart
@@ -102,8 +102,8 @@ class _CachedTokenStorage {
     final String? jsonString = await _storage.read(key: _kToken);
     return jsonString != null
         ? _GoogleSignInTokenDataTizen.fromJson(
-          jsonDecode(jsonString) as Map<String, Object?>,
-        )
+            jsonDecode(jsonString) as Map<String, Object?>,
+          )
         : null;
   }
 
@@ -166,8 +166,7 @@ class GoogleSignInTizen extends GoogleSignInPlatform {
     if (_credentials == null) {
       throw PlatformException(
         code: 'credentials-missing',
-        message:
-            'Cannot initialize GoogleSignInTizen: ClientID and '
+        message: 'Cannot initialize GoogleSignInTizen: ClientID and '
             'ClientSecret has not been set, first call `setCredentials` '
             "in google_sign_in_tizen.dart before calling GoogleSignIn's signIn API.",
       );
@@ -178,8 +177,7 @@ class GoogleSignInTizen extends GoogleSignInPlatform {
     if (device_flow_widget.navigatorKey.currentContext == null) {
       throw PlatformException(
         code: 'navigatorkey-unassigned',
-        message:
-            'Cannot initialize GoogleSignInTizen: a default or custom '
+        message: 'Cannot initialize GoogleSignInTizen: a default or custom '
             'navigator key must be assigned to `navigatorKey` parameter in '
             '`MaterialApp` or `CupertinoApp`.',
       );
@@ -234,8 +232,8 @@ class GoogleSignInTizen extends GoogleSignInPlatform {
     _ensureSetCredentials();
     _ensureNavigatorKeyAssigned();
 
-    final AuthorizationResponse authorizationResponse = await _authClient
-        .requestAuthorization(_credentials!.clientId, _scopes);
+    final AuthorizationResponse authorizationResponse =
+        await _authClient.requestAuthorization(_credentials!.clientId, _scopes);
 
     final Future<TokenResponse?> tokenResponseFuture = _authClient.pollToken(
       clientId: _credentials!.clientId,
@@ -357,8 +355,7 @@ class GoogleSignInTizen extends GoogleSignInPlatform {
     if (token.refreshToken == null) {
       throw PlatformException(
         code: 'refresh-token-missing',
-        message:
-            'Cannot refresh tokens as refresh tokens are missing. '
+        message: 'Cannot refresh tokens as refresh tokens are missing. '
             'Request new tokens by signing-in again.',
       );
     }

--- a/packages/google_sign_in/lib/src/device_flow_widget.dart
+++ b/packages/google_sign_in/lib/src/device_flow_widget.dart
@@ -37,7 +37,9 @@ void showDeviceFlowWidget({
       final TextStyle bodyStyle = Theme.of(
         context,
       ).textTheme.bodyLarge!.copyWith(color: Colors.black);
-      final TextStyle titleStyle = Theme.of(context).textTheme.titleLarge!
+      final TextStyle titleStyle = Theme.of(context)
+          .textTheme
+          .titleLarge!
           .copyWith(color: Colors.black, fontWeight: FontWeight.bold);
 
       return AlertDialog(
@@ -136,10 +138,8 @@ class _CountdownTimerState extends State<_CountdownTimer> {
   @override
   Widget build(BuildContext context) {
     final String minutes = _remaining.inMinutes.toString().padLeft(2, '0');
-    final String seconds = _remaining.inSeconds
-        .remainder(60)
-        .toString()
-        .padLeft(2, '0');
+    final String seconds =
+        _remaining.inSeconds.remainder(60).toString().padLeft(2, '0');
     return FittedBox(child: Text('$minutes:$seconds', style: widget.style));
   }
 

--- a/packages/google_sign_in/lib/src/oauth2.dart
+++ b/packages/google_sign_in/lib/src/oauth2.dart
@@ -27,10 +27,9 @@ class AuthorizationResponse {
       userCode: json['user_code']! as String,
       verificationUrl: Uri.parse(json['verification_url']! as String),
       expiresIn: Duration(seconds: json['expires_in']! as int),
-      interval:
-          json['interval'] is int
-              ? Duration(seconds: json['interval']! as int)
-              : null,
+      interval: json['interval'] is int
+          ? Duration(seconds: json['interval']! as int)
+          : null,
     );
   }
 
@@ -72,10 +71,9 @@ class TokenResponse {
       tokenType: json['token_type']! as String,
       expiresIn: Duration(seconds: json['expires_in']! as int),
       refreshToken: json['refresh_token'] as String?,
-      scope:
-          json['scope'] is String
-              ? (json['scope']! as String).split(' ').toList()
-              : null,
+      scope: json['scope'] is String
+          ? (json['scope']! as String).split(' ').toList()
+          : null,
       idToken: json['id_token']! as String,
     );
   }

--- a/packages/image_picker/CHANGELOG.md
+++ b/packages/image_picker/CHANGELOG.md
@@ -1,3 +1,7 @@
+## NEXT
+
+* Update code format.
+
 ## 2.3.1
 
 * Update minimum Flutter and Dart version to 3.13 and 3.1.

--- a/packages/image_picker/example/lib/main.dart
+++ b/packages/image_picker/example/lib/main.dart
@@ -108,18 +108,17 @@ class _MyHomePageState extends State<MyHomePage> {
           int? quality,
         ) async {
           try {
-            final List<XFile> pickedFileList =
-                isMedia
-                    ? await _picker.pickMultipleMedia(
-                      maxWidth: maxWidth,
-                      maxHeight: maxHeight,
-                      imageQuality: quality,
-                    )
-                    : await _picker.pickMultiImage(
-                      maxWidth: maxWidth,
-                      maxHeight: maxHeight,
-                      imageQuality: quality,
-                    );
+            final List<XFile> pickedFileList = isMedia
+                ? await _picker.pickMultipleMedia(
+                    maxWidth: maxWidth,
+                    maxHeight: maxHeight,
+                    imageQuality: quality,
+                  )
+                : await _picker.pickMultiImage(
+                    maxWidth: maxWidth,
+                    maxHeight: maxHeight,
+                    imageQuality: quality,
+                  );
             setState(() {
               _mediaFileList = pickedFileList;
             });
@@ -240,23 +239,22 @@ class _MyHomePageState extends State<MyHomePage> {
             // See https://pub.dev/packages/image_picker_for_web#limitations-on-the-web-platform
             return Semantics(
               label: 'image_picker_example_picked_image',
-              child:
-                  kIsWeb
-                      ? Image.network(_mediaFileList![index].path)
-                      : (mime == null || mime.startsWith('image/')
-                          ? Image.file(
-                            File(_mediaFileList![index].path),
-                            errorBuilder: (
-                              BuildContext context,
-                              Object error,
-                              StackTrace? stackTrace,
-                            ) {
-                              return const Center(
-                                child: Text('This image type is not supported'),
-                              );
-                            },
-                          )
-                          : _buildInlineVideoPlayer(index)),
+              child: kIsWeb
+                  ? Image.network(_mediaFileList![index].path)
+                  : (mime == null || mime.startsWith('image/')
+                      ? Image.file(
+                          File(_mediaFileList![index].path),
+                          errorBuilder: (
+                            BuildContext context,
+                            Object error,
+                            StackTrace? stackTrace,
+                          ) {
+                            return const Center(
+                              child: Text('This image type is not supported'),
+                            );
+                          },
+                        )
+                      : _buildInlineVideoPlayer(index)),
             );
           },
           itemCount: _mediaFileList!.length,
@@ -324,39 +322,38 @@ class _MyHomePageState extends State<MyHomePage> {
     return Scaffold(
       appBar: AppBar(title: Text(widget.title!)),
       body: Center(
-        child:
-            !kIsWeb && defaultTargetPlatform == TargetPlatform.android
-                ? FutureBuilder<void>(
-                  future: retrieveLostData(),
-                  builder: (
-                    BuildContext context,
-                    AsyncSnapshot<void> snapshot,
-                  ) {
-                    switch (snapshot.connectionState) {
-                      case ConnectionState.none:
-                      case ConnectionState.waiting:
+        child: !kIsWeb && defaultTargetPlatform == TargetPlatform.android
+            ? FutureBuilder<void>(
+                future: retrieveLostData(),
+                builder: (
+                  BuildContext context,
+                  AsyncSnapshot<void> snapshot,
+                ) {
+                  switch (snapshot.connectionState) {
+                    case ConnectionState.none:
+                    case ConnectionState.waiting:
+                      return const Text(
+                        'You have not yet picked an image.',
+                        textAlign: TextAlign.center,
+                      );
+                    case ConnectionState.done:
+                      return _handlePreview();
+                    case ConnectionState.active:
+                      if (snapshot.hasError) {
+                        return Text(
+                          'Pick image/video error: ${snapshot.error}}',
+                          textAlign: TextAlign.center,
+                        );
+                      } else {
                         return const Text(
                           'You have not yet picked an image.',
                           textAlign: TextAlign.center,
                         );
-                      case ConnectionState.done:
-                        return _handlePreview();
-                      case ConnectionState.active:
-                        if (snapshot.hasError) {
-                          return Text(
-                            'Pick image/video error: ${snapshot.error}}',
-                            textAlign: TextAlign.center,
-                          );
-                        } else {
-                          return const Text(
-                            'You have not yet picked an image.',
-                            textAlign: TextAlign.center,
-                          );
-                        }
-                    }
-                  },
-                )
-                : _handlePreview(),
+                      }
+                  }
+                },
+              )
+            : _handlePreview(),
       ),
       floatingActionButton: Column(
         mainAxisAlignment: MainAxisAlignment.end,
@@ -524,18 +521,15 @@ class _MyHomePageState extends State<MyHomePage> {
             TextButton(
               child: const Text('PICK'),
               onPressed: () {
-                final double? width =
-                    maxWidthController.text.isNotEmpty
-                        ? double.parse(maxWidthController.text)
-                        : null;
-                final double? height =
-                    maxHeightController.text.isNotEmpty
-                        ? double.parse(maxHeightController.text)
-                        : null;
-                final int? quality =
-                    qualityController.text.isNotEmpty
-                        ? int.parse(qualityController.text)
-                        : null;
+                final double? width = maxWidthController.text.isNotEmpty
+                    ? double.parse(maxWidthController.text)
+                    : null;
+                final double? height = maxHeightController.text.isNotEmpty
+                    ? double.parse(maxHeightController.text)
+                    : null;
+                final int? quality = qualityController.text.isNotEmpty
+                    ? int.parse(qualityController.text)
+                    : null;
                 onPick(width, height, quality);
                 Navigator.of(context).pop();
               },
@@ -547,8 +541,8 @@ class _MyHomePageState extends State<MyHomePage> {
   }
 }
 
-typedef OnPickImageCallback =
-    void Function(double? maxWidth, double? maxHeight, int? quality);
+typedef OnPickImageCallback = void Function(
+    double? maxWidth, double? maxHeight, int? quality);
 
 class AspectRatioVideo extends StatefulWidget {
   const AspectRatioVideo(this.controller, {super.key});

--- a/packages/image_picker/lib/image_picker_tizen.dart
+++ b/packages/image_picker/lib/image_picker_tizen.dart
@@ -145,11 +145,11 @@ class ImagePickerTizen extends CameraDelegatingImagePickerPlatform {
 
     return _channel
         .invokeMethod<List<dynamic>?>('pickMultiImage', <String, dynamic>{
-          'maxWidth': maxWidth,
-          'maxHeight': maxHeight,
-          'imageQuality': imageQuality,
-          'requestFullMetadata': requestFullMetadata,
-        });
+      'maxWidth': maxWidth,
+      'maxHeight': maxHeight,
+      'imageQuality': imageQuality,
+      'requestFullMetadata': requestFullMetadata,
+    });
   }
 
   @override
@@ -163,12 +163,11 @@ class ImagePickerTizen extends CameraDelegatingImagePickerPlatform {
       'allowMultiple': options.allowMultiple,
     };
 
-    final List<XFile>? paths = await _channel
-        .invokeMethod<List<dynamic>?>('pickMedia', args)
-        .then(
-          (List<dynamic>? paths) =>
-              paths?.map((dynamic path) => XFile(path as String)).toList(),
-        );
+    final List<XFile>? paths =
+        await _channel.invokeMethod<List<dynamic>?>('pickMedia', args).then(
+              (List<dynamic>? paths) =>
+                  paths?.map((dynamic path) => XFile(path as String)).toList(),
+            );
 
     return paths ?? <XFile>[];
   }

--- a/packages/in_app_purchase/CHANGELOG.md
+++ b/packages/in_app_purchase/CHANGELOG.md
@@ -1,3 +1,7 @@
+## NEXT
+
+* Update code format.
+
 ## 0.1.2
 
 * Update the LICENSE file so that it is recognized by pub.dev.

--- a/packages/in_app_purchase/example/lib/main.dart
+++ b/packages/in_app_purchase/example/lib/main.dart
@@ -61,9 +61,8 @@ class _MyAppState extends State<_MyApp> {
   Future<void> initStoreInfo() async {
     // Tizen specific API:
     // You need to set necessary parameters before calling any plugin API.
-    final InAppPurchaseTizenPlatformAddition platformAddition =
-        _inAppPurchase
-            .getPlatformAddition<InAppPurchaseTizenPlatformAddition>();
+    final InAppPurchaseTizenPlatformAddition platformAddition = _inAppPurchase
+        .getPlatformAddition<InAppPurchaseTizenPlatformAddition>();
     platformAddition.setRequestParameters(
       appId: _kAppId,
       pageSize: _kPageSize,
@@ -86,8 +85,8 @@ class _MyAppState extends State<_MyApp> {
 
     // The `identifiers` argument is not used on Tizen.
     // Use `InAppPurchaseTizenPlatformAddition.setRequestParameters` instead.
-    final ProductDetailsResponse productDetailResponse = await _inAppPurchase
-        .queryProductDetails(<String>{});
+    final ProductDetailsResponse productDetailResponse =
+        await _inAppPurchase.queryProductDetails(<String>{});
     if (productDetailResponse.error != null) {
       setState(() {
         _queryProductError = productDetailResponse.error!.message;
@@ -317,9 +316,8 @@ class _MyAppState extends State<_MyApp> {
 
     // Tizen specific verify purchase:
     // If `PurchaseDetails.status` is `purchased`, need to verify purchase.
-    final InAppPurchaseTizenPlatformAddition platformAddition =
-        _inAppPurchase
-            .getPlatformAddition<InAppPurchaseTizenPlatformAddition>();
+    final InAppPurchaseTizenPlatformAddition platformAddition = _inAppPurchase
+        .getPlatformAddition<InAppPurchaseTizenPlatformAddition>();
     return platformAddition.verifyPurchase(purchaseDetails: purchaseDetails);
   }
 

--- a/packages/in_app_purchase/lib/src/billing_manager.dart
+++ b/packages/in_app_purchase/lib/src/billing_manager.dart
@@ -20,7 +20,7 @@ import 'messages.g.dart';
 class BillingManager {
   /// Creates a billing manager.
   BillingManager({@visibleForTesting InAppPurchaseApi? hostApi})
-    : _hostApi = hostApi ?? InAppPurchaseApi();
+      : _hostApi = hostApi ?? InAppPurchaseApi();
 
   late RequestParameters _requestParameters;
 
@@ -391,19 +391,19 @@ class SamsungCheckoutPurchaseDetails extends PurchaseDetails {
   ) {
     final SamsungCheckoutPurchaseDetails purchaseDetails =
         SamsungCheckoutPurchaseDetails(
-          purchaseID: invoiceDetails.invoiceId,
-          productID: invoiceDetails.itemId,
-          verificationData: PurchaseVerificationData(
-            localVerificationData: invoiceDetails.invoiceId,
-            serverVerificationData: invoiceDetails.invoiceId,
-            source: kIAPSource,
-          ),
-          transactionDate: invoiceDetails.orderTime,
-          status: const PurchaseStateConverter().toPurchaseStatus(
-            invoiceDetails.cancelStatus,
-          ),
-          invoiceDetails: invoiceDetails,
-        );
+      purchaseID: invoiceDetails.invoiceId,
+      productID: invoiceDetails.itemId,
+      verificationData: PurchaseVerificationData(
+        localVerificationData: invoiceDetails.invoiceId,
+        serverVerificationData: invoiceDetails.invoiceId,
+        source: kIAPSource,
+      ),
+      transactionDate: invoiceDetails.orderTime,
+      status: const PurchaseStateConverter().toPurchaseStatus(
+        invoiceDetails.cancelStatus,
+      ),
+      invoiceDetails: invoiceDetails,
+    );
 
     if (purchaseDetails.status == PurchaseStatus.error) {
       purchaseDetails.error = IAPError(

--- a/packages/in_app_purchase/lib/src/in_app_purchase_tizen_platform.dart
+++ b/packages/in_app_purchase/lib/src/in_app_purchase_tizen_platform.dart
@@ -39,7 +39,7 @@ class InAppPurchaseTizenPlatform extends InAppPurchasePlatform {
   }
 
   static final StreamController<List<PurchaseDetails>>
-  _purchaseUpdatedController =
+      _purchaseUpdatedController =
       StreamController<List<PurchaseDetails>>.broadcast();
 
   @override
@@ -59,12 +59,12 @@ class InAppPurchaseTizenPlatform extends InAppPurchasePlatform {
 
   /// Converts integer to [ItemType].
   static ItemType _intToEnum(int number) => switch (number) {
-    1 => ItemType.consumable,
-    2 => ItemType.nonComsumabel,
-    3 => ItemType.limitedPeriod,
-    4 => ItemType.subscription,
-    _ => ItemType.none,
-  };
+        1 => ItemType.consumable,
+        2 => ItemType.nonComsumabel,
+        3 => ItemType.limitedPeriod,
+        4 => ItemType.subscription,
+        _ => ItemType.none,
+      };
 
   /// Converts Map<Object?, Object?>? to the list of [ItemDetails].
   List<ItemDetails> _getItemDetails(ProductsListApiResult response) {
@@ -118,31 +118,29 @@ class InAppPurchaseTizenPlatform extends InAppPurchasePlatform {
     final List<String> invalidMessage = <String>[];
 
     if (response.cpStatus == '100000') {
-      productDetailsList =
-          _getItemDetails(response)
-              .map(
-                (ItemDetails productWrapper) =>
-                    SamsungCheckoutProductDetails.fromProduct(productWrapper),
-              )
-              .toList();
+      productDetailsList = _getItemDetails(response)
+          .map(
+            (ItemDetails productWrapper) =>
+                SamsungCheckoutProductDetails.fromProduct(productWrapper),
+          )
+          .toList();
     } else {
       invalidMessage.add(response.encode().toString());
     }
 
     final ProductDetailsResponse productDetailsResponse =
         ProductDetailsResponse(
-          productDetails: productDetailsList,
-          notFoundIDs: invalidMessage,
-          error:
-              exception == null
-                  ? null
-                  : IAPError(
-                    source: kIAPSource,
-                    code: exception.code,
-                    message: exception.message ?? '',
-                    details: exception.details,
-                  ),
-        );
+      productDetails: productDetailsList,
+      notFoundIDs: invalidMessage,
+      error: exception == null
+          ? null
+          : IAPError(
+              source: kIAPSource,
+              code: exception.code,
+              message: exception.message ?? '',
+              details: exception.details,
+            ),
+    );
     return productDetailsResponse;
   }
 
@@ -198,22 +196,19 @@ class InAppPurchaseTizenPlatform extends InAppPurchasePlatform {
     ]);
 
     final List<PurchaseDetails> pastPurchases =
-        responses
-            .expand((GetUserPurchaseListAPIResult response) {
-              if (response.cpStatus == '100000') {
-                return _getInvoiceDetails(response);
-              } else {
-                return <InvoiceDetails>[];
-              }
-            })
-            .map((InvoiceDetails purchaseWrapper) {
-              final SamsungCheckoutPurchaseDetails purchaseDetails =
-                  SamsungCheckoutPurchaseDetails.fromPurchase(purchaseWrapper);
+        responses.expand((GetUserPurchaseListAPIResult response) {
+      if (response.cpStatus == '100000') {
+        return _getInvoiceDetails(response);
+      } else {
+        return <InvoiceDetails>[];
+      }
+    }).map((InvoiceDetails purchaseWrapper) {
+      final SamsungCheckoutPurchaseDetails purchaseDetails =
+          SamsungCheckoutPurchaseDetails.fromPurchase(purchaseWrapper);
 
-              purchaseDetails.status = PurchaseStatus.restored;
-              return purchaseDetails;
-            })
-            .toList();
+      purchaseDetails.status = PurchaseStatus.restored;
+      return purchaseDetails;
+    }).toList();
     _purchaseUpdatedController.add(pastPurchases);
   }
 
@@ -234,35 +229,33 @@ class InAppPurchaseTizenPlatform extends InAppPurchasePlatform {
         billingManager
             .requestPurchases()
             .then((GetUserPurchaseListAPIResult responses) {
-              for (int i = 0; i < responses.invoiceDetails.length; i++) {
-                if (_getInvoiceDetails(responses)[i].invoiceId == invoiceId) {
-                  final List<PurchaseDetails> purchases = <PurchaseDetails>[];
-                  purchases.add(
-                    PurchaseDetails(
-                      purchaseID: _getInvoiceDetails(responses)[i].invoiceId,
-                      productID: _getInvoiceDetails(responses)[i].itemId,
-                      verificationData: PurchaseVerificationData(
-                        localVerificationData:
-                            _getInvoiceDetails(responses)[i].invoiceId,
-                        serverVerificationData:
-                            _getInvoiceDetails(responses)[i].invoiceId,
-                        source: kIAPSource,
-                      ),
-                      transactionDate:
-                          _getInvoiceDetails(responses)[i].orderTime,
-                      status: const PurchaseStateConverter().toPurchaseStatus(
-                        _getInvoiceDetails(responses)[i].cancelStatus,
-                      ),
-                    ),
-                  );
+          for (int i = 0; i < responses.invoiceDetails.length; i++) {
+            if (_getInvoiceDetails(responses)[i].invoiceId == invoiceId) {
+              final List<PurchaseDetails> purchases = <PurchaseDetails>[];
+              purchases.add(
+                PurchaseDetails(
+                  purchaseID: _getInvoiceDetails(responses)[i].invoiceId,
+                  productID: _getInvoiceDetails(responses)[i].itemId,
+                  verificationData: PurchaseVerificationData(
+                    localVerificationData:
+                        _getInvoiceDetails(responses)[i].invoiceId,
+                    serverVerificationData:
+                        _getInvoiceDetails(responses)[i].invoiceId,
+                    source: kIAPSource,
+                  ),
+                  transactionDate: _getInvoiceDetails(responses)[i].orderTime,
+                  status: const PurchaseStateConverter().toPurchaseStatus(
+                    _getInvoiceDetails(responses)[i].cancelStatus,
+                  ),
+                ),
+              );
 
-                  _purchaseUpdatedController.add(purchases);
-                }
-              }
-            })
-            .catchError((Object error) {
-              _purchaseUpdatedController.addError(error);
-            }),
+              _purchaseUpdatedController.add(purchases);
+            }
+          }
+        }).catchError((Object error) {
+          _purchaseUpdatedController.addError(error);
+        }),
       );
 
       return true;

--- a/packages/in_app_purchase/lib/src/messages.g.dart
+++ b/packages/in_app_purchase/lib/src/messages.g.dart
@@ -478,9 +478,9 @@ class InAppPurchaseApi {
   InAppPurchaseApi({
     BinaryMessenger? binaryMessenger,
     String messageChannelSuffix = '',
-  }) : pigeonVar_binaryMessenger = binaryMessenger,
-       pigeonVar_messageChannelSuffix =
-           messageChannelSuffix.isNotEmpty ? '.$messageChannelSuffix' : '';
+  })  : pigeonVar_binaryMessenger = binaryMessenger,
+        pigeonVar_messageChannelSuffix =
+            messageChannelSuffix.isNotEmpty ? '.$messageChannelSuffix' : '';
   final BinaryMessenger? pigeonVar_binaryMessenger;
 
   static const MessageCodec<Object?> pigeonChannelCodec = _PigeonCodec();
@@ -493,10 +493,10 @@ class InAppPurchaseApi {
         'dev.flutter.pigeon.in_app_purchase_tizen.InAppPurchaseApi.getProductsList$pigeonVar_messageChannelSuffix';
     final BasicMessageChannel<Object?> pigeonVar_channel =
         BasicMessageChannel<Object?>(
-          pigeonVar_channelName,
-          pigeonChannelCodec,
-          binaryMessenger: pigeonVar_binaryMessenger,
-        );
+      pigeonVar_channelName,
+      pigeonChannelCodec,
+      binaryMessenger: pigeonVar_binaryMessenger,
+    );
     final List<Object?>? pigeonVar_replyList =
         await pigeonVar_channel.send(<Object?>[product]) as List<Object?>?;
     if (pigeonVar_replyList == null) {
@@ -525,10 +525,10 @@ class InAppPurchaseApi {
         'dev.flutter.pigeon.in_app_purchase_tizen.InAppPurchaseApi.getUserPurchaseList$pigeonVar_messageChannelSuffix';
     final BasicMessageChannel<Object?> pigeonVar_channel =
         BasicMessageChannel<Object?>(
-          pigeonVar_channelName,
-          pigeonChannelCodec,
-          binaryMessenger: pigeonVar_binaryMessenger,
-        );
+      pigeonVar_channelName,
+      pigeonChannelCodec,
+      binaryMessenger: pigeonVar_binaryMessenger,
+    );
     final List<Object?>? pigeonVar_replyList =
         await pigeonVar_channel.send(<Object?>[purchase]) as List<Object?>?;
     if (pigeonVar_replyList == null) {
@@ -556,10 +556,10 @@ class InAppPurchaseApi {
         'dev.flutter.pigeon.in_app_purchase_tizen.InAppPurchaseApi.buyItem$pigeonVar_messageChannelSuffix';
     final BasicMessageChannel<Object?> pigeonVar_channel =
         BasicMessageChannel<Object?>(
-          pigeonVar_channelName,
-          pigeonChannelCodec,
-          binaryMessenger: pigeonVar_binaryMessenger,
-        );
+      pigeonVar_channelName,
+      pigeonChannelCodec,
+      binaryMessenger: pigeonVar_binaryMessenger,
+    );
     final List<Object?>? pigeonVar_replyList =
         await pigeonVar_channel.send(<Object?>[buyInfo]) as List<Object?>?;
     if (pigeonVar_replyList == null) {
@@ -586,10 +586,10 @@ class InAppPurchaseApi {
         'dev.flutter.pigeon.in_app_purchase_tizen.InAppPurchaseApi.verifyInvoice$pigeonVar_messageChannelSuffix';
     final BasicMessageChannel<Object?> pigeonVar_channel =
         BasicMessageChannel<Object?>(
-          pigeonVar_channelName,
-          pigeonChannelCodec,
-          binaryMessenger: pigeonVar_binaryMessenger,
-        );
+      pigeonVar_channelName,
+      pigeonChannelCodec,
+      binaryMessenger: pigeonVar_binaryMessenger,
+    );
     final List<Object?>? pigeonVar_replyList =
         await pigeonVar_channel.send(<Object?>[invoice]) as List<Object?>?;
     if (pigeonVar_replyList == null) {
@@ -616,10 +616,10 @@ class InAppPurchaseApi {
         'dev.flutter.pigeon.in_app_purchase_tizen.InAppPurchaseApi.isServiceAvailable$pigeonVar_messageChannelSuffix';
     final BasicMessageChannel<Object?> pigeonVar_channel =
         BasicMessageChannel<Object?>(
-          pigeonVar_channelName,
-          pigeonChannelCodec,
-          binaryMessenger: pigeonVar_binaryMessenger,
-        );
+      pigeonVar_channelName,
+      pigeonChannelCodec,
+      binaryMessenger: pigeonVar_binaryMessenger,
+    );
     final List<Object?>? pigeonVar_replyList =
         await pigeonVar_channel.send(null) as List<Object?>?;
     if (pigeonVar_replyList == null) {
@@ -645,10 +645,10 @@ class InAppPurchaseApi {
         'dev.flutter.pigeon.in_app_purchase_tizen.InAppPurchaseApi.getCustomId$pigeonVar_messageChannelSuffix';
     final BasicMessageChannel<Object?> pigeonVar_channel =
         BasicMessageChannel<Object?>(
-          pigeonVar_channelName,
-          pigeonChannelCodec,
-          binaryMessenger: pigeonVar_binaryMessenger,
-        );
+      pigeonVar_channelName,
+      pigeonChannelCodec,
+      binaryMessenger: pigeonVar_binaryMessenger,
+    );
     final List<Object?>? pigeonVar_replyList =
         await pigeonVar_channel.send(null) as List<Object?>?;
     if (pigeonVar_replyList == null) {
@@ -674,10 +674,10 @@ class InAppPurchaseApi {
         'dev.flutter.pigeon.in_app_purchase_tizen.InAppPurchaseApi.getCountryCode$pigeonVar_messageChannelSuffix';
     final BasicMessageChannel<Object?> pigeonVar_channel =
         BasicMessageChannel<Object?>(
-          pigeonVar_channelName,
-          pigeonChannelCodec,
-          binaryMessenger: pigeonVar_binaryMessenger,
-        );
+      pigeonVar_channelName,
+      pigeonChannelCodec,
+      binaryMessenger: pigeonVar_binaryMessenger,
+    );
     final List<Object?>? pigeonVar_replyList =
         await pigeonVar_channel.send(null) as List<Object?>?;
     if (pigeonVar_replyList == null) {

--- a/packages/in_app_purchase/pigeons/messages.dart
+++ b/packages/in_app_purchase/pigeons/messages.dart
@@ -11,6 +11,7 @@ import 'package:pigeon/pigeon.dart';
     cppSourceOut: 'tizen/src/messages.cc',
   ),
 )
+
 /// Dart wrapper around [`ProductsListApiResult`] in (https://developer.samsung.com/smarttv/develop/api-references/samsung-product-api-references/billing-api.html).
 ///
 /// Defines a dictionary for product list data returned by the getProductsList API.

--- a/packages/messageport/CHANGELOG.md
+++ b/packages/messageport/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 * Fix new lint warnings.
 * Update minimum Flutter and Dart version to 3.13 and 3.1.
+* Update code format.
 
 ## 0.3.2
 

--- a/packages/messageport/example/lib/main.dart
+++ b/packages/messageport/example/lib/main.dart
@@ -158,8 +158,7 @@ class _MyAppState extends State<MyApp> {
   final List<String> _logs = <String>[];
 
   void _log(String log) {
-    final String date =
-        '${DateTime.now().hour.toString().padLeft(2, '0')}:'
+    final String date = '${DateTime.now().hour.toString().padLeft(2, '0')}:'
         '${DateTime.now().minute.toString().padLeft(2, '0')}:'
         '${DateTime.now().second.toString().padLeft(2, '0')}.'
         '${DateTime.now().millisecond.toString().padLeft(3, '0')}';

--- a/packages/messageport/lib/messageport_tizen.dart
+++ b/packages/messageport/lib/messageport_tizen.dart
@@ -11,8 +11,8 @@ MessagePortManager _manager = MessagePortManager();
 /// Called when a message is received on message port.
 ///
 /// This is used by [LocalPort.register].
-typedef OnMessageReceived =
-    void Function(dynamic message, [RemotePort? remotePort]);
+typedef OnMessageReceived = void Function(dynamic message,
+    [RemotePort? remotePort]);
 
 /// Local message port for receiving messages.
 class LocalPort {

--- a/packages/network_info_plus/CHANGELOG.md
+++ b/packages/network_info_plus/CHANGELOG.md
@@ -1,3 +1,7 @@
+## NEXT
+
+* Update code format.
+
 ## 1.1.5
 
 * Update minimum Flutter and Dart version to 3.13 and 3.1.

--- a/packages/network_info_plus/example/lib/main.dart
+++ b/packages/network_info_plus/example/lib/main.dart
@@ -144,8 +144,7 @@ class _MyHomePageState extends State<MyHomePage> {
     }
 
     setState(() {
-      _connectionStatus =
-          'Wifi Name: $wifiName\n'
+      _connectionStatus = 'Wifi Name: $wifiName\n'
           'Wifi BSSID: $wifiBSSID\n'
           'Wifi IPv4: $wifiIPv4\n'
           'Wifi IPv6: $wifiIPv6\n'

--- a/packages/path_provider/CHANGELOG.md
+++ b/packages/path_provider/CHANGELOG.md
@@ -1,3 +1,7 @@
+## NEXT
+
+* Update code format.
+
 ## 2.2.1
 
 * Update the LICENSE file so that it is recognized by pub.dev.

--- a/packages/path_provider/example/lib/main.dart
+++ b/packages/path_provider/example/lib/main.dart
@@ -77,9 +77,8 @@ class _MyHomePageState extends State<MyHomePage> {
       if (snapshot.hasError) {
         text = Text('Error: ${snapshot.error}');
       } else if (snapshot.hasData) {
-        final String combined = snapshot.data!
-            .map((Directory d) => d.path)
-            .join(', ');
+        final String combined =
+            snapshot.data!.map((Directory d) => d.path).join(', ');
         text = Text('paths: $combined');
       } else {
         text = const Text('path unavailable');
@@ -228,10 +227,9 @@ class _MyHomePageState extends State<MyHomePage> {
                 Padding(
                   padding: const EdgeInsets.all(16.0),
                   child: ElevatedButton(
-                    onPressed:
-                        !Platform.isAndroid
-                            ? null
-                            : _requestExternalStorageDirectory,
+                    onPressed: !Platform.isAndroid
+                        ? null
+                        : _requestExternalStorageDirectory,
                     child: Text(
                       !Platform.isAndroid
                           ? 'External storage is unavailable'
@@ -250,14 +248,13 @@ class _MyHomePageState extends State<MyHomePage> {
                 Padding(
                   padding: const EdgeInsets.all(16.0),
                   child: ElevatedButton(
-                    onPressed:
-                        !Platform.isAndroid
-                            ? null
-                            : () {
-                              _requestExternalStorageDirectories(
-                                StorageDirectory.music,
-                              );
-                            },
+                    onPressed: !Platform.isAndroid
+                        ? null
+                        : () {
+                            _requestExternalStorageDirectories(
+                              StorageDirectory.music,
+                            );
+                          },
                     child: Text(
                       !Platform.isAndroid
                           ? 'External directories are unavailable'
@@ -276,10 +273,9 @@ class _MyHomePageState extends State<MyHomePage> {
                 Padding(
                   padding: const EdgeInsets.all(16.0),
                   child: ElevatedButton(
-                    onPressed:
-                        !Platform.isAndroid
-                            ? null
-                            : _requestExternalCacheDirectories,
+                    onPressed: !Platform.isAndroid
+                        ? null
+                        : _requestExternalCacheDirectories,
                     child: Text(
                       !Platform.isAndroid
                           ? 'External directories are unavailable'
@@ -298,10 +294,9 @@ class _MyHomePageState extends State<MyHomePage> {
                 Padding(
                   padding: const EdgeInsets.all(16.0),
                   child: ElevatedButton(
-                    onPressed:
-                        Platform.isAndroid || Platform.isIOS
-                            ? null
-                            : _requestDownloadsDirectory,
+                    onPressed: Platform.isAndroid || Platform.isIOS
+                        ? null
+                        : _requestDownloadsDirectory,
                     child: Text(
                       Platform.isAndroid || Platform.isIOS
                           ? 'Downloads directory is unavailable'

--- a/packages/path_provider/lib/path_provider_tizen.dart
+++ b/packages/path_provider/lib/path_provider_tizen.dart
@@ -34,8 +34,8 @@ class PathProviderPlugin extends PathProviderPlatform {
 
   @override
   Future<List<String>> getExternalCachePaths() async => <String>[
-    appCommon.getExternalCachePath(),
-  ];
+        appCommon.getExternalCachePath(),
+      ];
 
   @override
   Future<List<String>> getExternalStoragePaths({StorageDirectory? type}) async {

--- a/packages/permission_handler/CHANGELOG.md
+++ b/packages/permission_handler/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 * Update minimum Flutter and Dart version to 3.13 and 3.1.
 * Fix analyze issue.
+* Update code format.
 
 ## 1.3.0
 

--- a/packages/permission_handler/example/lib/main.dart
+++ b/packages/permission_handler/example/lib/main.dart
@@ -16,8 +16,8 @@ void main() {
 ///Defines the main theme color
 final MaterialColor themeMaterialColor =
     BaseflowPluginExample.createMaterialColor(
-      const Color.fromRGBO(48, 49, 60, 1),
-    );
+  const Color.fromRGBO(48, 49, 60, 1),
+);
 
 /// A Flutter application demonstrating the functionality of this plugin
 class PermissionHandlerWidget extends StatefulWidget {
@@ -42,36 +42,35 @@ class _PermissionHandlerWidgetState extends State<PermissionHandlerWidget> {
   Widget build(BuildContext context) {
     return Center(
       child: ListView(
-        children:
-            Permission.values
-                .where((permission) {
-                  // Permissions not applicable for Tizen.
-                  return permission != Permission.unknown &&
-                      permission != Permission.photos &&
-                      permission != Permission.photosAddOnly &&
-                      permission != Permission.reminders &&
-                      permission != Permission.speech &&
-                      permission != Permission.ignoreBatteryOptimizations &&
-                      permission != Permission.notification &&
-                      permission != Permission.accessMediaLocation &&
-                      permission != Permission.activityRecognition &&
-                      permission != Permission.bluetooth &&
-                      permission != Permission.manageExternalStorage &&
-                      permission != Permission.systemAlertWindow &&
-                      permission != Permission.requestInstallPackages &&
-                      permission != Permission.appTrackingTransparency &&
-                      permission != Permission.criticalAlerts &&
-                      permission != Permission.accessNotificationPolicy &&
-                      permission != Permission.bluetoothScan &&
-                      permission != Permission.bluetoothAdvertise &&
-                      permission != Permission.bluetoothConnect &&
-                      permission != Permission.nearbyWifiDevices &&
-                      permission != Permission.videos &&
-                      permission != Permission.audio &&
-                      permission != Permission.scheduleExactAlarm;
-                })
-                .map((permission) => PermissionWidget(permission))
-                .toList(),
+        children: Permission.values
+            .where((permission) {
+              // Permissions not applicable for Tizen.
+              return permission != Permission.unknown &&
+                  permission != Permission.photos &&
+                  permission != Permission.photosAddOnly &&
+                  permission != Permission.reminders &&
+                  permission != Permission.speech &&
+                  permission != Permission.ignoreBatteryOptimizations &&
+                  permission != Permission.notification &&
+                  permission != Permission.accessMediaLocation &&
+                  permission != Permission.activityRecognition &&
+                  permission != Permission.bluetooth &&
+                  permission != Permission.manageExternalStorage &&
+                  permission != Permission.systemAlertWindow &&
+                  permission != Permission.requestInstallPackages &&
+                  permission != Permission.appTrackingTransparency &&
+                  permission != Permission.criticalAlerts &&
+                  permission != Permission.accessNotificationPolicy &&
+                  permission != Permission.bluetoothScan &&
+                  permission != Permission.bluetoothAdvertise &&
+                  permission != Permission.bluetoothConnect &&
+                  permission != Permission.nearbyWifiDevices &&
+                  permission != Permission.videos &&
+                  permission != Permission.audio &&
+                  permission != Permission.scheduleExactAlarm;
+            })
+            .map((permission) => PermissionWidget(permission))
+            .toList(),
       ),
     );
   }
@@ -131,18 +130,17 @@ class _PermissionState extends State<PermissionWidget> {
         _permissionStatus.toString(),
         style: TextStyle(color: getPermissionColor()),
       ),
-      trailing:
-          (_permission is PermissionWithService)
-              ? IconButton(
-                icon: const Icon(Icons.info, color: Colors.white),
-                onPressed: () {
-                  checkServiceStatus(
-                    context,
-                    _permission as PermissionWithService,
-                  );
-                },
-              )
-              : null,
+      trailing: (_permission is PermissionWithService)
+          ? IconButton(
+              icon: const Icon(Icons.info, color: Colors.white),
+              onPressed: () {
+                checkServiceStatus(
+                  context,
+                  _permission as PermissionWithService,
+                );
+              },
+            )
+          : null,
       onTap: () {
         requestPermission(_permission);
       },

--- a/packages/sensors_plus/CHANGELOG.md
+++ b/packages/sensors_plus/CHANGELOG.md
@@ -1,3 +1,7 @@
+## NEXT
+
+* Update code format.
+
 ## 1.1.5
 
 * Update minimum Flutter and Dart version to 3.13 and 3.1.

--- a/packages/sensors_plus/example/lib/snake.dart
+++ b/packages/sensors_plus/example/lib/snake.dart
@@ -12,7 +12,7 @@ import 'package:sensors_plus/sensors_plus.dart';
 
 class Snake extends StatefulWidget {
   Snake({Key? key, this.rows = 20, this.columns = 20, this.cellSize = 10.0})
-    : super(key: key) {
+      : super(key: key) {
     assert(10 <= rows);
     assert(10 <= columns);
     assert(5.0 <= cellSize);
@@ -36,10 +36,9 @@ class SnakeBoardPainter extends CustomPainter {
   @override
   void paint(Canvas canvas, Size size) {
     final blackLine = Paint()..color = Colors.black;
-    final blackFilled =
-        Paint()
-          ..color = Colors.black
-          ..style = PaintingStyle.fill;
+    final blackFilled = Paint()
+      ..color = Colors.black
+      ..style = PaintingStyle.fill;
     canvas.drawRect(
       Rect.fromPoints(Offset.zero, size.bottomLeft(Offset.zero)),
       blackLine,
@@ -100,14 +99,13 @@ class SnakeState extends State<Snake> {
   }
 
   void _step() {
-    final newDirection =
-        acceleration == null
-            ? null
-            : acceleration!.x.abs() < 1.0 && acceleration!.y.abs() < 1.0
+    final newDirection = acceleration == null
+        ? null
+        : acceleration!.x.abs() < 1.0 && acceleration!.y.abs() < 1.0
             ? null
             : (acceleration!.x.abs() < acceleration!.y.abs())
-            ? math.Point<int>(0, acceleration!.y.sign.toInt())
-            : math.Point<int>(-acceleration!.x.sign.toInt(), 0);
+                ? math.Point<int>(0, acceleration!.y.sign.toInt())
+                : math.Point<int>(-acceleration!.x.sign.toInt(), 0);
     state!.step(newDirection);
   }
 }

--- a/packages/shared_preferences/CHANGELOG.md
+++ b/packages/shared_preferences/CHANGELOG.md
@@ -1,3 +1,7 @@
+## NEXT
+
+* Update code format.
+
 ## 2.3.1
 
 * Update the LICENSE file so that it is recognized by pub.dev.

--- a/packages/shared_preferences/example/integration_test/shared_preferences_test.dart
+++ b/packages/shared_preferences/example/integration_test/shared_preferences_test.dart
@@ -410,13 +410,13 @@ void main() {
 
     group('withCache', () {
       Future<(SharedPreferencesWithCache, Map<String, Object?>)>
-      getPreferences() async {
+          getPreferences() async {
         final Map<String, Object?> cache = <String, Object?>{};
         final SharedPreferencesWithCache preferences =
             await SharedPreferencesWithCache.create(
-              cache: cache,
-              cacheOptions: const SharedPreferencesWithCacheOptions(),
-            );
+          cache: cache,
+          cacheOptions: const SharedPreferencesWithCacheOptions(),
+        );
         await preferences.clear();
         return (preferences, cache);
       }
@@ -530,21 +530,21 @@ void main() {
 
     group('withCache with filter', () {
       Future<(SharedPreferencesWithCache, Map<String, Object?>)>
-      getPreferences() async {
+          getPreferences() async {
         final Map<String, Object?> cache = <String, Object?>{};
         final SharedPreferencesWithCache preferences =
             await SharedPreferencesWithCache.create(
-              cache: cache,
-              cacheOptions: const SharedPreferencesWithCacheOptions(
-                allowList: <String>{
-                  stringKey,
-                  boolKey,
-                  intKey,
-                  doubleKey,
-                  listKey,
-                },
-              ),
-            );
+          cache: cache,
+          cacheOptions: const SharedPreferencesWithCacheOptions(
+            allowList: <String>{
+              stringKey,
+              boolKey,
+              intKey,
+              doubleKey,
+              listKey,
+            },
+          ),
+        );
         await preferences.clear();
         return (preferences, cache);
       }

--- a/packages/shared_preferences/example/lib/main.dart
+++ b/packages/shared_preferences/example/lib/main.dart
@@ -35,11 +35,11 @@ class SharedPreferencesDemo extends StatefulWidget {
 class SharedPreferencesDemoState extends State<SharedPreferencesDemo> {
   final Future<SharedPreferencesWithCache> _prefs =
       SharedPreferencesWithCache.create(
-        cacheOptions: const SharedPreferencesWithCacheOptions(
-          // This cache will only accept the key 'counter'.
-          allowList: <String>{'counter'},
-        ),
-      );
+    cacheOptions: const SharedPreferencesWithCacheOptions(
+      // This cache will only accept the key 'counter'.
+      allowList: <String>{'counter'},
+    ),
+  );
   late Future<int> _counter;
   int _externalCounter = 0;
 

--- a/packages/shared_preferences/lib/src/shared_preferences_tizen.dart
+++ b/packages/shared_preferences/lib/src/shared_preferences_tizen.dart
@@ -140,9 +140,8 @@ class SharedPreferencesPlugin extends SharedPreferencesStorePlatform {
       _preferences,
     );
     withPrefix.removeWhere(
-      (String key, _) =>
-          !(key.startsWith(filter.prefix) &&
-              (filter.allowList?.contains(key) ?? true)),
+      (String key, _) => !(key.startsWith(filter.prefix) &&
+          (filter.allowList?.contains(key) ?? true)),
     );
     return withPrefix;
   }

--- a/packages/sqflite/CHANGELOG.md
+++ b/packages/sqflite/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## NEXT
 
 * Update minimum Flutter and Dart version to 3.13 and 3.1.
+* Update code format.
 
 ## 0.1.3
 

--- a/packages/sqflite/example/integration_test/sqflite_test.dart
+++ b/packages/sqflite/example/integration_test/sqflite_test.dart
@@ -184,9 +184,10 @@ void main() {
       for (var i = 0; i < count; i++) {
         final db = dbs[i]!;
         try {
-          final name =
-              (await db.query('Test', columns: ['name'])).first.values.first
-                  as String?;
+          final name = (await db.query('Test', columns: ['name']))
+              .first
+              .values
+              .first as String?;
           expect(name, 'test_$i');
         } finally {
           await db.close();

--- a/packages/sqflite/example/lib/database/database_impl.dart
+++ b/packages/sqflite/example/lib/database/database_impl.dart
@@ -61,7 +61,8 @@ Future<void> writeFileAsBytes(
   String path,
   List<int> bytes, {
   bool flush = false,
-}) => platformHandler.writeFileAsBytes(path, bytes, flush: flush);
+}) =>
+    platformHandler.writeFileAsBytes(path, bytes, flush: flush);
 
 /// Read a file as bytes
 Future<Uint8List> readFileAsBytes(String path) =>
@@ -72,7 +73,8 @@ Future<void> writeFileAsString(
   String path,
   String text, {
   bool flush = false,
-}) => platformHandler.writeFileAsString(path, text, flush: flush);
+}) =>
+    platformHandler.writeFileAsString(path, text, flush: flush);
 
 /// Read a file as a string
 Future<String> readFileAsString(String path) =>

--- a/packages/sqflite/example/lib/exp_test_page.dart
+++ b/packages/sqflite/example/lib/exp_test_page.dart
@@ -156,9 +156,12 @@ class ExpTestPage extends TestPage {
       // inserted in a wrong order to check ASC/DESC
 
       await db.insert(table, {'group': 'group_value'});
-      await db.update(table, {
-        'group': 'group_new_value',
-      }, where: "\"group\" = 'group_value'");
+      await db.update(
+          table,
+          {
+            'group': 'group_new_value',
+          },
+          where: "\"group\" = 'group_value'");
 
       final expectedResult = [
         {'group': 'group_new_value'},
@@ -510,9 +513,12 @@ CREATE TABLE test (
         await db.execute('PRAGMA sqflite -- db_config_defensive_off');
         await db.execute('PRAGMA writable_schema = ON');
         expect(
-          await db.update('sqlite_master', {
-            'sql': 'CREATE TABLE Test(value BLOB)',
-          }, where: 'name = \'Test\' and type = \'table\''),
+          await db.update(
+              'sqlite_master',
+              {
+                'sql': 'CREATE TABLE Test(value BLOB)',
+              },
+              where: 'name = \'Test\' and type = \'table\''),
           1,
         );
       } finally {
@@ -527,9 +533,12 @@ CREATE TABLE test (
         await db.execute('CREATE TABLE Test(value TEXT)');
         await db.execute('PRAGMA writable_schema = ON');
         expect(
-          await db.update('sqlite_master', {
-            'sql': 'CREATE TABLE Test(value BLOB)',
-          }, where: 'name = \'Test\' and type = \'table\''),
+          await db.update(
+              'sqlite_master',
+              {
+                'sql': 'CREATE TABLE Test(value BLOB)',
+              },
+              where: 'name = \'Test\' and type = \'table\''),
           1,
         );
       } finally {

--- a/packages/sqflite/example/lib/model/test.dart
+++ b/packages/sqflite/example/lib/model/test.dart
@@ -4,8 +4,8 @@ import 'dart:async';
 class Test {
   /// Test definition.
   Test(this.name, this.fn, {bool? solo, bool? skip})
-    : solo = solo == true,
-      skip = skip == true;
+      : solo = solo == true,
+        skip = skip == true;
 
   /// Only run this test.
   final bool solo;

--- a/packages/sqflite/example/lib/open_test_page.dart
+++ b/packages/sqflite/example/lib/open_test_page.dart
@@ -4,9 +4,11 @@ import 'package:flutter/services.dart';
 import 'package:path/path.dart';
 import 'package:sqflite/sqflite.dart';
 import 'package:sqflite/src/database_mixin.dart' // ignore: implementation_imports
-    show SqfliteDatabaseMixin;
+    show
+        SqfliteDatabaseMixin;
 import 'package:sqflite/src/factory_mixin.dart' // ignore: implementation_imports
-    show SqfliteDatabaseFactoryMixin;
+    show
+        SqfliteDatabaseFactoryMixin;
 import 'package:synchronized/synchronized.dart';
 
 import 'src/common_import.dart';
@@ -913,8 +915,8 @@ class OpenTestPage extends TestPage {
         await db.execute('BEGIN IMMEDIATE');
         // Trick to make sure we don't reuse the same instance during open
         (factory as SqfliteDatabaseFactoryMixin).databaseOpenHelpers.remove(
-          db.path,
-        );
+              db.path,
+            );
 
         final db2 = await factory.openDatabase(
           path,

--- a/packages/sqflite/example/lib/raw_test_page.dart
+++ b/packages/sqflite/example/lib/raw_test_page.dart
@@ -104,10 +104,9 @@ class RawTestPage extends TestPage {
 
         Future testItem(int i) async {
           await db.transaction((txn) async {
-            final count =
-                Sqflite.firstIntValue(
-                  await txn.rawQuery('SELECT COUNT(*) FROM Test'),
-                )!;
+            final count = Sqflite.firstIntValue(
+              await txn.rawQuery('SELECT COUNT(*) FROM Test'),
+            )!;
             await Future<void>.delayed(const Duration(milliseconds: 40));
             await txn.rawInsert('INSERT INTO Test (name) VALUES (?)', [
               'item $i',
@@ -444,10 +443,9 @@ class RawTestPage extends TestPage {
       expect(list, expectedList);
 
       // Count the records
-      count =
-          (Sqflite.firstIntValue(
-            await database.rawQuery('SELECT COUNT(*) FROM Test'),
-          ))!;
+      count = (Sqflite.firstIntValue(
+        await database.rawQuery('SELECT COUNT(*) FROM Test'),
+      ))!;
       expect(count, 2);
 
       // Delete a record
@@ -673,15 +671,21 @@ class RawTestPage extends TestPage {
         } on StateError catch (_) {}
 
         // No data
-        cursor = await db.rawQueryCursor('SELECT * FROM test WHERE id > ?', [
-          3,
-        ], bufferSize: 2);
+        cursor = await db.rawQueryCursor(
+            'SELECT * FROM test WHERE id > ?',
+            [
+              3,
+            ],
+            bufferSize: 2);
         expect(await cursor.moveNext(), isFalse);
 
         // Matching page size
-        cursor = await db.rawQueryCursor('SELECT * FROM test WHERE id > ?', [
-          1,
-        ], bufferSize: 2);
+        cursor = await db.rawQueryCursor(
+            'SELECT * FROM test WHERE id > ?',
+            [
+              1,
+            ],
+            bufferSize: 2);
         expect(await cursor.moveNext(), isTrue);
         expect(await cursor.moveNext(), isTrue);
         expect(await cursor.moveNext(), isFalse);

--- a/packages/sqflite/example/lib/src/expect.dart
+++ b/packages/sqflite/example/lib/src/expect.dart
@@ -21,14 +21,13 @@ class TestFailure {
 /// The type used for functions that can be used to build up error reports
 /// upon failures in [expect].
 @Deprecated('Will be removed in 0.13.0.')
-typedef ErrorFormatter =
-    String Function(
-      dynamic actual,
-      Matcher matcher,
-      String? reason,
-      Map matchState,
-      bool verbose,
-    );
+typedef ErrorFormatter = String Function(
+  dynamic actual,
+  Matcher matcher,
+  String? reason,
+  Map matchState,
+  bool verbose,
+);
 
 /// Assert that [actual] matches [matcher].
 ///
@@ -74,7 +73,8 @@ Future expectLater(
   Object? matcher, {
   String? reason,
   Object? skip,
-}) => _expect(actual, matcher, reason: reason, skip: skip) as Future;
+}) =>
+    _expect(actual, matcher, reason: reason, skip: skip) as Future;
 
 String _formatFailure(
   Matcher expected,

--- a/packages/sqflite/example/lib/src/item_widget.dart
+++ b/packages/sqflite/example/lib/src/item_widget.dart
@@ -5,7 +5,7 @@ import 'package:sqflite_tizen_example/model/item.dart';
 class ItemWidget extends StatefulWidget {
   /// Item widget.
   const ItemWidget(this.item, this.onTap, {this.summary, Key? key})
-    : super(key: key);
+      : super(key: key);
 
   /// item summary.
   final String? summary;

--- a/packages/tizen_app_control/CHANGELOG.md
+++ b/packages/tizen_app_control/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## NEXT
 
 * Update minimum Flutter and Dart version to 3.13 and 3.1.
+* Update code format.
 
 ## 0.2.3
 

--- a/packages/tizen_app_control/example/lib/main.dart
+++ b/packages/tizen_app_control/example/lib/main.dart
@@ -26,32 +26,29 @@ void serviceMain() {
   WidgetsFlutterBinding.ensureInitialized();
 
   // Listen for incoming AppControls.
-  final StreamSubscription<ReceivedAppControl> appControlListener = AppControl
-      .onAppControl
-      .listen((ReceivedAppControl request) async {
-        if (request.shouldReply) {
-          final AppControl reply = AppControl();
-          await request.reply(reply, AppControlReplyResult.succeeded);
-        }
-      });
+  final StreamSubscription<ReceivedAppControl> appControlListener =
+      AppControl.onAppControl.listen((ReceivedAppControl request) async {
+    if (request.shouldReply) {
+      final AppControl reply = AppControl();
+      await request.reply(reply, AppControlReplyResult.succeeded);
+    }
+  });
 
   // Connect to the UI app and send messages.
   // An exception will be thrown if the UI app is not running.
-  RemotePort.connect(_kAppId, _kPortName)
-      .then((RemotePort remotePort) async {
-        while (true) {
-          if (await remotePort.check()) {
-            await remotePort.send(null);
-          } else {
-            break;
-          }
-          await Future<void>.delayed(const Duration(seconds: 1));
-        }
-      })
-      .whenComplete(() async {
-        await appControlListener.cancel();
-        await SystemNavigator.pop();
-      });
+  RemotePort.connect(_kAppId, _kPortName).then((RemotePort remotePort) async {
+    while (true) {
+      if (await remotePort.check()) {
+        await remotePort.send(null);
+      } else {
+        break;
+      }
+      await Future<void>.delayed(const Duration(seconds: 1));
+    }
+  }).whenComplete(() async {
+    await appControlListener.cancel();
+    await SystemNavigator.pop();
+  });
 }
 
 /// The main UI app widget.

--- a/packages/tizen_app_control/lib/src/app_control.dart
+++ b/packages/tizen_app_control/lib/src/app_control.dart
@@ -42,12 +42,11 @@ enum AppControlReplyResult {
 /// [request] represents the launch request that has been sent.
 /// [reply] represents the reply message sent by the callee application.
 /// [result] represents the result of launch.
-typedef AppControlReplyCallback =
-    FutureOr<void> Function(
-      AppControl request,
-      AppControl reply,
-      AppControlReplyResult result,
-    );
+typedef AppControlReplyCallback = FutureOr<void> Function(
+  AppControl request,
+  AppControl reply,
+  AppControlReplyResult result,
+);
 
 /// Represents a control message exchanged between applications.
 ///
@@ -76,15 +75,15 @@ class AppControl {
   }
 
   AppControl._fromMap(Map<String, dynamic> map)
-    : _id = map['id'] as int,
-      appId = map['appId'] as String?,
-      operation = map['operation'] as String?,
-      uri = map['uri'] as String?,
-      mime = map['mime'] as String?,
-      category = map['category'] as String?,
-      launchMode = LaunchMode.values.byName(map['launchMode'] as String),
-      extraData =
-          (map['extraData'] as Map<dynamic, dynamic>).cast<String, dynamic>() {
+      : _id = map['id'] as int,
+        appId = map['appId'] as String?,
+        operation = map['operation'] as String?,
+        uri = map['uri'] as String?,
+        mime = map['mime'] as String?,
+        category = map['category'] as String?,
+        launchMode = LaunchMode.values.byName(map['launchMode'] as String),
+        extraData = (map['extraData'] as Map<dynamic, dynamic>)
+            .cast<String, dynamic>() {
     if (!nativeAttachAppControl(_id, this)) {
       throw Exception('Could not find an instance of AppControl with ID $_id.');
     }
@@ -139,13 +138,12 @@ class AppControl {
   );
 
   /// A stream of incoming application controls.
-  static final Stream<ReceivedAppControl> onAppControl = _eventChannel
-      .receiveBroadcastStream()
-      .map(
-        (dynamic event) => ReceivedAppControl._fromMap(
-          (event as Map<dynamic, dynamic>).cast<String, dynamic>(),
-        ),
-      );
+  static final Stream<ReceivedAppControl> onAppControl =
+      _eventChannel.receiveBroadcastStream().map(
+            (dynamic event) => ReceivedAppControl._fromMap(
+              (event as Map<dynamic, dynamic>).cast<String, dynamic>(),
+            ),
+          );
 
   /// Returns a list of installed applications that can handle this request.
   Future<List<String>> getMatchedAppIds() async {
@@ -271,9 +269,9 @@ class AppControl {
 /// Represents a received [AppControl] message.
 class ReceivedAppControl extends AppControl {
   ReceivedAppControl._fromMap(super.map)
-    : callerAppId = map['callerAppId'] as String?,
-      shouldReply = map['shouldReply'] as bool,
-      super._fromMap();
+      : callerAppId = map['callerAppId'] as String?,
+        shouldReply = map['shouldReply'] as bool,
+        super._fromMap();
 
   /// The caller application ID.
   final String? callerAppId;

--- a/packages/tizen_app_control/lib/src/ffi.dart
+++ b/packages/tizen_app_control/lib/src/ffi.dart
@@ -17,41 +17,41 @@ typedef AttachAppControl = bool Function(int, Object);
 
 final DynamicLibrary _processLib = () {
   final DynamicLibrary processLib = DynamicLibrary.process();
-  final _InitializeDartApi initFunction = processLib
-      .lookupFunction<_InitializeDartApiNative, _InitializeDartApi>(
-        'NativeInitializeDartApi',
-      );
+  final _InitializeDartApi initFunction =
+      processLib.lookupFunction<_InitializeDartApiNative, _InitializeDartApi>(
+    'NativeInitializeDartApi',
+  );
   initFunction(NativeApi.initializeApiDLData);
   return processLib;
 }();
 
-final CreateAppControl nativeCreateAppControl = _processLib
-    .lookupFunction<_CreateAppControlNative, CreateAppControl>(
-      'NativeCreateAppControl',
-    );
-final AttachAppControl nativeAttachAppControl = _processLib
-    .lookupFunction<_AttachAppControlNative, AttachAppControl>(
-      'NativeAttachAppControl',
-    );
+final CreateAppControl nativeCreateAppControl =
+    _processLib.lookupFunction<_CreateAppControlNative, CreateAppControl>(
+  'NativeCreateAppControl',
+);
+final AttachAppControl nativeAttachAppControl =
+    _processLib.lookupFunction<_AttachAppControlNative, AttachAppControl>(
+  'NativeAttachAppControl',
+);
 
 typedef _SetAutoRestartNative = Int32 Function(Pointer<Void>);
 typedef SetAutoRestart = int Function(Pointer<Void>);
 typedef _UnsetAutoRestartNative = Int32 Function();
 typedef UnsetAutoRestart = int Function();
 
-final SetAutoRestart appControlSetAutoRestart = _processLib
-    .lookupFunction<_SetAutoRestartNative, SetAutoRestart>(
-      'app_control_set_auto_restart',
-    );
-final UnsetAutoRestart appControlUnsetAutoRestart = _processLib
-    .lookupFunction<_UnsetAutoRestartNative, UnsetAutoRestart>(
-      'app_control_unset_auto_restart',
-    );
+final SetAutoRestart appControlSetAutoRestart =
+    _processLib.lookupFunction<_SetAutoRestartNative, SetAutoRestart>(
+  'app_control_set_auto_restart',
+);
+final UnsetAutoRestart appControlUnsetAutoRestart =
+    _processLib.lookupFunction<_UnsetAutoRestartNative, UnsetAutoRestart>(
+  'app_control_unset_auto_restart',
+);
 
 typedef _GetErrorMessageNative = Pointer<Utf8> Function(Int);
 typedef GetErrorMessage = Pointer<Utf8> Function(int);
 
-final GetErrorMessage getErrorMessage = _processLib
-    .lookupFunction<_GetErrorMessageNative, GetErrorMessage>(
-      'get_error_message',
-    );
+final GetErrorMessage getErrorMessage =
+    _processLib.lookupFunction<_GetErrorMessageNative, GetErrorMessage>(
+  'get_error_message',
+);

--- a/packages/tizen_app_manager/CHANGELOG.md
+++ b/packages/tizen_app_manager/CHANGELOG.md
@@ -1,3 +1,7 @@
+## NEXT
+
+* Update code format.
+
 ## 0.2.3
 
 * Update minimum Flutter and Dart version to 3.13 and 3.1.

--- a/packages/tizen_app_manager/lib/src/app_context.dart
+++ b/packages/tizen_app_manager/lib/src/app_context.dart
@@ -16,10 +16,10 @@ typedef _TerminateApp = int Function(app_context_h);
 final DynamicLibrary _libAppMananger = DynamicLibrary.open(
   'libcapi-appfw-app-manager.so.0',
 );
-final _TerminateApp _terminateApp = _libAppMananger
-    .lookupFunction<_TerminateAppNative, _TerminateApp>(
-      'app_manager_terminate_app',
-    );
+final _TerminateApp _terminateApp =
+    _libAppMananger.lookupFunction<_TerminateAppNative, _TerminateApp>(
+  'app_manager_terminate_app',
+);
 
 class AppContext {
   AppContext(String appId, int handleAddress) : _appId = appId {

--- a/packages/tizen_app_manager/lib/src/app_manager.dart
+++ b/packages/tizen_app_manager/lib/src/app_manager.dart
@@ -62,8 +62,8 @@ class AppManager {
 
     final Map<String, dynamic>? app = await _channel
         .invokeMapMethod<String, dynamic>('getAppInfo', <String, String>{
-          'appId': appId,
-        });
+      'appId': appId,
+    });
     return AppInfo.fromMap(app!);
   }
 
@@ -95,18 +95,18 @@ class AppManager {
   /// A stream of events occurring when any application is launched.
   static Stream<AppRunningContext> get onAppLaunched =>
       _launchEventChannel.receiveBroadcastStream().map(
-        (dynamic event) => AppRunningContext.fromMap(
-          (event as Map<dynamic, dynamic>).cast<String, dynamic>(),
-        ),
-      );
+            (dynamic event) => AppRunningContext.fromMap(
+              (event as Map<dynamic, dynamic>).cast<String, dynamic>(),
+            ),
+          );
 
   /// A stream of events occurring when any application is terminated.
   static Stream<AppRunningContext> get onAppTerminated =>
       _terminateEventChannel.receiveBroadcastStream().map(
-        (dynamic event) => AppRunningContext.fromMap(
-          (event as Map<dynamic, dynamic>).cast<String, dynamic>(),
-        ),
-      );
+            (dynamic event) => AppRunningContext.fromMap(
+              (event as Map<dynamic, dynamic>).cast<String, dynamic>(),
+            ),
+          );
 }
 
 /// Represents general information on an installed application.

--- a/packages/tizen_audio_manager/CHANGELOG.md
+++ b/packages/tizen_audio_manager/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 * Fix new lint warnings.
 * Update minimum Flutter and Dart version to 3.13 and 3.1.
+* Update code format.
 
 ## 0.1.1
 

--- a/packages/tizen_audio_manager/lib/tizen_audio_manager.dart
+++ b/packages/tizen_audio_manager/lib/tizen_audio_manager.dart
@@ -120,13 +120,12 @@ class AudioVolume {
   }
 
   /// A stream of events occurring when the volume level is changed.
-  Stream<VolumeChangedEvent> onChanged = AudioManager._eventChannel
-      .receiveBroadcastStream()
-      .map(
-        (dynamic msg) => VolumeChangedEvent.fromMap(
-          (msg as Map<Object?, Object?>).cast<String, dynamic>(),
-        ),
-      );
+  Stream<VolumeChangedEvent> onChanged =
+      AudioManager._eventChannel.receiveBroadcastStream().map(
+            (dynamic msg) => VolumeChangedEvent.fromMap(
+              (msg as Map<Object?, Object?>).cast<String, dynamic>(),
+            ),
+          );
 }
 
 /// Represents an event emitted on volume change.

--- a/packages/tizen_bundle/CHANGELOG.md
+++ b/packages/tizen_bundle/CHANGELOG.md
@@ -1,3 +1,7 @@
+## NEXT
+
+* Update code format.
+
 ## 0.1.2
 
 * Update minimum Flutter and Dart version to 3.13 and 3.1.

--- a/packages/tizen_bundle/lib/tizen_bundle.dart
+++ b/packages/tizen_bundle/lib/tizen_bundle.dart
@@ -48,8 +48,8 @@ class Bundle extends MapMixin<String, Object> {
   late final Pointer<bundle> _handle;
   static final Finalizer<Pointer<bundle>> _finalizer =
       Finalizer<Pointer<bundle>>(
-        (Pointer<bundle> bundle) => tizen.bundle_free(bundle),
-      );
+    (Pointer<bundle> bundle) => tizen.bundle_free(bundle),
+  );
 
   static final List<String> _keys = <String>[];
 
@@ -198,10 +198,9 @@ class Bundle extends MapMixin<String, Object> {
 
   void _addStrings(String key, List<String> values) {
     using((Arena arena) {
-      final List<Pointer<Char>> stringList =
-          values
-              .map((String str) => str.toNativeChar(allocator: arena))
-              .toList();
+      final List<Pointer<Char>> stringList = values
+          .map((String str) => str.toNativeChar(allocator: arena))
+          .toList();
       final Pointer<Pointer<Char>> stringArray = arena<Pointer<Char>>(
         stringList.length,
       );

--- a/packages/tizen_log/CHANGELOG.md
+++ b/packages/tizen_log/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 * Update minimum Flutter and Dart version to 3.13 and 3.1.
 * Fix new lint warnings.
+* Update code format.
 
 ## 0.1.2
 

--- a/packages/tizen_log/lib/tizen_log.dart
+++ b/packages/tizen_log/lib/tizen_log.dart
@@ -6,10 +6,10 @@ import 'dart:ffi';
 
 import 'package:ffi/ffi.dart';
 
-typedef _DlogPrintNative =
-    Void Function(Int32, Pointer<Utf8>, Pointer<Utf8>, Pointer<Utf8>);
-typedef _DlogPrint =
-    void Function(int, Pointer<Utf8>, Pointer<Utf8>, Pointer<Utf8>);
+typedef _DlogPrintNative = Void Function(
+    Int32, Pointer<Utf8>, Pointer<Utf8>, Pointer<Utf8>);
+typedef _DlogPrint = void Function(
+    int, Pointer<Utf8>, Pointer<Utf8>, Pointer<Utf8>);
 
 /// Provides the ability to use Tizen's logging service, dlog.
 ///
@@ -24,10 +24,9 @@ class Log {
 
   static final DynamicLibrary _library = DynamicLibrary.open('libdlog.so.0');
 
-  static final _DlogPrint _dlogPrint =
-      _library
-          .lookup<NativeFunction<_DlogPrintNative>>('dlog_print')
-          .asFunction();
+  static final _DlogPrint _dlogPrint = _library
+      .lookup<NativeFunction<_DlogPrintNative>>('dlog_print')
+      .asFunction();
 
   static final RegExp _stackTraceRegExp = RegExp(
     r'^#(\d+)\s+(.+)\((.+\.dart):(\d+)(:\d+)?\)$',
@@ -190,8 +189,8 @@ class Log {
           if (frameIndex == index) {
             final List<String> funcParts = groups[1]!.trim().split('.');
             final List<String> pathParts = groups[2]!.trim().split(
-              RegExp(r'[:/]'),
-            );
+                  RegExp(r'[:/]'),
+                );
             return _StackFrame(
               frameIndex,
               funcParts.last,

--- a/packages/tizen_notification/CHANGELOG.md
+++ b/packages/tizen_notification/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## NEXT
 
 * Update minimum Flutter and Dart version to 3.13 and 3.1.
+* Update code format.
 
 ## 0.2.0
 

--- a/packages/tizen_notification/lib/src/types.dart
+++ b/packages/tizen_notification/lib/src/types.dart
@@ -60,10 +60,10 @@ class NotificationIcons {
 
   /// Converts to a map.
   Map<String, String?> toMap() => <String, String?>{
-    'icon': icon,
-    'iconForIndicator': indicatorIcon,
-    'iconForLock': lockIcon,
-  };
+        'icon': icon,
+        'iconForIndicator': indicatorIcon,
+        'iconForLock': lockIcon,
+      };
 }
 
 /// The type of sound.
@@ -93,9 +93,9 @@ class NotificationSound {
 
   /// Converts to a map.
   Map<String, String?> toMap() => <String, String?>{
-    'type': type.name,
-    'path': path,
-  };
+        'type': type.name,
+        'path': path,
+      };
 }
 
 /// The type of vibration.
@@ -125,20 +125,20 @@ class NotificationVibration {
 
   /// Converts to a map.
   Map<String, String?> toMap() => <String, String?>{
-    'type': type.name,
-    'path': path,
-  };
+        'type': type.name,
+        'path': path,
+      };
 }
 
 extension _AppControlToMap on AppControl {
   /// Converts to a map.
   Map<String, Object?> toMap() => <String, Object?>{
-    'appId': appId,
-    'operation': operation,
-    'uri': uri,
-    'mime': mime,
-    'extraData': extraData,
-  };
+        'appId': appId,
+        'operation': operation,
+        'uri': uri,
+        'mime': mime,
+        'extraData': extraData,
+      };
 }
 
 /// The notification details.
@@ -185,12 +185,12 @@ class TizenNotificationDetails {
 
   /// Converts to a map.
   Map<String, Object?> toMap() => <String, Object?>{
-    'image': icons?.toMap(),
-    'sound': sound?.toMap(),
-    'vibration': vibration?.toMap(),
-    'properties': properties,
-    'displayApplist': style,
-    'ongoing': ongoing,
-    'appControl': appControl?.toMap(),
-  };
+        'image': icons?.toMap(),
+        'sound': sound?.toMap(),
+        'vibration': vibration?.toMap(),
+        'properties': properties,
+        'displayApplist': style,
+        'ongoing': ongoing,
+        'appControl': appControl?.toMap(),
+      };
 }

--- a/packages/tizen_package_manager/CHANGELOG.md
+++ b/packages/tizen_package_manager/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## NEXT
 
 * Update minimum Flutter and Dart version to 3.13 and 3.1.
+* Update code format.
 
 ## 0.2.1
 

--- a/packages/tizen_package_manager/lib/tizen_package_manager.dart
+++ b/packages/tizen_package_manager/lib/tizen_package_manager.dart
@@ -95,15 +95,15 @@ class PackageManager {
 
     final Map<String, dynamic>? package = await _channel
         .invokeMapMethod<String, dynamic>('getPackage', <String, String>{
-          'packageId': packageId,
-        });
+      'packageId': packageId,
+    });
     return PackageInfo.fromMap(package!);
   }
 
   /// Retrieves the package information of all installed packages.
   static Future<List<PackageInfo>> getPackagesInfo() async {
-    final List<Map<dynamic, dynamic>>? packages = await _channel
-        .invokeListMethod<Map<dynamic, dynamic>>('getPackages');
+    final List<Map<dynamic, dynamic>>? packages =
+        await _channel.invokeListMethod<Map<dynamic, dynamic>>('getPackages');
 
     final List<PackageInfo> list = <PackageInfo>[];
     for (final Map<dynamic, dynamic> package in packages!) {
@@ -142,28 +142,28 @@ class PackageManager {
   /// and the progress of the request to the package manager is changed.
   static Stream<PackageEvent> get onInstallProgressChanged =>
       _installEventChannel.receiveBroadcastStream().map(
-        (dynamic event) => PackageEvent.fromMap(
-          (event as Map<dynamic, dynamic>).cast<String, dynamic>(),
-        ),
-      );
+            (dynamic event) => PackageEvent.fromMap(
+              (event as Map<dynamic, dynamic>).cast<String, dynamic>(),
+            ),
+          );
 
   /// A stream of events occurring when a package is getting uninstalled
   /// and the progress of the request to the package manager is changed.
   static Stream<PackageEvent> get onUninstallProgressChanged =>
       _uninstallEventChannel.receiveBroadcastStream().map(
-        (dynamic event) => PackageEvent.fromMap(
-          (event as Map<dynamic, dynamic>).cast<String, dynamic>(),
-        ),
-      );
+            (dynamic event) => PackageEvent.fromMap(
+              (event as Map<dynamic, dynamic>).cast<String, dynamic>(),
+            ),
+          );
 
   /// A stream of events occurring when a package is getting updated
   /// and the progress of the request to the package manager is changed.
   static Stream<PackageEvent> get onUpdateProgressChanged =>
       _updateEventChannel.receiveBroadcastStream().map(
-        (dynamic event) => PackageEvent.fromMap(
-          (event as Map<dynamic, dynamic>).cast<String, dynamic>(),
-        ),
-      );
+            (dynamic event) => PackageEvent.fromMap(
+              (event as Map<dynamic, dynamic>).cast<String, dynamic>(),
+            ),
+          );
 }
 
 /// Represents information of specific package.

--- a/packages/tizen_rpc_port/CHANGELOG.md
+++ b/packages/tizen_rpc_port/CHANGELOG.md
@@ -1,3 +1,7 @@
+## NEXT
+
+* Update code format.
+
 ## 0.1.4
 
 * Fix token in finalizer to be different from value.

--- a/packages/tizen_rpc_port/example/client/lib/message_client.dart
+++ b/packages/tizen_rpc_port/example/client/lib/message_client.dart
@@ -58,7 +58,7 @@ typedef NotifyCallback = void Function(String, String);
 
 class _NotifyCallback extends _Delegate {
   _NotifyCallback(NotifyCallback callback, {bool once = false})
-    : super(_DelegateId.notifyCallback.id, once, callback);
+      : super(_DelegateId.notifyCallback.id, once, callback);
 
   @override
   Future<void> onReceivedEvent(Parcel parcel) async {

--- a/packages/tizen_rpc_port/example/server/lib/main.dart
+++ b/packages/tizen_rpc_port/example/server/lib/main.dart
@@ -64,8 +64,8 @@ class MyApp extends StatefulWidget {
 
 class _MyAppState extends State<MyApp> {
   final Message _server = Message(
-    serviceBuilder:
-        (String sender, String instance) => EchoService(sender, instance),
+    serviceBuilder: (String sender, String instance) =>
+        EchoService(sender, instance),
   );
 
   @override

--- a/packages/tizen_rpc_port/example/server/lib/message_server.dart
+++ b/packages/tizen_rpc_port/example/server/lib/message_server.dart
@@ -73,7 +73,7 @@ abstract class ServiceBase {
 
 class NotifyCallback extends _Delegate {
   NotifyCallback(this._port, this.service, {bool once = false})
-    : super(_DelegateId.notifyCallback.id, once);
+      : super(_DelegateId.notifyCallback.id, once);
 
   final Port? _port;
 
@@ -110,8 +110,8 @@ typedef _MethodHandler = Future<void> Function(ServiceBase, Port, Parcel);
 
 class Message extends StubBase {
   Message({required ServiceBuilder serviceBuilder})
-    : _serviceBuilder = serviceBuilder,
-      super('Message') {
+      : _serviceBuilder = serviceBuilder,
+        super('Message') {
     _methodHandlers[_MethodId.register.id] = _onRegisterMethod;
     _methodHandlers[_MethodId.unregister.id] = _onUnregisterMethod;
     _methodHandlers[_MethodId.send.id] = _onSendMethod;

--- a/packages/tizen_rpc_port/lib/src/parcel.dart
+++ b/packages/tizen_rpc_port/lib/src/parcel.dart
@@ -157,8 +157,8 @@ class Parcel {
 
   static final Finalizer<rpc_port_parcel_h> _finalizer =
       Finalizer<rpc_port_parcel_h>((rpc_port_parcel_h handle) {
-        tizen.rpc_port_parcel_destroy(handle);
-      });
+    tizen.rpc_port_parcel_destroy(handle);
+  });
 
   /// Gets a byte array backed by the raw data of this parcel.
   Uint8List asRaw() {

--- a/packages/url_launcher/CHANGELOG.md
+++ b/packages/url_launcher/CHANGELOG.md
@@ -1,3 +1,7 @@
+## NEXT
+
+* Update code format.
+
 ## 2.1.4
 
 * Update the LICENSE file so that it is recognized by pub.dev.

--- a/packages/url_launcher/example/lib/main.dart
+++ b/packages/url_launcher/example/lib/main.dart
@@ -160,86 +160,76 @@ class _MyHomePageState extends State<MyHomePage> {
                 ),
               ),
               ElevatedButton(
-                onPressed:
-                    _hasCallSupport
-                        ? () => setState(() {
+                onPressed: _hasCallSupport
+                    ? () => setState(() {
                           _launched = _makePhoneCall(_phone);
                         })
-                        : null,
-                child:
-                    _hasCallSupport
-                        ? const Text('Make phone call')
-                        : const Text('Calling not supported'),
+                    : null,
+                child: _hasCallSupport
+                    ? const Text('Make phone call')
+                    : const Text('Calling not supported'),
               ),
               Padding(
                 padding: const EdgeInsets.all(16.0),
                 child: Text(toLaunch.toString()),
               ),
               ElevatedButton(
-                onPressed:
-                    () => setState(() {
-                      _launched = _launchInBrowser(toLaunch);
-                    }),
+                onPressed: () => setState(() {
+                  _launched = _launchInBrowser(toLaunch);
+                }),
                 child: const Text('Launch in browser'),
               ),
               const Padding(padding: EdgeInsets.all(16.0)),
               ElevatedButton(
-                onPressed:
-                    () => setState(() {
-                      _launched = _launchInBrowserView(toLaunch);
-                    }),
+                onPressed: () => setState(() {
+                  _launched = _launchInBrowserView(toLaunch);
+                }),
                 child: const Text('Launch in app'),
               ),
               ElevatedButton(
-                onPressed:
-                    () => setState(() {
-                      _launched = _launchAsInAppWebViewWithCustomHeaders(
-                        toLaunch,
-                      );
-                    }),
+                onPressed: () => setState(() {
+                  _launched = _launchAsInAppWebViewWithCustomHeaders(
+                    toLaunch,
+                  );
+                }),
                 child: const Text('Launch in app (Custom Headers)'),
               ),
               ElevatedButton(
-                onPressed:
-                    () => setState(() {
-                      _launched = _launchInWebViewWithoutJavaScript(toLaunch);
-                    }),
+                onPressed: () => setState(() {
+                  _launched = _launchInWebViewWithoutJavaScript(toLaunch);
+                }),
                 child: const Text('Launch in app (JavaScript OFF)'),
               ),
               ElevatedButton(
-                onPressed:
-                    () => setState(() {
-                      _launched = _launchInWebViewWithoutDomStorage(toLaunch);
-                    }),
+                onPressed: () => setState(() {
+                  _launched = _launchInWebViewWithoutDomStorage(toLaunch);
+                }),
                 child: const Text('Launch in app (DOM storage OFF)'),
               ),
               const Padding(padding: EdgeInsets.all(16.0)),
               ElevatedButton(
-                onPressed:
-                    () => setState(() {
-                      _launched = _launchUniversalLinkIOS(toLaunch);
-                    }),
+                onPressed: () => setState(() {
+                  _launched = _launchUniversalLinkIOS(toLaunch);
+                }),
                 child: const Text(
                   'Launch a universal link in a native app, fallback to Safari.(Youtube)',
                 ),
               ),
               const Padding(padding: EdgeInsets.all(16.0)),
               ElevatedButton(
-                onPressed:
-                    () => setState(() {
-                      _launched = _launchInWebView(toLaunch);
-                      Timer(const Duration(seconds: 5), () {
-                        closeInAppWebView();
-                      });
-                    }),
+                onPressed: () => setState(() {
+                  _launched = _launchInWebView(toLaunch);
+                  Timer(const Duration(seconds: 5), () {
+                    closeInAppWebView();
+                  });
+                }),
                 child: const Text('Launch in app + close after 5 seconds'),
               ),
               const Padding(padding: EdgeInsets.all(16.0)),
               ElevatedButton(
-                onPressed:
-                    () => setState(() {
-                      _launched = _launchInAppWithBrowserOptions(toLaunch);
-                    }),
+                onPressed: () => setState(() {
+                  _launched = _launchInAppWithBrowserOptions(toLaunch);
+                }),
                 child: const Text('Launch in app with title displayed'),
               ),
               const Padding(padding: EdgeInsets.all(16.0)),

--- a/packages/video_player/CHANGELOG.md
+++ b/packages/video_player/CHANGELOG.md
@@ -1,3 +1,7 @@
+## NEXT
+
+* Update code format.
+
 ## 2.5.5
 
 * Add ignore analyzer option to fix analyze issue.

--- a/packages/video_player/example/integration_test/video_player_test.dart
+++ b/packages/video_player/example/integration_test/video_player_test.dart
@@ -56,8 +56,8 @@ void main() {
     });
 
     testWidgets('live stream duration != 0', (WidgetTester tester) async {
-      final VideoPlayerController
-      networkController = VideoPlayerController.networkUrl(
+      final VideoPlayerController networkController =
+          VideoPlayerController.networkUrl(
         Uri.parse(
           'https://flutter.github.io/assets-for-api-docs/assets/videos/hls/bee.m3u8',
         ),

--- a/packages/video_player/example/lib/main.dart
+++ b/packages/video_player/example/lib/main.dart
@@ -81,8 +81,7 @@ class _ButterFlyAssetVideoInList extends StatelessWidget {
                     title: Text('Video video'),
                   ),
                   Stack(
-                    alignment:
-                        FractionalOffset.bottomRight +
+                    alignment: FractionalOffset.bottomRight +
                         const FractionalOffset(-0.1, -0.1),
                     children: <Widget>[
                       _ButterFlyAssetVideo(),
@@ -304,20 +303,19 @@ class _ControlsOverlay extends StatelessWidget {
         AnimatedSwitcher(
           duration: const Duration(milliseconds: 50),
           reverseDuration: const Duration(milliseconds: 200),
-          child:
-              controller.value.isPlaying
-                  ? const SizedBox.shrink()
-                  : const ColoredBox(
-                    color: Colors.black26,
-                    child: Center(
-                      child: Icon(
-                        Icons.play_arrow,
-                        color: Colors.white,
-                        size: 100.0,
-                        semanticLabel: 'Play',
-                      ),
+          child: controller.value.isPlaying
+              ? const SizedBox.shrink()
+              : const ColoredBox(
+                  color: Colors.black26,
+                  child: Center(
+                    child: Icon(
+                      Icons.play_arrow,
+                      color: Colors.white,
+                      size: 100.0,
+                      semanticLabel: 'Play',
                     ),
                   ),
+                ),
         ),
         GestureDetector(
           onTap: () {

--- a/packages/video_player/lib/src/messages.g.dart
+++ b/packages/video_player/lib/src/messages.g.dart
@@ -224,9 +224,9 @@ class TizenVideoPlayerApi {
   TizenVideoPlayerApi({
     BinaryMessenger? binaryMessenger,
     String messageChannelSuffix = '',
-  }) : pigeonVar_binaryMessenger = binaryMessenger,
-       pigeonVar_messageChannelSuffix =
-           messageChannelSuffix.isNotEmpty ? '.$messageChannelSuffix' : '';
+  })  : pigeonVar_binaryMessenger = binaryMessenger,
+        pigeonVar_messageChannelSuffix =
+            messageChannelSuffix.isNotEmpty ? '.$messageChannelSuffix' : '';
   final BinaryMessenger? pigeonVar_binaryMessenger;
 
   static const MessageCodec<Object?> pigeonChannelCodec = _PigeonCodec();
@@ -238,10 +238,10 @@ class TizenVideoPlayerApi {
         'dev.flutter.pigeon.video_player_tizen.TizenVideoPlayerApi.initialize$pigeonVar_messageChannelSuffix';
     final BasicMessageChannel<Object?> pigeonVar_channel =
         BasicMessageChannel<Object?>(
-          pigeonVar_channelName,
-          pigeonChannelCodec,
-          binaryMessenger: pigeonVar_binaryMessenger,
-        );
+      pigeonVar_channelName,
+      pigeonChannelCodec,
+      binaryMessenger: pigeonVar_binaryMessenger,
+    );
     final List<Object?>? pigeonVar_replyList =
         await pigeonVar_channel.send(null) as List<Object?>?;
     if (pigeonVar_replyList == null) {
@@ -262,10 +262,10 @@ class TizenVideoPlayerApi {
         'dev.flutter.pigeon.video_player_tizen.TizenVideoPlayerApi.create$pigeonVar_messageChannelSuffix';
     final BasicMessageChannel<Object?> pigeonVar_channel =
         BasicMessageChannel<Object?>(
-          pigeonVar_channelName,
-          pigeonChannelCodec,
-          binaryMessenger: pigeonVar_binaryMessenger,
-        );
+      pigeonVar_channelName,
+      pigeonChannelCodec,
+      binaryMessenger: pigeonVar_binaryMessenger,
+    );
     final List<Object?>? pigeonVar_replyList =
         await pigeonVar_channel.send(<Object?>[msg]) as List<Object?>?;
     if (pigeonVar_replyList == null) {
@@ -291,10 +291,10 @@ class TizenVideoPlayerApi {
         'dev.flutter.pigeon.video_player_tizen.TizenVideoPlayerApi.dispose$pigeonVar_messageChannelSuffix';
     final BasicMessageChannel<Object?> pigeonVar_channel =
         BasicMessageChannel<Object?>(
-          pigeonVar_channelName,
-          pigeonChannelCodec,
-          binaryMessenger: pigeonVar_binaryMessenger,
-        );
+      pigeonVar_channelName,
+      pigeonChannelCodec,
+      binaryMessenger: pigeonVar_binaryMessenger,
+    );
     final List<Object?>? pigeonVar_replyList =
         await pigeonVar_channel.send(<Object?>[msg]) as List<Object?>?;
     if (pigeonVar_replyList == null) {
@@ -315,10 +315,10 @@ class TizenVideoPlayerApi {
         'dev.flutter.pigeon.video_player_tizen.TizenVideoPlayerApi.setLooping$pigeonVar_messageChannelSuffix';
     final BasicMessageChannel<Object?> pigeonVar_channel =
         BasicMessageChannel<Object?>(
-          pigeonVar_channelName,
-          pigeonChannelCodec,
-          binaryMessenger: pigeonVar_binaryMessenger,
-        );
+      pigeonVar_channelName,
+      pigeonChannelCodec,
+      binaryMessenger: pigeonVar_binaryMessenger,
+    );
     final List<Object?>? pigeonVar_replyList =
         await pigeonVar_channel.send(<Object?>[msg]) as List<Object?>?;
     if (pigeonVar_replyList == null) {
@@ -339,10 +339,10 @@ class TizenVideoPlayerApi {
         'dev.flutter.pigeon.video_player_tizen.TizenVideoPlayerApi.setVolume$pigeonVar_messageChannelSuffix';
     final BasicMessageChannel<Object?> pigeonVar_channel =
         BasicMessageChannel<Object?>(
-          pigeonVar_channelName,
-          pigeonChannelCodec,
-          binaryMessenger: pigeonVar_binaryMessenger,
-        );
+      pigeonVar_channelName,
+      pigeonChannelCodec,
+      binaryMessenger: pigeonVar_binaryMessenger,
+    );
     final List<Object?>? pigeonVar_replyList =
         await pigeonVar_channel.send(<Object?>[msg]) as List<Object?>?;
     if (pigeonVar_replyList == null) {
@@ -363,10 +363,10 @@ class TizenVideoPlayerApi {
         'dev.flutter.pigeon.video_player_tizen.TizenVideoPlayerApi.setPlaybackSpeed$pigeonVar_messageChannelSuffix';
     final BasicMessageChannel<Object?> pigeonVar_channel =
         BasicMessageChannel<Object?>(
-          pigeonVar_channelName,
-          pigeonChannelCodec,
-          binaryMessenger: pigeonVar_binaryMessenger,
-        );
+      pigeonVar_channelName,
+      pigeonChannelCodec,
+      binaryMessenger: pigeonVar_binaryMessenger,
+    );
     final List<Object?>? pigeonVar_replyList =
         await pigeonVar_channel.send(<Object?>[msg]) as List<Object?>?;
     if (pigeonVar_replyList == null) {
@@ -387,10 +387,10 @@ class TizenVideoPlayerApi {
         'dev.flutter.pigeon.video_player_tizen.TizenVideoPlayerApi.play$pigeonVar_messageChannelSuffix';
     final BasicMessageChannel<Object?> pigeonVar_channel =
         BasicMessageChannel<Object?>(
-          pigeonVar_channelName,
-          pigeonChannelCodec,
-          binaryMessenger: pigeonVar_binaryMessenger,
-        );
+      pigeonVar_channelName,
+      pigeonChannelCodec,
+      binaryMessenger: pigeonVar_binaryMessenger,
+    );
     final List<Object?>? pigeonVar_replyList =
         await pigeonVar_channel.send(<Object?>[msg]) as List<Object?>?;
     if (pigeonVar_replyList == null) {
@@ -411,10 +411,10 @@ class TizenVideoPlayerApi {
         'dev.flutter.pigeon.video_player_tizen.TizenVideoPlayerApi.position$pigeonVar_messageChannelSuffix';
     final BasicMessageChannel<Object?> pigeonVar_channel =
         BasicMessageChannel<Object?>(
-          pigeonVar_channelName,
-          pigeonChannelCodec,
-          binaryMessenger: pigeonVar_binaryMessenger,
-        );
+      pigeonVar_channelName,
+      pigeonChannelCodec,
+      binaryMessenger: pigeonVar_binaryMessenger,
+    );
     final List<Object?>? pigeonVar_replyList =
         await pigeonVar_channel.send(<Object?>[msg]) as List<Object?>?;
     if (pigeonVar_replyList == null) {
@@ -440,10 +440,10 @@ class TizenVideoPlayerApi {
         'dev.flutter.pigeon.video_player_tizen.TizenVideoPlayerApi.seekTo$pigeonVar_messageChannelSuffix';
     final BasicMessageChannel<Object?> pigeonVar_channel =
         BasicMessageChannel<Object?>(
-          pigeonVar_channelName,
-          pigeonChannelCodec,
-          binaryMessenger: pigeonVar_binaryMessenger,
-        );
+      pigeonVar_channelName,
+      pigeonChannelCodec,
+      binaryMessenger: pigeonVar_binaryMessenger,
+    );
     final List<Object?>? pigeonVar_replyList =
         await pigeonVar_channel.send(<Object?>[msg]) as List<Object?>?;
     if (pigeonVar_replyList == null) {
@@ -464,10 +464,10 @@ class TizenVideoPlayerApi {
         'dev.flutter.pigeon.video_player_tizen.TizenVideoPlayerApi.pause$pigeonVar_messageChannelSuffix';
     final BasicMessageChannel<Object?> pigeonVar_channel =
         BasicMessageChannel<Object?>(
-          pigeonVar_channelName,
-          pigeonChannelCodec,
-          binaryMessenger: pigeonVar_binaryMessenger,
-        );
+      pigeonVar_channelName,
+      pigeonChannelCodec,
+      binaryMessenger: pigeonVar_binaryMessenger,
+    );
     final List<Object?>? pigeonVar_replyList =
         await pigeonVar_channel.send(<Object?>[msg]) as List<Object?>?;
     if (pigeonVar_replyList == null) {
@@ -488,10 +488,10 @@ class TizenVideoPlayerApi {
         'dev.flutter.pigeon.video_player_tizen.TizenVideoPlayerApi.setMixWithOthers$pigeonVar_messageChannelSuffix';
     final BasicMessageChannel<Object?> pigeonVar_channel =
         BasicMessageChannel<Object?>(
-          pigeonVar_channelName,
-          pigeonChannelCodec,
-          binaryMessenger: pigeonVar_binaryMessenger,
-        );
+      pigeonVar_channelName,
+      pigeonChannelCodec,
+      binaryMessenger: pigeonVar_binaryMessenger,
+    );
     final List<Object?>? pigeonVar_replyList =
         await pigeonVar_channel.send(<Object?>[msg]) as List<Object?>?;
     if (pigeonVar_replyList == null) {

--- a/packages/video_player/lib/video_player_tizen.dart
+++ b/packages/video_player/lib/video_player_tizen.dart
@@ -170,11 +170,11 @@ class VideoPlayerTizen extends VideoPlayerPlatform {
 
   static const Map<VideoFormat, String> _videoFormatStringMap =
       <VideoFormat, String>{
-        VideoFormat.ss: 'ss',
-        VideoFormat.hls: 'hls',
-        VideoFormat.dash: 'dash',
-        VideoFormat.other: 'other',
-      };
+    VideoFormat.ss: 'ss',
+    VideoFormat.hls: 'hls',
+    VideoFormat.dash: 'dash',
+    VideoFormat.other: 'other',
+  };
 
   DurationRange _toDurationRange(dynamic value) {
     final List<dynamic> pair = value as List<dynamic>;

--- a/packages/video_player_avplay/CHANGELOG.md
+++ b/packages/video_player_avplay/CHANGELOG.md
@@ -1,3 +1,7 @@
+## NEXT
+
+* Update code format.
+
 ## 0.5.24
 
 * Fix issue that seek not working for dynamic manifests.

--- a/packages/video_player_avplay/example/integration_test/video_player_test.dart
+++ b/packages/video_player_avplay/example/integration_test/video_player_test.dart
@@ -53,8 +53,8 @@ void main() {
     });
 
     testWidgets('live stream duration != 0', (WidgetTester tester) async {
-      final VideoPlayerController
-      networkController = VideoPlayerController.network(
+      final VideoPlayerController networkController =
+          VideoPlayerController.network(
         'https://flutter.github.io/assets-for-api-docs/assets/videos/hls/bee.m3u8',
       );
       await networkController.initialize();
@@ -194,8 +194,7 @@ void main() {
         await tester.pumpAndSettle();
         expect(controller.value.isPlaying, true);
       },
-      skip:
-          kIsWeb || // Web does not support local assets.
+      skip: kIsWeb || // Web does not support local assets.
           // Extremely flaky on iOS: https://github.com/flutter/flutter/issues/86915
           defaultTargetPlatform == TargetPlatform.iOS,
     );

--- a/packages/video_player_avplay/example/lib/main.dart
+++ b/packages/video_player_avplay/example/lib/main.dart
@@ -536,20 +536,19 @@ class _ControlsOverlay extends StatelessWidget {
         AnimatedSwitcher(
           duration: const Duration(milliseconds: 50),
           reverseDuration: const Duration(milliseconds: 200),
-          child:
-              controller.value.isPlaying
-                  ? const SizedBox.shrink()
-                  : const ColoredBox(
-                    color: Colors.black26,
-                    child: Center(
-                      child: Icon(
-                        Icons.play_arrow,
-                        color: Colors.white,
-                        size: 100.0,
-                        semanticLabel: 'Play',
-                      ),
+          child: controller.value.isPlaying
+              ? const SizedBox.shrink()
+              : const ColoredBox(
+                  color: Colors.black26,
+                  child: Center(
+                    child: Icon(
+                      Icons.play_arrow,
+                      color: Colors.white,
+                      size: 100.0,
+                      semanticLabel: 'Play',
                     ),
                   ),
+                ),
         ),
         GestureDetector(
           onTap: () {

--- a/packages/video_player_avplay/lib/src/messages.g.dart
+++ b/packages/video_player_avplay/lib/src/messages.g.dart
@@ -988,9 +988,9 @@ class VideoPlayerAvplayApi {
   VideoPlayerAvplayApi({
     BinaryMessenger? binaryMessenger,
     String messageChannelSuffix = '',
-  }) : pigeonVar_binaryMessenger = binaryMessenger,
-       pigeonVar_messageChannelSuffix =
-           messageChannelSuffix.isNotEmpty ? '.$messageChannelSuffix' : '';
+  })  : pigeonVar_binaryMessenger = binaryMessenger,
+        pigeonVar_messageChannelSuffix =
+            messageChannelSuffix.isNotEmpty ? '.$messageChannelSuffix' : '';
   final BinaryMessenger? pigeonVar_binaryMessenger;
 
   static const MessageCodec<Object?> pigeonChannelCodec = _PigeonCodec();
@@ -1002,10 +1002,10 @@ class VideoPlayerAvplayApi {
         'dev.flutter.pigeon.video_player_avplay.VideoPlayerAvplayApi.initialize$pigeonVar_messageChannelSuffix';
     final BasicMessageChannel<Object?> pigeonVar_channel =
         BasicMessageChannel<Object?>(
-          pigeonVar_channelName,
-          pigeonChannelCodec,
-          binaryMessenger: pigeonVar_binaryMessenger,
-        );
+      pigeonVar_channelName,
+      pigeonChannelCodec,
+      binaryMessenger: pigeonVar_binaryMessenger,
+    );
     final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(null);
     final List<Object?>? pigeonVar_replyList =
         await pigeonVar_sendFuture as List<Object?>?;
@@ -1027,10 +1027,10 @@ class VideoPlayerAvplayApi {
         'dev.flutter.pigeon.video_player_avplay.VideoPlayerAvplayApi.create$pigeonVar_messageChannelSuffix';
     final BasicMessageChannel<Object?> pigeonVar_channel =
         BasicMessageChannel<Object?>(
-          pigeonVar_channelName,
-          pigeonChannelCodec,
-          binaryMessenger: pigeonVar_binaryMessenger,
-        );
+      pigeonVar_channelName,
+      pigeonChannelCodec,
+      binaryMessenger: pigeonVar_binaryMessenger,
+    );
     final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(
       <Object?>[msg],
     );
@@ -1059,10 +1059,10 @@ class VideoPlayerAvplayApi {
         'dev.flutter.pigeon.video_player_avplay.VideoPlayerAvplayApi.dispose$pigeonVar_messageChannelSuffix';
     final BasicMessageChannel<Object?> pigeonVar_channel =
         BasicMessageChannel<Object?>(
-          pigeonVar_channelName,
-          pigeonChannelCodec,
-          binaryMessenger: pigeonVar_binaryMessenger,
-        );
+      pigeonVar_channelName,
+      pigeonChannelCodec,
+      binaryMessenger: pigeonVar_binaryMessenger,
+    );
     final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(
       <Object?>[msg],
     );
@@ -1086,10 +1086,10 @@ class VideoPlayerAvplayApi {
         'dev.flutter.pigeon.video_player_avplay.VideoPlayerAvplayApi.setLooping$pigeonVar_messageChannelSuffix';
     final BasicMessageChannel<Object?> pigeonVar_channel =
         BasicMessageChannel<Object?>(
-          pigeonVar_channelName,
-          pigeonChannelCodec,
-          binaryMessenger: pigeonVar_binaryMessenger,
-        );
+      pigeonVar_channelName,
+      pigeonChannelCodec,
+      binaryMessenger: pigeonVar_binaryMessenger,
+    );
     final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(
       <Object?>[msg],
     );
@@ -1113,10 +1113,10 @@ class VideoPlayerAvplayApi {
         'dev.flutter.pigeon.video_player_avplay.VideoPlayerAvplayApi.setVolume$pigeonVar_messageChannelSuffix';
     final BasicMessageChannel<Object?> pigeonVar_channel =
         BasicMessageChannel<Object?>(
-          pigeonVar_channelName,
-          pigeonChannelCodec,
-          binaryMessenger: pigeonVar_binaryMessenger,
-        );
+      pigeonVar_channelName,
+      pigeonChannelCodec,
+      binaryMessenger: pigeonVar_binaryMessenger,
+    );
     final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(
       <Object?>[msg],
     );
@@ -1140,10 +1140,10 @@ class VideoPlayerAvplayApi {
         'dev.flutter.pigeon.video_player_avplay.VideoPlayerAvplayApi.setPlaybackSpeed$pigeonVar_messageChannelSuffix';
     final BasicMessageChannel<Object?> pigeonVar_channel =
         BasicMessageChannel<Object?>(
-          pigeonVar_channelName,
-          pigeonChannelCodec,
-          binaryMessenger: pigeonVar_binaryMessenger,
-        );
+      pigeonVar_channelName,
+      pigeonChannelCodec,
+      binaryMessenger: pigeonVar_binaryMessenger,
+    );
     final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(
       <Object?>[msg],
     );
@@ -1167,10 +1167,10 @@ class VideoPlayerAvplayApi {
         'dev.flutter.pigeon.video_player_avplay.VideoPlayerAvplayApi.play$pigeonVar_messageChannelSuffix';
     final BasicMessageChannel<Object?> pigeonVar_channel =
         BasicMessageChannel<Object?>(
-          pigeonVar_channelName,
-          pigeonChannelCodec,
-          binaryMessenger: pigeonVar_binaryMessenger,
-        );
+      pigeonVar_channelName,
+      pigeonChannelCodec,
+      binaryMessenger: pigeonVar_binaryMessenger,
+    );
     final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(
       <Object?>[msg],
     );
@@ -1194,10 +1194,10 @@ class VideoPlayerAvplayApi {
         'dev.flutter.pigeon.video_player_avplay.VideoPlayerAvplayApi.setDeactivate$pigeonVar_messageChannelSuffix';
     final BasicMessageChannel<Object?> pigeonVar_channel =
         BasicMessageChannel<Object?>(
-          pigeonVar_channelName,
-          pigeonChannelCodec,
-          binaryMessenger: pigeonVar_binaryMessenger,
-        );
+      pigeonVar_channelName,
+      pigeonChannelCodec,
+      binaryMessenger: pigeonVar_binaryMessenger,
+    );
     final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(
       <Object?>[msg],
     );
@@ -1226,10 +1226,10 @@ class VideoPlayerAvplayApi {
         'dev.flutter.pigeon.video_player_avplay.VideoPlayerAvplayApi.setActivate$pigeonVar_messageChannelSuffix';
     final BasicMessageChannel<Object?> pigeonVar_channel =
         BasicMessageChannel<Object?>(
-          pigeonVar_channelName,
-          pigeonChannelCodec,
-          binaryMessenger: pigeonVar_binaryMessenger,
-        );
+      pigeonVar_channelName,
+      pigeonChannelCodec,
+      binaryMessenger: pigeonVar_binaryMessenger,
+    );
     final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(
       <Object?>[msg],
     );
@@ -1258,10 +1258,10 @@ class VideoPlayerAvplayApi {
         'dev.flutter.pigeon.video_player_avplay.VideoPlayerAvplayApi.track$pigeonVar_messageChannelSuffix';
     final BasicMessageChannel<Object?> pigeonVar_channel =
         BasicMessageChannel<Object?>(
-          pigeonVar_channelName,
-          pigeonChannelCodec,
-          binaryMessenger: pigeonVar_binaryMessenger,
-        );
+      pigeonVar_channelName,
+      pigeonChannelCodec,
+      binaryMessenger: pigeonVar_binaryMessenger,
+    );
     final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(
       <Object?>[msg],
     );
@@ -1290,10 +1290,10 @@ class VideoPlayerAvplayApi {
         'dev.flutter.pigeon.video_player_avplay.VideoPlayerAvplayApi.setTrackSelection$pigeonVar_messageChannelSuffix';
     final BasicMessageChannel<Object?> pigeonVar_channel =
         BasicMessageChannel<Object?>(
-          pigeonVar_channelName,
-          pigeonChannelCodec,
-          binaryMessenger: pigeonVar_binaryMessenger,
-        );
+      pigeonVar_channelName,
+      pigeonChannelCodec,
+      binaryMessenger: pigeonVar_binaryMessenger,
+    );
     final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(
       <Object?>[msg],
     );
@@ -1322,10 +1322,10 @@ class VideoPlayerAvplayApi {
         'dev.flutter.pigeon.video_player_avplay.VideoPlayerAvplayApi.position$pigeonVar_messageChannelSuffix';
     final BasicMessageChannel<Object?> pigeonVar_channel =
         BasicMessageChannel<Object?>(
-          pigeonVar_channelName,
-          pigeonChannelCodec,
-          binaryMessenger: pigeonVar_binaryMessenger,
-        );
+      pigeonVar_channelName,
+      pigeonChannelCodec,
+      binaryMessenger: pigeonVar_binaryMessenger,
+    );
     final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(
       <Object?>[msg],
     );
@@ -1354,10 +1354,10 @@ class VideoPlayerAvplayApi {
         'dev.flutter.pigeon.video_player_avplay.VideoPlayerAvplayApi.duration$pigeonVar_messageChannelSuffix';
     final BasicMessageChannel<Object?> pigeonVar_channel =
         BasicMessageChannel<Object?>(
-          pigeonVar_channelName,
-          pigeonChannelCodec,
-          binaryMessenger: pigeonVar_binaryMessenger,
-        );
+      pigeonVar_channelName,
+      pigeonChannelCodec,
+      binaryMessenger: pigeonVar_binaryMessenger,
+    );
     final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(
       <Object?>[msg],
     );
@@ -1386,10 +1386,10 @@ class VideoPlayerAvplayApi {
         'dev.flutter.pigeon.video_player_avplay.VideoPlayerAvplayApi.seekTo$pigeonVar_messageChannelSuffix';
     final BasicMessageChannel<Object?> pigeonVar_channel =
         BasicMessageChannel<Object?>(
-          pigeonVar_channelName,
-          pigeonChannelCodec,
-          binaryMessenger: pigeonVar_binaryMessenger,
-        );
+      pigeonVar_channelName,
+      pigeonChannelCodec,
+      binaryMessenger: pigeonVar_binaryMessenger,
+    );
     final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(
       <Object?>[msg],
     );
@@ -1413,10 +1413,10 @@ class VideoPlayerAvplayApi {
         'dev.flutter.pigeon.video_player_avplay.VideoPlayerAvplayApi.pause$pigeonVar_messageChannelSuffix';
     final BasicMessageChannel<Object?> pigeonVar_channel =
         BasicMessageChannel<Object?>(
-          pigeonVar_channelName,
-          pigeonChannelCodec,
-          binaryMessenger: pigeonVar_binaryMessenger,
-        );
+      pigeonVar_channelName,
+      pigeonChannelCodec,
+      binaryMessenger: pigeonVar_binaryMessenger,
+    );
     final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(
       <Object?>[msg],
     );
@@ -1440,10 +1440,10 @@ class VideoPlayerAvplayApi {
         'dev.flutter.pigeon.video_player_avplay.VideoPlayerAvplayApi.setMixWithOthers$pigeonVar_messageChannelSuffix';
     final BasicMessageChannel<Object?> pigeonVar_channel =
         BasicMessageChannel<Object?>(
-          pigeonVar_channelName,
-          pigeonChannelCodec,
-          binaryMessenger: pigeonVar_binaryMessenger,
-        );
+      pigeonVar_channelName,
+      pigeonChannelCodec,
+      binaryMessenger: pigeonVar_binaryMessenger,
+    );
     final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(
       <Object?>[msg],
     );
@@ -1467,10 +1467,10 @@ class VideoPlayerAvplayApi {
         'dev.flutter.pigeon.video_player_avplay.VideoPlayerAvplayApi.setDisplayGeometry$pigeonVar_messageChannelSuffix';
     final BasicMessageChannel<Object?> pigeonVar_channel =
         BasicMessageChannel<Object?>(
-          pigeonVar_channelName,
-          pigeonChannelCodec,
-          binaryMessenger: pigeonVar_binaryMessenger,
-        );
+      pigeonVar_channelName,
+      pigeonChannelCodec,
+      binaryMessenger: pigeonVar_binaryMessenger,
+    );
     final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(
       <Object?>[msg],
     );
@@ -1494,10 +1494,10 @@ class VideoPlayerAvplayApi {
         'dev.flutter.pigeon.video_player_avplay.VideoPlayerAvplayApi.getStreamingProperty$pigeonVar_messageChannelSuffix';
     final BasicMessageChannel<Object?> pigeonVar_channel =
         BasicMessageChannel<Object?>(
-          pigeonVar_channelName,
-          pigeonChannelCodec,
-          binaryMessenger: pigeonVar_binaryMessenger,
-        );
+      pigeonVar_channelName,
+      pigeonChannelCodec,
+      binaryMessenger: pigeonVar_binaryMessenger,
+    );
     final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(
       <Object?>[msg],
     );
@@ -1526,10 +1526,10 @@ class VideoPlayerAvplayApi {
         'dev.flutter.pigeon.video_player_avplay.VideoPlayerAvplayApi.setBufferConfig$pigeonVar_messageChannelSuffix';
     final BasicMessageChannel<Object?> pigeonVar_channel =
         BasicMessageChannel<Object?>(
-          pigeonVar_channelName,
-          pigeonChannelCodec,
-          binaryMessenger: pigeonVar_binaryMessenger,
-        );
+      pigeonVar_channelName,
+      pigeonChannelCodec,
+      binaryMessenger: pigeonVar_binaryMessenger,
+    );
     final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(
       <Object?>[msg],
     );
@@ -1558,10 +1558,10 @@ class VideoPlayerAvplayApi {
         'dev.flutter.pigeon.video_player_avplay.VideoPlayerAvplayApi.setStreamingProperty$pigeonVar_messageChannelSuffix';
     final BasicMessageChannel<Object?> pigeonVar_channel =
         BasicMessageChannel<Object?>(
-          pigeonVar_channelName,
-          pigeonChannelCodec,
-          binaryMessenger: pigeonVar_binaryMessenger,
-        );
+      pigeonVar_channelName,
+      pigeonChannelCodec,
+      binaryMessenger: pigeonVar_binaryMessenger,
+    );
     final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(
       <Object?>[msg],
     );
@@ -1585,10 +1585,10 @@ class VideoPlayerAvplayApi {
         'dev.flutter.pigeon.video_player_avplay.VideoPlayerAvplayApi.setDisplayRotate$pigeonVar_messageChannelSuffix';
     final BasicMessageChannel<Object?> pigeonVar_channel =
         BasicMessageChannel<Object?>(
-          pigeonVar_channelName,
-          pigeonChannelCodec,
-          binaryMessenger: pigeonVar_binaryMessenger,
-        );
+      pigeonVar_channelName,
+      pigeonChannelCodec,
+      binaryMessenger: pigeonVar_binaryMessenger,
+    );
     final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(
       <Object?>[msg],
     );
@@ -1617,10 +1617,10 @@ class VideoPlayerAvplayApi {
         'dev.flutter.pigeon.video_player_avplay.VideoPlayerAvplayApi.setDisplayMode$pigeonVar_messageChannelSuffix';
     final BasicMessageChannel<Object?> pigeonVar_channel =
         BasicMessageChannel<Object?>(
-          pigeonVar_channelName,
-          pigeonChannelCodec,
-          binaryMessenger: pigeonVar_binaryMessenger,
-        );
+      pigeonVar_channelName,
+      pigeonChannelCodec,
+      binaryMessenger: pigeonVar_binaryMessenger,
+    );
     final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(
       <Object?>[msg],
     );
@@ -1649,10 +1649,10 @@ class VideoPlayerAvplayApi {
         'dev.flutter.pigeon.video_player_avplay.VideoPlayerAvplayApi.suspend$pigeonVar_messageChannelSuffix';
     final BasicMessageChannel<Object?> pigeonVar_channel =
         BasicMessageChannel<Object?>(
-          pigeonVar_channelName,
-          pigeonChannelCodec,
-          binaryMessenger: pigeonVar_binaryMessenger,
-        );
+      pigeonVar_channelName,
+      pigeonChannelCodec,
+      binaryMessenger: pigeonVar_binaryMessenger,
+    );
     final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(
       <Object?>[playerId],
     );
@@ -1676,10 +1676,10 @@ class VideoPlayerAvplayApi {
         'dev.flutter.pigeon.video_player_avplay.VideoPlayerAvplayApi.restore$pigeonVar_messageChannelSuffix';
     final BasicMessageChannel<Object?> pigeonVar_channel =
         BasicMessageChannel<Object?>(
-          pigeonVar_channelName,
-          pigeonChannelCodec,
-          binaryMessenger: pigeonVar_binaryMessenger,
-        );
+      pigeonVar_channelName,
+      pigeonChannelCodec,
+      binaryMessenger: pigeonVar_binaryMessenger,
+    );
     final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(
       <Object?>[playerId, msg, resumeTime],
     );
@@ -1703,10 +1703,10 @@ class VideoPlayerAvplayApi {
         'dev.flutter.pigeon.video_player_avplay.VideoPlayerAvplayApi.setData$pigeonVar_messageChannelSuffix';
     final BasicMessageChannel<Object?> pigeonVar_channel =
         BasicMessageChannel<Object?>(
-          pigeonVar_channelName,
-          pigeonChannelCodec,
-          binaryMessenger: pigeonVar_binaryMessenger,
-        );
+      pigeonVar_channelName,
+      pigeonChannelCodec,
+      binaryMessenger: pigeonVar_binaryMessenger,
+    );
     final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(
       <Object?>[msg],
     );
@@ -1737,10 +1737,10 @@ class VideoPlayerAvplayApi {
         'dev.flutter.pigeon.video_player_avplay.VideoPlayerAvplayApi.getData$pigeonVar_messageChannelSuffix';
     final BasicMessageChannel<Object?> pigeonVar_channel =
         BasicMessageChannel<Object?>(
-          pigeonVar_channelName,
-          pigeonChannelCodec,
-          binaryMessenger: pigeonVar_binaryMessenger,
-        );
+      pigeonVar_channelName,
+      pigeonChannelCodec,
+      binaryMessenger: pigeonVar_binaryMessenger,
+    );
     final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(
       <Object?>[msg],
     );
@@ -1769,10 +1769,10 @@ class VideoPlayerAvplayApi {
         'dev.flutter.pigeon.video_player_avplay.VideoPlayerAvplayApi.getActiveTrackInfo$pigeonVar_messageChannelSuffix';
     final BasicMessageChannel<Object?> pigeonVar_channel =
         BasicMessageChannel<Object?>(
-          pigeonVar_channelName,
-          pigeonChannelCodec,
-          binaryMessenger: pigeonVar_binaryMessenger,
-        );
+      pigeonVar_channelName,
+      pigeonChannelCodec,
+      binaryMessenger: pigeonVar_binaryMessenger,
+    );
     final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(
       <Object?>[msg],
     );

--- a/packages/video_player_avplay/lib/src/sub_rip.dart
+++ b/packages/video_player_avplay/lib/src/sub_rip.dart
@@ -13,7 +13,7 @@ class SubRipCaptionFile extends ClosedCaptionFile {
   /// the SubRip file format.
   /// * See: https://en.wikipedia.org/wiki/SubRip
   SubRipCaptionFile(this.fileContents)
-    : _captions = _parseCaptionsFromSubRipString(fileContents);
+      : _captions = _parseCaptionsFromSubRipString(fileContents);
 
   /// The entire body of the SubRip file.
   // TODO(cyanglaz): Remove this public member as it doesn't seem need to exist.

--- a/packages/video_player_avplay/lib/src/video_player_tizen.dart
+++ b/packages/video_player_avplay/lib/src/video_player_tizen.dart
@@ -39,14 +39,13 @@ class VideoPlayerTizen extends VideoPlayerPlatform {
         message.httpHeaders = dataSource.httpHeaders;
         message.drmConfigs = dataSource.drmConfigs?.toMap();
         message.playerOptions = dataSource.playerOptions;
-        message.streamingProperty =
-            dataSource.streamingProperty == null
-                ? null
-                : <String, String>{
-                  for (final MapEntry<StreamingPropertyType, String> entry
-                      in dataSource.streamingProperty!.entries)
-                    _streamingPropertyType[entry.key]!: entry.value,
-                };
+        message.streamingProperty = dataSource.streamingProperty == null
+            ? null
+            : <String, String>{
+                for (final MapEntry<StreamingPropertyType, String> entry
+                    in dataSource.streamingProperty!.entries)
+                  _streamingPropertyType[entry.key]!: entry.value,
+              };
       case DataSourceType.file:
         message.uri = dataSource.uri;
       case DataSourceType.contentUri:
@@ -277,14 +276,13 @@ class VideoPlayerTizen extends VideoPlayerPlatform {
           message.httpHeaders = dataSource.httpHeaders;
           message.drmConfigs = dataSource.drmConfigs?.toMap();
           message.playerOptions = dataSource.playerOptions;
-          message.streamingProperty =
-              dataSource.streamingProperty == null
-                  ? null
-                  : <String, String>{
-                    for (final MapEntry<StreamingPropertyType, String> entry
-                        in dataSource.streamingProperty!.entries)
-                      _streamingPropertyType[entry.key]!: entry.value,
-                  };
+          message.streamingProperty = dataSource.streamingProperty == null
+              ? null
+              : <String, String>{
+                  for (final MapEntry<StreamingPropertyType, String> entry
+                      in dataSource.streamingProperty!.entries)
+                    _streamingPropertyType[entry.key]!: entry.value,
+                };
         case DataSourceType.file:
           message.uri = dataSource.uri;
         case DataSourceType.contentUri:
@@ -324,10 +322,8 @@ class VideoPlayerTizen extends VideoPlayerPlatform {
     return <DashPlayerProperty, Object>{
       for (final MapEntry<Object?, Object?> entry in msg.mapData.entries)
         _dashPlayerPropertyMap.keys.firstWhere(
-              (DashPlayerProperty key) =>
-                  _dashPlayerPropertyMap[key] == entry.key!,
-            ):
-            entry.value!,
+          (DashPlayerProperty key) => _dashPlayerPropertyMap[key] == entry.key!,
+        ): entry.value!,
     };
   }
 
@@ -486,32 +482,32 @@ class VideoPlayerTizen extends VideoPlayerPlatform {
 
   static const Map<VideoFormat, String> _videoFormatStringMap =
       <VideoFormat, String>{
-        VideoFormat.ss: 'ss',
-        VideoFormat.hls: 'hls',
-        VideoFormat.dash: 'dash',
-        VideoFormat.other: 'other',
-      };
+    VideoFormat.ss: 'ss',
+    VideoFormat.hls: 'hls',
+    VideoFormat.dash: 'dash',
+    VideoFormat.other: 'other',
+  };
 
   static const Map<StreamingPropertyType, String> _streamingPropertyType =
       <StreamingPropertyType, String>{
-        StreamingPropertyType.adaptiveInfo: 'ADAPTIVE_INFO',
-        StreamingPropertyType.availableBitrate: 'AVAILABLE_BITRATE',
-        StreamingPropertyType.cookie: 'COOKIE',
-        StreamingPropertyType.currentBandwidth: 'CURRENT_BANDWIDTH',
-        StreamingPropertyType.getLiveDuration: 'GET_LIVE_DURATION',
-        StreamingPropertyType.inAppMultiView: 'IN_APP_MULTIVIEW',
-        StreamingPropertyType.isLive: 'IS_LIVE',
-        StreamingPropertyType.listenSparseTrack: 'LISTEN_SPARSE_TRACK',
-        StreamingPropertyType.portraitMode: 'PORTRAIT_MODE',
-        StreamingPropertyType.prebufferMode: 'PREBUFFER_MODE',
-        StreamingPropertyType.setMixedFrame: 'SET_MIXEDFRAME',
-        StreamingPropertyType.setMode4K: 'SET_MODE_4K',
-        StreamingPropertyType.userAgent: 'USER_AGENT',
-        StreamingPropertyType.useVideoMixer: 'USE_VIDEOMIXER',
-      };
+    StreamingPropertyType.adaptiveInfo: 'ADAPTIVE_INFO',
+    StreamingPropertyType.availableBitrate: 'AVAILABLE_BITRATE',
+    StreamingPropertyType.cookie: 'COOKIE',
+    StreamingPropertyType.currentBandwidth: 'CURRENT_BANDWIDTH',
+    StreamingPropertyType.getLiveDuration: 'GET_LIVE_DURATION',
+    StreamingPropertyType.inAppMultiView: 'IN_APP_MULTIVIEW',
+    StreamingPropertyType.isLive: 'IS_LIVE',
+    StreamingPropertyType.listenSparseTrack: 'LISTEN_SPARSE_TRACK',
+    StreamingPropertyType.portraitMode: 'PORTRAIT_MODE',
+    StreamingPropertyType.prebufferMode: 'PREBUFFER_MODE',
+    StreamingPropertyType.setMixedFrame: 'SET_MIXEDFRAME',
+    StreamingPropertyType.setMode4K: 'SET_MODE_4K',
+    StreamingPropertyType.userAgent: 'USER_AGENT',
+    StreamingPropertyType.useVideoMixer: 'USE_VIDEOMIXER',
+  };
 
-  static const Map<BufferConfigType, String>
-  _bufferConfigTypeMap = <BufferConfigType, String>{
+  static const Map<BufferConfigType, String> _bufferConfigTypeMap =
+      <BufferConfigType, String>{
     BufferConfigType.totalBufferSizeInByte: 'total_buffer_size_in_byte',
     BufferConfigType.totalBufferSizeInTime: 'total_buffer_size_in_time',
     BufferConfigType.bufferSizeInByteForPlay: 'buffer_size_in_byte_for_play',
@@ -525,7 +521,7 @@ class VideoPlayerTizen extends VideoPlayerPlatform {
 
   static const Map<DashPlayerProperty, String> _dashPlayerPropertyMap =
       <DashPlayerProperty, String>{
-        DashPlayerProperty.maxBandWidth: 'max-bandwidth',
-        DashPlayerProperty.dashStreamInfo: 'dash-stream-info',
-      };
+    DashPlayerProperty.maxBandWidth: 'max-bandwidth',
+    DashPlayerProperty.dashStreamInfo: 'dash-stream-info',
+  };
 }

--- a/packages/video_player_avplay/lib/src/web_vtt.dart
+++ b/packages/video_player_avplay/lib/src/web_vtt.dart
@@ -16,7 +16,7 @@ class WebVTTCaptionFile extends ClosedCaptionFile {
   /// the WebVTT file format.
   /// * See: https://en.wikipedia.org/wiki/WebVTT
   WebVTTCaptionFile(String fileContents)
-    : _captions = _parseCaptionsFromWebVTTString(fileContents);
+      : _captions = _parseCaptionsFromWebVTTString(fileContents);
 
   @override
   List<Caption> get captions => _captions;

--- a/packages/video_player_avplay/lib/video_player.dart
+++ b/packages/video_player_avplay/lib/video_player.dart
@@ -67,18 +67,18 @@ class VideoPlayerValue {
 
   /// Returns an instance for a video that hasn't been loaded.
   VideoPlayerValue.uninitialized()
-    : this(
-        duration: DurationRange(Duration.zero, Duration.zero),
-        isInitialized: false,
-      );
+      : this(
+          duration: DurationRange(Duration.zero, Duration.zero),
+          isInitialized: false,
+        );
 
   /// Returns an instance with the given [errorDescription].
   VideoPlayerValue.erroneous(String errorDescription)
-    : this(
-        duration: DurationRange(Duration.zero, Duration.zero),
-        isInitialized: false,
-        errorDescription: errorDescription,
-      );
+      : this(
+          duration: DurationRange(Duration.zero, Duration.zero),
+          isInitialized: false,
+          errorDescription: errorDescription,
+        );
 
   /// This constant is just to indicate that parameter is not passed to [copyWith]
   /// workaround for this issue https://github.com/dart-lang/language/issues/2009
@@ -195,10 +195,9 @@ class VideoPlayerValue {
       isBuffering: isBuffering ?? this.isBuffering,
       volume: volume ?? this.volume,
       playbackSpeed: playbackSpeed ?? this.playbackSpeed,
-      errorDescription:
-          errorDescription != _defaultErrorDescription
-              ? errorDescription
-              : this.errorDescription,
+      errorDescription: errorDescription != _defaultErrorDescription
+          ? errorDescription
+          : this.errorDescription,
       isCompleted: isCompleted ?? this.isCompleted,
     );
   }
@@ -246,22 +245,22 @@ class VideoPlayerValue {
 
   @override
   int get hashCode => Object.hash(
-    duration,
-    size,
-    position,
-    caption,
-    captionOffset,
-    tracks,
-    buffered,
-    isInitialized,
-    isPlaying,
-    isLooping,
-    isBuffering,
-    volume,
-    playbackSpeed,
-    errorDescription,
-    isCompleted,
-  );
+        duration,
+        size,
+        position,
+        caption,
+        captionOffset,
+        tracks,
+        buffered,
+        isInitialized,
+        isPlaying,
+        isLooping,
+        isBuffering,
+        volume,
+        playbackSpeed,
+        errorDescription,
+        isCompleted,
+      );
 }
 
 /// Controls a platform video player, and provides updates when the state is
@@ -285,17 +284,17 @@ class VideoPlayerController extends ValueNotifier<VideoPlayerValue> {
     this.package,
     this.closedCaptionFile,
     this.videoPlayerOptions,
-  }) : dataSourceType = DataSourceType.asset,
-       formatHint = null,
-       httpHeaders = const <String, String>{},
-       drmConfigs = null,
-       playerOptions = const <String, dynamic>{},
-       streamingProperty = null,
-       super(
-         VideoPlayerValue(
-           duration: DurationRange(Duration.zero, Duration.zero),
-         ),
-       );
+  })  : dataSourceType = DataSourceType.asset,
+        formatHint = null,
+        httpHeaders = const <String, String>{},
+        drmConfigs = null,
+        playerOptions = const <String, dynamic>{},
+        streamingProperty = null,
+        super(
+          VideoPlayerValue(
+            duration: DurationRange(Duration.zero, Duration.zero),
+          ),
+        );
 
   /// Constructs a [VideoPlayerController] playing a video from obtained from
   /// the network.
@@ -315,13 +314,13 @@ class VideoPlayerController extends ValueNotifier<VideoPlayerValue> {
     this.drmConfigs,
     this.playerOptions,
     this.streamingProperty,
-  }) : dataSourceType = DataSourceType.network,
-       package = null,
-       super(
-         VideoPlayerValue(
-           duration: DurationRange(Duration.zero, Duration.zero),
-         ),
-       );
+  })  : dataSourceType = DataSourceType.network,
+        package = null,
+        super(
+          VideoPlayerValue(
+            duration: DurationRange(Duration.zero, Duration.zero),
+          ),
+        );
 
   /// Constructs a [VideoPlayerController] playing a video from a file.
   ///
@@ -331,19 +330,19 @@ class VideoPlayerController extends ValueNotifier<VideoPlayerValue> {
     File file, {
     this.closedCaptionFile,
     this.videoPlayerOptions,
-  }) : dataSource = 'file://${file.path}',
-       dataSourceType = DataSourceType.file,
-       package = null,
-       formatHint = null,
-       httpHeaders = const <String, String>{},
-       drmConfigs = null,
-       playerOptions = const <String, dynamic>{},
-       streamingProperty = null,
-       super(
-         VideoPlayerValue(
-           duration: DurationRange(Duration.zero, Duration.zero),
-         ),
-       );
+  })  : dataSource = 'file://${file.path}',
+        dataSourceType = DataSourceType.file,
+        package = null,
+        formatHint = null,
+        httpHeaders = const <String, String>{},
+        drmConfigs = null,
+        playerOptions = const <String, dynamic>{},
+        streamingProperty = null,
+        super(
+          VideoPlayerValue(
+            duration: DurationRange(Duration.zero, Duration.zero),
+          ),
+        );
 
   /// Constructs a [VideoPlayerController] playing a video from a contentUri.
   ///
@@ -353,23 +352,23 @@ class VideoPlayerController extends ValueNotifier<VideoPlayerValue> {
     Uri contentUri, {
     this.closedCaptionFile,
     this.videoPlayerOptions,
-  }) : assert(
-         defaultTargetPlatform == TargetPlatform.android,
-         'VideoPlayerController.contentUri is only supported on Android.',
-       ),
-       dataSource = contentUri.toString(),
-       dataSourceType = DataSourceType.contentUri,
-       package = null,
-       formatHint = null,
-       httpHeaders = const <String, String>{},
-       drmConfigs = null,
-       playerOptions = const <String, dynamic>{},
-       streamingProperty = null,
-       super(
-         VideoPlayerValue(
-           duration: DurationRange(Duration.zero, Duration.zero),
-         ),
-       );
+  })  : assert(
+          defaultTargetPlatform == TargetPlatform.android,
+          'VideoPlayerController.contentUri is only supported on Android.',
+        ),
+        dataSource = contentUri.toString(),
+        dataSourceType = DataSourceType.contentUri,
+        package = null,
+        formatHint = null,
+        httpHeaders = const <String, String>{},
+        drmConfigs = null,
+        playerOptions = const <String, dynamic>{},
+        streamingProperty = null,
+        super(
+          VideoPlayerValue(
+            duration: DurationRange(Duration.zero, Duration.zero),
+          ),
+        );
 
   /// The URI to the video file. This will be in different formats depending on
   /// the [DataSourceType] of the original video.
@@ -504,8 +503,7 @@ class VideoPlayerController extends ValueNotifier<VideoPlayerValue> {
       );
     }
 
-    _playerId =
-        (await _videoPlayerPlatform.create(dataSourceDescription)) ??
+    _playerId = (await _videoPlayerPlatform.create(dataSourceDescription)) ??
         kUninitializedPlayerId;
     _creatingCompleter!.complete(null);
     final Completer<void> initializingCompleter = Completer<void>();
@@ -568,8 +566,8 @@ class VideoPlayerController extends ValueNotifier<VideoPlayerValue> {
         case VideoEventType.subtitleUpdate:
           final List<SubtitleAttribute> subtitleAttributes =
               SubtitleAttribute.fromEventSubtitleAttrList(
-                event.subtitleAttributes,
-              );
+            event.subtitleAttributes,
+          );
           final Caption caption = Caption(
             number: 0,
             start: value.position,
@@ -1477,8 +1475,7 @@ class ClosedCaption extends StatelessWidget {
       return const SizedBox.shrink();
     }
 
-    final TextStyle effectiveTextStyle =
-        textStyle ??
+    final TextStyle effectiveTextStyle = textStyle ??
         DefaultTextStyle.of(
           context,
         ).style.copyWith(fontSize: 36.0, color: Colors.white);

--- a/packages/video_player_videohole/CHANGELOG.md
+++ b/packages/video_player_videohole/CHANGELOG.md
@@ -1,3 +1,7 @@
+## NEXT
+
+* Update code format.
+
 ## 0.5.6
 
 * Add suspend and restore for handing onPause and onResume lifecycle event.

--- a/packages/video_player_videohole/example/integration_test/video_player_test.dart
+++ b/packages/video_player_videohole/example/integration_test/video_player_test.dart
@@ -53,8 +53,8 @@ void main() {
     });
 
     testWidgets('live stream duration != 0', (WidgetTester tester) async {
-      final VideoPlayerController
-      networkController = VideoPlayerController.network(
+      final VideoPlayerController networkController =
+          VideoPlayerController.network(
         'https://flutter.github.io/assets-for-api-docs/assets/videos/hls/bee.m3u8',
       );
       await networkController.initialize();
@@ -194,8 +194,7 @@ void main() {
         await tester.pumpAndSettle();
         expect(controller.value.isPlaying, true);
       },
-      skip:
-          kIsWeb || // Web does not support local assets.
+      skip: kIsWeb || // Web does not support local assets.
           // Extremely flaky on iOS: https://github.com/flutter/flutter/issues/86915
           defaultTargetPlatform == TargetPlatform.iOS,
     );

--- a/packages/video_player_videohole/example/lib/main.dart
+++ b/packages/video_player_videohole/example/lib/main.dart
@@ -473,20 +473,19 @@ class _ControlsOverlay extends StatelessWidget {
         AnimatedSwitcher(
           duration: const Duration(milliseconds: 50),
           reverseDuration: const Duration(milliseconds: 200),
-          child:
-              controller.value.isPlaying
-                  ? const SizedBox.shrink()
-                  : const ColoredBox(
-                    color: Colors.black26,
-                    child: Center(
-                      child: Icon(
-                        Icons.play_arrow,
-                        color: Colors.white,
-                        size: 100.0,
-                        semanticLabel: 'Play',
-                      ),
+          child: controller.value.isPlaying
+              ? const SizedBox.shrink()
+              : const ColoredBox(
+                  color: Colors.black26,
+                  child: Center(
+                    child: Icon(
+                      Icons.play_arrow,
+                      color: Colors.white,
+                      size: 100.0,
+                      semanticLabel: 'Play',
                     ),
                   ),
+                ),
         ),
         GestureDetector(
           onTap: () {

--- a/packages/video_player_videohole/lib/src/messages.g.dart
+++ b/packages/video_player_videohole/lib/src/messages.g.dart
@@ -382,7 +382,7 @@ class VideoPlayerVideoholeApi {
   /// available for dependency injection.  If it is left null, the default
   /// BinaryMessenger will be used which routes to the host platform.
   VideoPlayerVideoholeApi({BinaryMessenger? binaryMessenger})
-    : _binaryMessenger = binaryMessenger;
+      : _binaryMessenger = binaryMessenger;
   final BinaryMessenger? _binaryMessenger;
 
   static const MessageCodec<Object?> codec = _VideoPlayerVideoholeApiCodec();

--- a/packages/video_player_videohole/lib/src/sub_rip.dart
+++ b/packages/video_player_videohole/lib/src/sub_rip.dart
@@ -13,7 +13,7 @@ class SubRipCaptionFile extends ClosedCaptionFile {
   /// the SubRip file format.
   /// * See: https://en.wikipedia.org/wiki/SubRip
   SubRipCaptionFile(this.fileContents)
-    : _captions = _parseCaptionsFromSubRipString(fileContents);
+      : _captions = _parseCaptionsFromSubRipString(fileContents);
 
   /// The entire body of the SubRip file.
   // TODO(cyanglaz): Remove this public member as it doesn't seem need to exist.

--- a/packages/video_player_videohole/lib/src/video_player_tizen.dart
+++ b/packages/video_player_videohole/lib/src/video_player_tizen.dart
@@ -325,9 +325,9 @@ class VideoPlayerTizen extends VideoPlayerPlatform {
 
   static const Map<VideoFormat, String> _videoFormatStringMap =
       <VideoFormat, String>{
-        VideoFormat.ss: 'ss',
-        VideoFormat.hls: 'hls',
-        VideoFormat.dash: 'dash',
-        VideoFormat.other: 'other',
-      };
+    VideoFormat.ss: 'ss',
+    VideoFormat.hls: 'hls',
+    VideoFormat.dash: 'dash',
+    VideoFormat.other: 'other',
+  };
 }

--- a/packages/video_player_videohole/lib/src/web_vtt.dart
+++ b/packages/video_player_videohole/lib/src/web_vtt.dart
@@ -16,7 +16,7 @@ class WebVTTCaptionFile extends ClosedCaptionFile {
   /// the WebVTT file format.
   /// * See: https://en.wikipedia.org/wiki/WebVTT
   WebVTTCaptionFile(String fileContents)
-    : _captions = _parseCaptionsFromWebVTTString(fileContents);
+      : _captions = _parseCaptionsFromWebVTTString(fileContents);
 
   @override
   List<Caption> get captions => _captions;

--- a/packages/video_player_videohole/lib/video_player.dart
+++ b/packages/video_player_videohole/lib/video_player.dart
@@ -64,18 +64,18 @@ class VideoPlayerValue {
 
   /// Returns an instance for a video that hasn't been loaded.
   VideoPlayerValue.uninitialized()
-    : this(
-        duration: DurationRange(Duration.zero, Duration.zero),
-        isInitialized: false,
-      );
+      : this(
+          duration: DurationRange(Duration.zero, Duration.zero),
+          isInitialized: false,
+        );
 
   /// Returns an instance with the given [errorDescription].
   VideoPlayerValue.erroneous(String errorDescription)
-    : this(
-        duration: DurationRange(Duration.zero, Duration.zero),
-        isInitialized: false,
-        errorDescription: errorDescription,
-      );
+      : this(
+          duration: DurationRange(Duration.zero, Duration.zero),
+          isInitialized: false,
+          errorDescription: errorDescription,
+        );
 
   /// This constant is just to indicate that parameter is not passed to [copyWith]
   /// workaround for this issue https://github.com/dart-lang/language/issues/2009
@@ -192,10 +192,9 @@ class VideoPlayerValue {
       isBuffering: isBuffering ?? this.isBuffering,
       volume: volume ?? this.volume,
       playbackSpeed: playbackSpeed ?? this.playbackSpeed,
-      errorDescription:
-          errorDescription != _defaultErrorDescription
-              ? errorDescription
-              : this.errorDescription,
+      errorDescription: errorDescription != _defaultErrorDescription
+          ? errorDescription
+          : this.errorDescription,
       isCompleted: isCompleted ?? this.isCompleted,
     );
   }
@@ -242,16 +241,16 @@ class VideoPlayerController extends ValueNotifier<VideoPlayerValue> {
     this.package,
     this.closedCaptionFile,
     this.videoPlayerOptions,
-  }) : dataSourceType = DataSourceType.asset,
-       formatHint = null,
-       httpHeaders = const <String, String>{},
-       drmConfigs = null,
-       playerOptions = const <String, dynamic>{},
-       super(
-         VideoPlayerValue(
-           duration: DurationRange(Duration.zero, Duration.zero),
-         ),
-       );
+  })  : dataSourceType = DataSourceType.asset,
+        formatHint = null,
+        httpHeaders = const <String, String>{},
+        drmConfigs = null,
+        playerOptions = const <String, dynamic>{},
+        super(
+          VideoPlayerValue(
+            duration: DurationRange(Duration.zero, Duration.zero),
+          ),
+        );
 
   /// Constructs a [VideoPlayerController] playing a video from obtained from
   /// the network.
@@ -270,13 +269,13 @@ class VideoPlayerController extends ValueNotifier<VideoPlayerValue> {
     this.httpHeaders = const <String, String>{},
     this.drmConfigs,
     this.playerOptions,
-  }) : dataSourceType = DataSourceType.network,
-       package = null,
-       super(
-         VideoPlayerValue(
-           duration: DurationRange(Duration.zero, Duration.zero),
-         ),
-       );
+  })  : dataSourceType = DataSourceType.network,
+        package = null,
+        super(
+          VideoPlayerValue(
+            duration: DurationRange(Duration.zero, Duration.zero),
+          ),
+        );
 
   /// Constructs a [VideoPlayerController] playing a video from a file.
   ///
@@ -286,18 +285,18 @@ class VideoPlayerController extends ValueNotifier<VideoPlayerValue> {
     File file, {
     this.closedCaptionFile,
     this.videoPlayerOptions,
-  }) : dataSource = 'file://${file.path}',
-       dataSourceType = DataSourceType.file,
-       package = null,
-       formatHint = null,
-       httpHeaders = const <String, String>{},
-       drmConfigs = null,
-       playerOptions = const <String, dynamic>{},
-       super(
-         VideoPlayerValue(
-           duration: DurationRange(Duration.zero, Duration.zero),
-         ),
-       );
+  })  : dataSource = 'file://${file.path}',
+        dataSourceType = DataSourceType.file,
+        package = null,
+        formatHint = null,
+        httpHeaders = const <String, String>{},
+        drmConfigs = null,
+        playerOptions = const <String, dynamic>{},
+        super(
+          VideoPlayerValue(
+            duration: DurationRange(Duration.zero, Duration.zero),
+          ),
+        );
 
   /// Constructs a [VideoPlayerController] playing a video from a contentUri.
   ///
@@ -307,22 +306,22 @@ class VideoPlayerController extends ValueNotifier<VideoPlayerValue> {
     Uri contentUri, {
     this.closedCaptionFile,
     this.videoPlayerOptions,
-  }) : assert(
-         defaultTargetPlatform == TargetPlatform.android,
-         'VideoPlayerController.contentUri is only supported on Android.',
-       ),
-       dataSource = contentUri.toString(),
-       dataSourceType = DataSourceType.contentUri,
-       package = null,
-       formatHint = null,
-       httpHeaders = const <String, String>{},
-       drmConfigs = null,
-       playerOptions = const <String, dynamic>{},
-       super(
-         VideoPlayerValue(
-           duration: DurationRange(Duration.zero, Duration.zero),
-         ),
-       );
+  })  : assert(
+          defaultTargetPlatform == TargetPlatform.android,
+          'VideoPlayerController.contentUri is only supported on Android.',
+        ),
+        dataSource = contentUri.toString(),
+        dataSourceType = DataSourceType.contentUri,
+        package = null,
+        formatHint = null,
+        httpHeaders = const <String, String>{},
+        drmConfigs = null,
+        playerOptions = const <String, dynamic>{},
+        super(
+          VideoPlayerValue(
+            duration: DurationRange(Duration.zero, Duration.zero),
+          ),
+        );
 
   /// The URI to the video file. This will be in different formats depending on
   /// the [DataSourceType] of the original video.
@@ -431,8 +430,7 @@ class VideoPlayerController extends ValueNotifier<VideoPlayerValue> {
       );
     }
 
-    _playerId =
-        (await _videoPlayerPlatform.create(dataSourceDescription)) ??
+    _playerId = (await _videoPlayerPlatform.create(dataSourceDescription)) ??
         kUninitializedPlayerId;
     _creatingCompleter!.complete(null);
     final Completer<void> initializingCompleter = Completer<void>();
@@ -1303,8 +1301,7 @@ class ClosedCaption extends StatelessWidget {
       return const SizedBox.shrink();
     }
 
-    final TextStyle effectiveTextStyle =
-        textStyle ??
+    final TextStyle effectiveTextStyle = textStyle ??
         DefaultTextStyle.of(
           context,
         ).style.copyWith(fontSize: 36.0, color: Colors.white);

--- a/packages/wearable_rotary/CHANGELOG.md
+++ b/packages/wearable_rotary/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 * Fix new lint warnings.
 * Update minimum Flutter and Dart version to 3.13 and 3.1.
+* Update code format.
 
 ## 2.0.2
 

--- a/packages/wearable_rotary/example/lib/main.dart
+++ b/packages/wearable_rotary/example/lib/main.dart
@@ -35,10 +35,9 @@ class MyApp extends StatelessWidget {
                 Navigator.push<dynamic>(
                   context,
                   MaterialPageRoute<dynamic>(
-                    builder:
-                        (BuildContext context) => const RotaryScrollPage(
-                          scrollDirection: Axis.horizontal,
-                        ),
+                    builder: (BuildContext context) => const RotaryScrollPage(
+                      scrollDirection: Axis.horizontal,
+                    ),
                   ),
                 );
               },
@@ -50,10 +49,9 @@ class MyApp extends StatelessWidget {
                 Navigator.push<dynamic>(
                   context,
                   MaterialPageRoute<dynamic>(
-                    builder:
-                        (BuildContext context) => const RotaryScrollPage(
-                          scrollDirection: Axis.vertical,
-                        ),
+                    builder: (BuildContext context) => const RotaryScrollPage(
+                      scrollDirection: Axis.vertical,
+                    ),
                   ),
                 );
               },

--- a/packages/wearable_rotary/lib/src/wearable_rotary_base.dart
+++ b/packages/wearable_rotary/lib/src/wearable_rotary_base.dart
@@ -11,8 +11,8 @@ const EventChannel _channel = EventChannel(_channelName);
 /// A broadcast stream of events from the device rotary sensor.
 Stream<RotaryEvent> get rotaryEvents {
   return _rotaryEvents ??= _channel.receiveBroadcastStream().map(
-    (dynamic event) => _parseEvent(event),
-  );
+        (dynamic event) => _parseEvent(event),
+      );
 }
 
 Stream<RotaryEvent>? _rotaryEvents;

--- a/packages/webview_flutter/CHANGELOG.md
+++ b/packages/webview_flutter/CHANGELOG.md
@@ -1,3 +1,7 @@
+## NEXT
+
+* Update code format.
+
 ## 0.9.5
 
 * Update the LICENSE file so that it is recognized by pub.dev.

--- a/packages/webview_flutter/example/integration_test/webview_flutter_test.dart
+++ b/packages/webview_flutter/example/integration_test/webview_flutter_test.dart
@@ -102,11 +102,9 @@ Future<void> main() async {
 
     await pageLoads.stream.firstWhere((String url) => url == headersUrl);
 
-    final String content =
-        await controller.runJavaScriptReturningResult(
-              'document.documentElement.innerText',
-            )
-            as String;
+    final String content = await controller.runJavaScriptReturningResult(
+      'document.documentElement.innerText',
+    ) as String;
     expect(content.contains('flutter_test_header'), isTrue);
   });
 
@@ -311,8 +309,7 @@ Future<void> main() async {
 
   group('NavigationDelegate', () {
     const String blankPage = '<!DOCTYPE html><head></head><body></body></html>';
-    final String blankPageEncoded =
-        'data:text/html;charset=utf-8;base64,'
+    final String blankPageEncoded = 'data:text/html;charset=utf-8;base64,'
         '${base64Encode(const Utf8Encoder().convert(blankPage))}';
 
     testWidgets('can allow requests', (WidgetTester tester) async {
@@ -558,23 +555,22 @@ class ResizableWebView extends StatefulWidget {
 }
 
 class ResizableWebViewState extends State<ResizableWebView> {
-  late final WebViewController controller =
-      WebViewController()
-        ..setJavaScriptMode(JavaScriptMode.unrestricted)
-        ..setNavigationDelegate(
-          NavigationDelegate(onPageFinished: (_) => widget.onPageFinished()),
-        )
-        ..addJavaScriptChannel(
-          'Resize',
-          onMessageReceived: (_) {
-            widget.onResize();
-          },
-        )
-        ..loadRequest(
-          Uri.parse(
-            'data:text/html;charset=utf-8;base64,${base64Encode(const Utf8Encoder().convert(resizePage))}',
-          ),
-        );
+  late final WebViewController controller = WebViewController()
+    ..setJavaScriptMode(JavaScriptMode.unrestricted)
+    ..setNavigationDelegate(
+      NavigationDelegate(onPageFinished: (_) => widget.onPageFinished()),
+    )
+    ..addJavaScriptChannel(
+      'Resize',
+      onMessageReceived: (_) {
+        widget.onResize();
+      },
+    )
+    ..loadRequest(
+      Uri.parse(
+        'data:text/html;charset=utf-8;base64,${base64Encode(const Utf8Encoder().convert(resizePage))}',
+      ),
+    );
 
   double webViewWidth = 200;
   double webViewHeight = 200;

--- a/packages/webview_flutter/example/lib/main.dart
+++ b/packages/webview_flutter/example/lib/main.dart
@@ -374,74 +374,73 @@ class SampleMenu extends StatelessWidget {
             _onJavaScriptAlertExample(context);
         }
       },
-      itemBuilder:
-          (BuildContext context) => <PopupMenuItem<MenuOptions>>[
-            const PopupMenuItem<MenuOptions>(
-              value: MenuOptions.showUserAgent,
-              child: Text('Show user agent'),
-            ),
-            const PopupMenuItem<MenuOptions>(
-              value: MenuOptions.listCookies,
-              child: Text('List cookies'),
-            ),
-            const PopupMenuItem<MenuOptions>(
-              value: MenuOptions.clearCookies,
-              child: Text('Clear cookies'),
-            ),
-            const PopupMenuItem<MenuOptions>(
-              value: MenuOptions.addToCache,
-              child: Text('Add to cache'),
-            ),
-            const PopupMenuItem<MenuOptions>(
-              value: MenuOptions.listCache,
-              child: Text('List cache'),
-            ),
-            const PopupMenuItem<MenuOptions>(
-              value: MenuOptions.clearCache,
-              child: Text('Clear cache'),
-            ),
-            const PopupMenuItem<MenuOptions>(
-              value: MenuOptions.navigationDelegate,
-              child: Text('Navigation Delegate example'),
-            ),
-            const PopupMenuItem<MenuOptions>(
-              value: MenuOptions.doPostRequest,
-              child: Text('Post Request'),
-            ),
-            const PopupMenuItem<MenuOptions>(
-              value: MenuOptions.loadHtmlString,
-              child: Text('Load HTML string'),
-            ),
-            const PopupMenuItem<MenuOptions>(
-              value: MenuOptions.loadLocalFile,
-              child: Text('Load local file'),
-            ),
-            const PopupMenuItem<MenuOptions>(
-              value: MenuOptions.loadFlutterAsset,
-              child: Text('Load Flutter Asset'),
-            ),
-            const PopupMenuItem<MenuOptions>(
-              key: ValueKey<String>('ShowTransparentBackgroundExample'),
-              value: MenuOptions.transparentBackground,
-              child: Text('Transparent background example'),
-            ),
-            const PopupMenuItem<MenuOptions>(
-              value: MenuOptions.setCookie,
-              child: Text('Set cookie'),
-            ),
-            const PopupMenuItem<MenuOptions>(
-              value: MenuOptions.logExample,
-              child: Text('Log example'),
-            ),
-            const PopupMenuItem<MenuOptions>(
-              value: MenuOptions.basicAuthentication,
-              child: Text('Basic Authentication Example'),
-            ),
-            const PopupMenuItem<MenuOptions>(
-              value: MenuOptions.javaScriptAlert,
-              child: Text('JavaScript Alert Example'),
-            ),
-          ],
+      itemBuilder: (BuildContext context) => <PopupMenuItem<MenuOptions>>[
+        const PopupMenuItem<MenuOptions>(
+          value: MenuOptions.showUserAgent,
+          child: Text('Show user agent'),
+        ),
+        const PopupMenuItem<MenuOptions>(
+          value: MenuOptions.listCookies,
+          child: Text('List cookies'),
+        ),
+        const PopupMenuItem<MenuOptions>(
+          value: MenuOptions.clearCookies,
+          child: Text('Clear cookies'),
+        ),
+        const PopupMenuItem<MenuOptions>(
+          value: MenuOptions.addToCache,
+          child: Text('Add to cache'),
+        ),
+        const PopupMenuItem<MenuOptions>(
+          value: MenuOptions.listCache,
+          child: Text('List cache'),
+        ),
+        const PopupMenuItem<MenuOptions>(
+          value: MenuOptions.clearCache,
+          child: Text('Clear cache'),
+        ),
+        const PopupMenuItem<MenuOptions>(
+          value: MenuOptions.navigationDelegate,
+          child: Text('Navigation Delegate example'),
+        ),
+        const PopupMenuItem<MenuOptions>(
+          value: MenuOptions.doPostRequest,
+          child: Text('Post Request'),
+        ),
+        const PopupMenuItem<MenuOptions>(
+          value: MenuOptions.loadHtmlString,
+          child: Text('Load HTML string'),
+        ),
+        const PopupMenuItem<MenuOptions>(
+          value: MenuOptions.loadLocalFile,
+          child: Text('Load local file'),
+        ),
+        const PopupMenuItem<MenuOptions>(
+          value: MenuOptions.loadFlutterAsset,
+          child: Text('Load Flutter Asset'),
+        ),
+        const PopupMenuItem<MenuOptions>(
+          key: ValueKey<String>('ShowTransparentBackgroundExample'),
+          value: MenuOptions.transparentBackground,
+          child: Text('Transparent background example'),
+        ),
+        const PopupMenuItem<MenuOptions>(
+          value: MenuOptions.setCookie,
+          child: Text('Set cookie'),
+        ),
+        const PopupMenuItem<MenuOptions>(
+          value: MenuOptions.logExample,
+          child: Text('Log example'),
+        ),
+        const PopupMenuItem<MenuOptions>(
+          value: MenuOptions.basicAuthentication,
+          child: Text('Basic Authentication Example'),
+        ),
+        const PopupMenuItem<MenuOptions>(
+          value: MenuOptions.javaScriptAlert,
+          child: Text('JavaScript Alert Example'),
+        ),
+      ],
     );
   }
 
@@ -454,9 +453,8 @@ class SampleMenu extends StatelessWidget {
   }
 
   Future<void> _onListCookies(BuildContext context) async {
-    final String cookies =
-        await webViewController.runJavaScriptReturningResult('document.cookie')
-            as String;
+    final String cookies = await webViewController
+        .runJavaScriptReturningResult('document.cookie') as String;
     if (context.mounted) {
       ScaffoldMessenger.of(context).showSnackBar(
         SnackBar(

--- a/packages/webview_flutter/lib/src/tizen_webview.dart
+++ b/packages/webview_flutter/lib/src/tizen_webview.dart
@@ -170,8 +170,9 @@ class TizenWebView {
   Future<Offset> getScrollPosition() async {
     final Map<String, Object?>? position =
         (await _invokeChannelMethod<Map<Object?, Object?>>(
-          'getScrollPosition',
-        ))?.cast<String, Object?>();
+      'getScrollPosition',
+    ))
+            ?.cast<String, Object?>();
     if (position == null) {
       return Offset.zero;
     }

--- a/packages/webview_flutter/lib/src/tizen_webview_controller.dart
+++ b/packages/webview_flutter/lib/src/tizen_webview_controller.dart
@@ -35,8 +35,8 @@ extension TizenWebViewControllerExtension on WebViewController {
 class TizenWebViewController extends PlatformWebViewController {
   /// Constructs a [TizenWebViewController].
   TizenWebViewController(super.params)
-    : _webview = TizenWebView(),
-      super.implementation();
+      : _webview = TizenWebView(),
+        super.implementation();
 
   final TizenWebView _webview;
   late TizenNavigationDelegate _tizenNavigationDelegate;
@@ -44,11 +44,11 @@ class TizenWebViewController extends PlatformWebViewController {
   void Function(JavaScriptConsoleMessage consoleMessage)? _onConsoleLogCallback;
 
   Future<void> Function(JavaScriptAlertDialogRequest request)?
-  _onJavaScriptAlert;
+      _onJavaScriptAlert;
   Future<bool> Function(JavaScriptConfirmDialogRequest request)?
-  _onJavaScriptConfirm;
+      _onJavaScriptConfirm;
   Future<String> Function(JavaScriptTextInputDialogRequest request)?
-  _onJavaScriptPrompt;
+      _onJavaScriptPrompt;
 
   late final MethodChannel _webviewControllerChannel;
 
@@ -93,9 +93,9 @@ class TizenWebViewController extends PlatformWebViewController {
           if (callback != null) {
             final JavaScriptAlertDialogRequest request =
                 JavaScriptAlertDialogRequest(
-                  message: arguments['message']! as String,
-                  url: arguments['url']! as String,
-                );
+              message: arguments['message']! as String,
+              url: arguments['url']! as String,
+            );
 
             await callback.call(request);
             await _webview.javaScriptAlertReply();
@@ -103,27 +103,27 @@ class TizenWebViewController extends PlatformWebViewController {
           return null;
         case 'onJavaScriptConfirm':
           final Future<bool> Function(JavaScriptConfirmDialogRequest)?
-          callback = _onJavaScriptConfirm;
+              callback = _onJavaScriptConfirm;
           if (callback != null) {
             final JavaScriptConfirmDialogRequest request =
                 JavaScriptConfirmDialogRequest(
-                  message: arguments['message']! as String,
-                  url: arguments['url']! as String,
-                );
+              message: arguments['message']! as String,
+              url: arguments['url']! as String,
+            );
             final bool result = await callback.call(request);
             await _webview.javaScriptConfirmReply(result);
           }
           return null;
         case 'onJavaScriptPrompt':
           final Future<String> Function(JavaScriptTextInputDialogRequest)?
-          callback = _onJavaScriptPrompt;
+              callback = _onJavaScriptPrompt;
           if (callback != null) {
             final JavaScriptTextInputDialogRequest request =
                 JavaScriptTextInputDialogRequest(
-                  message: arguments['message']! as String,
-                  url: arguments['url']! as String,
-                  defaultText: arguments['defaultText']! as String,
-                );
+              message: arguments['message']! as String,
+              url: arguments['url']! as String,
+              defaultText: arguments['defaultText']! as String,
+            );
             final String result = await callback.call(request);
             await _webview.javaScriptPromptReply(result);
           }
@@ -248,7 +248,8 @@ class TizenWebViewController extends PlatformWebViewController {
   @override
   Future<void> addJavaScriptChannel(
     JavaScriptChannelParams javaScriptChannelParams,
-  ) => _webview.addJavaScriptChannel(javaScriptChannelParams);
+  ) =>
+      _webview.addJavaScriptChannel(javaScriptChannelParams);
 
   @override
   Future<void> removeJavaScriptChannel(String javaScriptChannelName) async {
@@ -288,7 +289,7 @@ class TizenWebViewController extends PlatformWebViewController {
   @override
   Future<void> setOnScrollPositionChange(
     void Function(ScrollPositionChange scrollPositionChange)?
-    onScrollPositionChange,
+        onScrollPositionChange,
   ) async {
     throw UnimplementedError(
       'This version of `TizenWebViewController` currently has no '
@@ -321,7 +322,7 @@ class TizenWebViewController extends PlatformWebViewController {
   @override
   Future<void> setOnJavaScriptAlertDialog(
     Future<void> Function(JavaScriptAlertDialogRequest request)
-    onJavaScriptAlertDialog,
+        onJavaScriptAlertDialog,
   ) async {
     _onJavaScriptAlert = onJavaScriptAlertDialog;
   }
@@ -329,7 +330,7 @@ class TizenWebViewController extends PlatformWebViewController {
   @override
   Future<void> setOnJavaScriptConfirmDialog(
     Future<bool> Function(JavaScriptConfirmDialogRequest request)
-    onJavaScriptConfirmDialog,
+        onJavaScriptConfirmDialog,
   ) async {
     _onJavaScriptConfirm = onJavaScriptConfirmDialog;
   }
@@ -337,7 +338,7 @@ class TizenWebViewController extends PlatformWebViewController {
   @override
   Future<void> setOnJavaScriptTextInputDialog(
     Future<String> Function(JavaScriptTextInputDialogRequest request)
-    onJavaScriptTextInputDialog,
+        onJavaScriptTextInputDialog,
   ) async {
     _onJavaScriptPrompt = onJavaScriptTextInputDialog;
   }

--- a/packages/webview_flutter_lwe/CHANGELOG.md
+++ b/packages/webview_flutter_lwe/CHANGELOG.md
@@ -1,3 +1,7 @@
+## NEXT
+
+* Update code format.
+
 ## 0.3.8
 
 * Update the LICENSE file so that it is recognized by pub.dev.

--- a/packages/webview_flutter_lwe/example/integration_test/webview_flutter_test.dart
+++ b/packages/webview_flutter_lwe/example/integration_test/webview_flutter_test.dart
@@ -281,8 +281,7 @@ Future<void> main() async {
 
   group('NavigationDelegate', () {
     const String blankPage = '<!DOCTYPE html><head></head><body></body></html>';
-    final String blankPageEncoded =
-        'data:text/html;charset=utf-8;base64,'
+    final String blankPageEncoded = 'data:text/html;charset=utf-8;base64,'
         '${base64Encode(const Utf8Encoder().convert(blankPage))}';
 
     testWidgets('can allow requests', (WidgetTester tester) async {
@@ -465,23 +464,22 @@ class ResizableWebView extends StatefulWidget {
 }
 
 class ResizableWebViewState extends State<ResizableWebView> {
-  late final WebViewController controller =
-      WebViewController()
-        ..setJavaScriptMode(JavaScriptMode.unrestricted)
-        ..setNavigationDelegate(
-          NavigationDelegate(onPageFinished: (_) => widget.onPageFinished()),
-        )
-        ..addJavaScriptChannel(
-          'Resize',
-          onMessageReceived: (_) {
-            widget.onResize();
-          },
-        )
-        ..loadRequest(
-          Uri.parse(
-            'data:text/html;charset=utf-8;base64,${base64Encode(const Utf8Encoder().convert(resizePage))}',
-          ),
-        );
+  late final WebViewController controller = WebViewController()
+    ..setJavaScriptMode(JavaScriptMode.unrestricted)
+    ..setNavigationDelegate(
+      NavigationDelegate(onPageFinished: (_) => widget.onPageFinished()),
+    )
+    ..addJavaScriptChannel(
+      'Resize',
+      onMessageReceived: (_) {
+        widget.onResize();
+      },
+    )
+    ..loadRequest(
+      Uri.parse(
+        'data:text/html;charset=utf-8;base64,${base64Encode(const Utf8Encoder().convert(resizePage))}',
+      ),
+    );
 
   double webViewWidth = 200;
   double webViewHeight = 200;

--- a/packages/webview_flutter_lwe/example/lib/main.dart
+++ b/packages/webview_flutter_lwe/example/lib/main.dart
@@ -335,70 +335,69 @@ class SampleMenu extends StatelessWidget {
             _promptForUrl(context);
         }
       },
-      itemBuilder:
-          (BuildContext context) => <PopupMenuItem<MenuOptions>>[
-            const PopupMenuItem<MenuOptions>(
-              value: MenuOptions.showUserAgent,
-              child: Text('Show user agent'),
-            ),
-            const PopupMenuItem<MenuOptions>(
-              value: MenuOptions.listCookies,
-              child: Text('List cookies'),
-            ),
-            const PopupMenuItem<MenuOptions>(
-              value: MenuOptions.clearCookies,
-              child: Text('Clear cookies'),
-            ),
-            const PopupMenuItem<MenuOptions>(
-              value: MenuOptions.addToCache,
-              child: Text('Add to cache'),
-            ),
-            const PopupMenuItem<MenuOptions>(
-              value: MenuOptions.listCache,
-              child: Text('List cache'),
-            ),
-            const PopupMenuItem<MenuOptions>(
-              value: MenuOptions.clearCache,
-              child: Text('Clear cache'),
-            ),
-            const PopupMenuItem<MenuOptions>(
-              value: MenuOptions.navigationDelegate,
-              child: Text('Navigation Delegate example'),
-            ),
-            const PopupMenuItem<MenuOptions>(
-              value: MenuOptions.doPostRequest,
-              child: Text('Post Request'),
-            ),
-            const PopupMenuItem<MenuOptions>(
-              value: MenuOptions.loadHtmlString,
-              child: Text('Load HTML string'),
-            ),
-            const PopupMenuItem<MenuOptions>(
-              value: MenuOptions.loadLocalFile,
-              child: Text('Load local file'),
-            ),
-            const PopupMenuItem<MenuOptions>(
-              value: MenuOptions.loadFlutterAsset,
-              child: Text('Load Flutter Asset'),
-            ),
-            const PopupMenuItem<MenuOptions>(
-              key: ValueKey<String>('ShowTransparentBackgroundExample'),
-              value: MenuOptions.transparentBackground,
-              child: Text('Transparent background example'),
-            ),
-            const PopupMenuItem<MenuOptions>(
-              value: MenuOptions.setCookie,
-              child: Text('Set cookie'),
-            ),
-            const PopupMenuItem<MenuOptions>(
-              value: MenuOptions.logExample,
-              child: Text('Log example'),
-            ),
-            const PopupMenuItem<MenuOptions>(
-              value: MenuOptions.basicAuthentication,
-              child: Text('Basic Authentication Example'),
-            ),
-          ],
+      itemBuilder: (BuildContext context) => <PopupMenuItem<MenuOptions>>[
+        const PopupMenuItem<MenuOptions>(
+          value: MenuOptions.showUserAgent,
+          child: Text('Show user agent'),
+        ),
+        const PopupMenuItem<MenuOptions>(
+          value: MenuOptions.listCookies,
+          child: Text('List cookies'),
+        ),
+        const PopupMenuItem<MenuOptions>(
+          value: MenuOptions.clearCookies,
+          child: Text('Clear cookies'),
+        ),
+        const PopupMenuItem<MenuOptions>(
+          value: MenuOptions.addToCache,
+          child: Text('Add to cache'),
+        ),
+        const PopupMenuItem<MenuOptions>(
+          value: MenuOptions.listCache,
+          child: Text('List cache'),
+        ),
+        const PopupMenuItem<MenuOptions>(
+          value: MenuOptions.clearCache,
+          child: Text('Clear cache'),
+        ),
+        const PopupMenuItem<MenuOptions>(
+          value: MenuOptions.navigationDelegate,
+          child: Text('Navigation Delegate example'),
+        ),
+        const PopupMenuItem<MenuOptions>(
+          value: MenuOptions.doPostRequest,
+          child: Text('Post Request'),
+        ),
+        const PopupMenuItem<MenuOptions>(
+          value: MenuOptions.loadHtmlString,
+          child: Text('Load HTML string'),
+        ),
+        const PopupMenuItem<MenuOptions>(
+          value: MenuOptions.loadLocalFile,
+          child: Text('Load local file'),
+        ),
+        const PopupMenuItem<MenuOptions>(
+          value: MenuOptions.loadFlutterAsset,
+          child: Text('Load Flutter Asset'),
+        ),
+        const PopupMenuItem<MenuOptions>(
+          key: ValueKey<String>('ShowTransparentBackgroundExample'),
+          value: MenuOptions.transparentBackground,
+          child: Text('Transparent background example'),
+        ),
+        const PopupMenuItem<MenuOptions>(
+          value: MenuOptions.setCookie,
+          child: Text('Set cookie'),
+        ),
+        const PopupMenuItem<MenuOptions>(
+          value: MenuOptions.logExample,
+          child: Text('Log example'),
+        ),
+        const PopupMenuItem<MenuOptions>(
+          value: MenuOptions.basicAuthentication,
+          child: Text('Basic Authentication Example'),
+        ),
+      ],
     );
   }
 
@@ -411,9 +410,8 @@ class SampleMenu extends StatelessWidget {
   }
 
   Future<void> _onListCookies(BuildContext context) async {
-    final String cookies =
-        await webViewController.runJavaScriptReturningResult('document.cookie')
-            as String;
+    final String cookies = await webViewController
+        .runJavaScriptReturningResult('document.cookie') as String;
     if (context.mounted) {
       ScaffoldMessenger.of(context).showSnackBar(
         SnackBar(

--- a/packages/webview_flutter_lwe/lib/src/lwe_webview.dart
+++ b/packages/webview_flutter_lwe/lib/src/lwe_webview.dart
@@ -151,8 +151,9 @@ class LweWebView {
   Future<Offset> getScrollPosition() async {
     final Map<String, Object?>? position =
         (await _invokeChannelMethod<Map<Object?, Object?>>(
-          'getScrollPosition',
-        ))?.cast<String, Object?>();
+      'getScrollPosition',
+    ))
+            ?.cast<String, Object?>();
     if (position == null) {
       return Offset.zero;
     }

--- a/packages/webview_flutter_lwe/lib/src/lwe_webview_controller.dart
+++ b/packages/webview_flutter_lwe/lib/src/lwe_webview_controller.dart
@@ -20,8 +20,8 @@ const String kLweNavigationDelegateChannelName =
 class LweWebViewController extends PlatformWebViewController {
   /// Constructs a [LweWebViewController].
   LweWebViewController(super.params)
-    : _webview = LweWebView(),
-      super.implementation();
+      : _webview = LweWebView(),
+        super.implementation();
 
   final LweWebView _webview;
   late LweNavigationDelegate _lweNavigationDelegate;
@@ -147,7 +147,8 @@ class LweWebViewController extends PlatformWebViewController {
   @override
   Future<void> addJavaScriptChannel(
     JavaScriptChannelParams javaScriptChannelParams,
-  ) => _webview.addJavaScriptChannel(javaScriptChannelParams);
+  ) =>
+      _webview.addJavaScriptChannel(javaScriptChannelParams);
 
   @override
   Future<void> removeJavaScriptChannel(String javaScriptChannelName) =>
@@ -168,7 +169,7 @@ class LweWebViewController extends PlatformWebViewController {
   @override
   Future<void> setOnScrollPositionChange(
     void Function(ScrollPositionChange scrollPositionChange)?
-    onScrollPositionChange,
+        onScrollPositionChange,
   ) async {
     throw UnimplementedError(
       'This version of `LweWebViewController` currently has no '
@@ -204,7 +205,7 @@ class LweWebViewController extends PlatformWebViewController {
   @override
   Future<void> setOnJavaScriptAlertDialog(
     Future<void> Function(JavaScriptAlertDialogRequest request)
-    onJavaScriptAlertDialog,
+        onJavaScriptAlertDialog,
   ) async {
     throw UnimplementedError(
       'This version of `LweWebViewController` currently has no '
@@ -215,7 +216,7 @@ class LweWebViewController extends PlatformWebViewController {
   @override
   Future<void> setOnJavaScriptConfirmDialog(
     Future<bool> Function(JavaScriptConfirmDialogRequest request)
-    onJavaScriptConfirmDialog,
+        onJavaScriptConfirmDialog,
   ) async {
     throw UnimplementedError(
       'This version of `LweWebViewController` currently has no '
@@ -226,7 +227,7 @@ class LweWebViewController extends PlatformWebViewController {
   @override
   Future<void> setOnJavaScriptTextInputDialog(
     Future<String> Function(JavaScriptTextInputDialogRequest request)
-    onJavaScriptTextInputDialog,
+        onJavaScriptTextInputDialog,
   ) async {
     throw UnimplementedError(
       'This version of `LweWebViewController` currently has no '

--- a/tools/lib/src/output_utils.dart
+++ b/tools/lib/src/output_utils.dart
@@ -1,0 +1,44 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:io';
+
+import 'package:colorize/colorize.dart';
+import 'package:meta/meta.dart';
+
+export 'package:colorize/colorize.dart' show Styles;
+
+/// True if color should be applied.
+///
+/// Defaults to autodetecting stdout.
+@visibleForTesting
+bool useColorForOutput = stdout.supportsAnsiEscapes;
+
+String _colorizeIfAppropriate(String string, Styles color) {
+  if (!useColorForOutput) {
+    return string;
+  }
+  return Colorize(string).apply(color).toString();
+}
+
+/// Prints [message] in green, if the environment supports color.
+void printSuccess(String message) {
+  print(_colorizeIfAppropriate(message, Styles.GREEN));
+}
+
+/// Prints [message] in yellow, if the environment supports color.
+void printWarning(String message) {
+  print(_colorizeIfAppropriate(message, Styles.YELLOW));
+}
+
+/// Prints [message] in red, if the environment supports color.
+void printError(String message) {
+  print(_colorizeIfAppropriate(message, Styles.RED));
+}
+
+/// Returns [message] with escapes to print it in [color], if the environment
+/// supports color.
+String colorizeString(String message, Styles color) {
+  return _colorizeIfAppropriate(message, color);
+}

--- a/tools/lib/src/publish_command.dart
+++ b/tools/lib/src/publish_command.dart
@@ -23,6 +23,8 @@ import 'package:path/path.dart' as p;
 import 'package:platform/platform.dart';
 import 'package:pub_semver/pub_semver.dart';
 
+import 'output_utils.dart';
+
 /// Wraps pub publish with a few niceties used by the flutter-tizen team.
 ///
 /// The code is a copy of [flutter_plugin_tools.PublishCommand] with parts
@@ -112,8 +114,12 @@ class PublishCommand extends PackageLoopingCommand {
       final String baseSha = await gitVersionFinder.getBaseSha();
       print(
           'Publishing all packages that have changed relative to "$baseSha"\n');
-      final List<String> changedPubspecs =
-          await gitVersionFinder.getChangedPubSpecs();
+      // final List<String> changedPubspecs =
+      //     await gitVersionFinder.getChangedPubSpecs();
+
+      final List<String> changedPubspecs = changedFiles
+          .where((String file) => file.trim().endsWith('pubspec.yaml'))
+          .toList();
 
       for (final String pubspecPath in changedPubspecs) {
         // git outputs a relative, Posix-style path.

--- a/tools/pubspec.yaml
+++ b/tools/pubspec.yaml
@@ -8,12 +8,16 @@ environment:
 
 dependencies:
   args: ^2.1.0
-  file: ^6.1.0
-  flutter_plugin_tools: ^0.13.0
-  http: ^0.13.3
-  path: ^1.8.0
-  platform: ^3.0.0
-  pub_semver: ^2.1.0
+  file: ^7.0.1
+  flutter_plugin_tools:
+    git:
+      url: https://github.com/flutter/packages.git
+      path: script/tool
+      ref: fdc1ec7c1c30e134aeeb5c50d9e0092ecd64165c #2025-04-18
+  http: ^1.0.0
+  path: ^1.8.3
+  platform: ^3.0.2
+  pub_semver: ^2.0.0
   yaml: ^3.1.0
 
 dev_dependencies:


### PR DESCRIPTION
The existing plugin_tools's dart formatter does not `pub get` each plugin,
separates all dart and cc file types and then executes formatting.
`flutter_plugin_tools 0.13.4+3` is no longer updated and the last update was 2 years ago.
Therefore, we use flutter_plugin_tools from flutter/packages directly.
(https://github.com/flutter/packages/tree/main/script/tool)
The formatter in the latest version of flutter_plugin_tools formats reliably using `PackageLoopingCommand`.
The `ref` for flutter_plugin_tools(in pubspec.yaml) is the latest commit in flutter/packages/script/tool.