### PR TITLE
[shared_preferences] Update shared_preferences to 2.5.3

### DIFF
--- a/packages/shared_preferences/CHANGELOG.md
+++ b/packages/shared_preferences/CHANGELOG.md
@@ -1,5 +1,9 @@
-## NEXT
+## 2.3.2
 
+* Update shared_preferences to 2.5.3.
+* Update shared_preferences_interface to 2.4.1. 
+* Update the example app and integration_test.
+* Updates minimum supported SDK version to Flutter 3.27/Dart 3.6.
 * Update code format.
 
 ## 2.3.1

--- a/packages/shared_preferences/README.md
+++ b/packages/shared_preferences/README.md
@@ -10,8 +10,8 @@ This package is not an _endorsed_ implementation of `shared_preferences`. Theref
 
 ```yaml
 dependencies:
-  shared_preferences: ^2.3.2
-  shared_preferences_tizen: ^2.3.1
+  shared_preferences: ^2.5.3
+  shared_preferences_tizen: ^2.3.2
 ```
 
 Then you can import `shared_preferences` in your Dart code:

--- a/packages/shared_preferences/example/integration_test/shared_preferences_test.dart
+++ b/packages/shared_preferences/example/integration_test/shared_preferences_test.dart
@@ -234,7 +234,7 @@ void main() {
           preferences.setBool(boolKey, testBool),
           preferences.setInt(intKey, testInt),
           preferences.setDouble(doubleKey, testDouble),
-          preferences.setStringList(listKey, testList),
+          preferences.setStringList(listKey, testList)
         ]);
 
         final Map<String, Object?> gotAll = await preferences.getAll();
@@ -254,12 +254,11 @@ void main() {
           preferences.setBool(boolKey, testBool),
           preferences.setInt(intKey, testInt),
           preferences.setDouble(doubleKey, testDouble),
-          preferences.setStringList(listKey, testList),
+          preferences.setStringList(listKey, testList)
         ]);
 
-        final Map<String, Object?> gotAll = await preferences.getAll(
-          allowList: <String>{stringKey, boolKey},
-        );
+        final Map<String, Object?> gotAll =
+            await preferences.getAll(allowList: <String>{stringKey, boolKey});
 
         expect(gotAll.length, 2);
         expect(gotAll[stringKey], testString);
@@ -273,7 +272,7 @@ void main() {
           preferences.setBool(boolKey, testBool),
           preferences.setInt(intKey, testInt),
           preferences.setDouble(doubleKey, testDouble),
-          preferences.setStringList(listKey, testList),
+          preferences.setStringList(listKey, testList)
         ]);
 
         final Set<String?> keys = await preferences.getKeys();
@@ -293,12 +292,11 @@ void main() {
           preferences.setBool(boolKey, testBool),
           preferences.setInt(intKey, testInt),
           preferences.setDouble(doubleKey, testDouble),
-          preferences.setStringList(listKey, testList),
+          preferences.setStringList(listKey, testList)
         ]);
 
-        final Set<String?> keys = await preferences.getKeys(
-          allowList: <String>{stringKey, boolKey},
-        );
+        final Set<String?> keys =
+            await preferences.getKeys(allowList: <String>{stringKey, boolKey});
 
         expect(keys.length, 2);
         expect(keys, contains(stringKey));
@@ -322,7 +320,7 @@ void main() {
           preferences.setBool(boolKey, testBool),
           preferences.setInt(intKey, testInt),
           preferences.setDouble(doubleKey, testDouble),
-          preferences.setStringList(listKey, testList),
+          preferences.setStringList(listKey, testList)
         ]);
         await preferences.clear();
         expect(await preferences.getString(stringKey), null);
@@ -339,7 +337,7 @@ void main() {
           preferences.setBool(boolKey, testBool),
           preferences.setInt(intKey, testInt),
           preferences.setDouble(doubleKey, testDouble),
-          preferences.setStringList(listKey, testList),
+          preferences.setStringList(listKey, testList)
         ]);
         await preferences.clear(allowList: <String>{stringKey, boolKey});
         expect(await preferences.getString(stringKey), null);
@@ -349,9 +347,8 @@ void main() {
         expect(await preferences.getStringList(listKey), testList);
       });
 
-      testWidgets('throws TypeError when returned getBool type is incorrect', (
-        WidgetTester _,
-      ) async {
+      testWidgets('throws TypeError when returned getBool type is incorrect',
+          (WidgetTester _) async {
         final SharedPreferencesAsync preferences = await getPreferences();
         await preferences.setString(stringKey, testString);
 
@@ -360,21 +357,18 @@ void main() {
         }, throwsA(isA<TypeError>()));
       });
 
-      testWidgets(
-        'throws TypeError when returned getString type is incorrect',
-        (WidgetTester _) async {
-          final SharedPreferencesAsync preferences = await getPreferences();
-          await preferences.setInt(stringKey, testInt);
+      testWidgets('throws TypeError when returned getString type is incorrect',
+          (WidgetTester _) async {
+        final SharedPreferencesAsync preferences = await getPreferences();
+        await preferences.setInt(stringKey, testInt);
 
-          expect(() async {
-            await preferences.getString(stringKey);
-          }, throwsA(isA<TypeError>()));
-        },
-      );
+        expect(() async {
+          await preferences.getString(stringKey);
+        }, throwsA(isA<TypeError>()));
+      });
 
-      testWidgets('throws TypeError when returned getInt type is incorrect', (
-        WidgetTester _,
-      ) async {
+      testWidgets('throws TypeError when returned getInt type is incorrect',
+          (WidgetTester _) async {
         final SharedPreferencesAsync preferences = await getPreferences();
         await preferences.setString(stringKey, testString);
 
@@ -383,34 +377,34 @@ void main() {
         }, throwsA(isA<TypeError>()));
       });
 
-      testWidgets(
-        'throws TypeError when returned getDouble type is incorrect',
-        (WidgetTester _) async {
-          final SharedPreferencesAsync preferences = await getPreferences();
-          await preferences.setString(stringKey, testString);
+      testWidgets('throws TypeError when returned getDouble type is incorrect',
+          (WidgetTester _) async {
+        final SharedPreferencesAsync preferences = await getPreferences();
+        await preferences.setString(stringKey, testString);
 
-          expect(() async {
-            await preferences.getDouble(stringKey);
-          }, throwsA(isA<TypeError>()));
-        },
-      );
+        expect(() async {
+          await preferences.getDouble(stringKey);
+        }, throwsA(isA<TypeError>()));
+      });
 
       testWidgets(
-        'throws TypeError when returned getStringList type is incorrect',
-        (WidgetTester _) async {
-          final SharedPreferencesAsync preferences = await getPreferences();
-          await preferences.setString(stringKey, testString);
+          'throws TypeError when returned getStringList type is incorrect',
+          (WidgetTester _) async {
+        final SharedPreferencesAsync preferences = await getPreferences();
+        await preferences.setString(stringKey, testString);
 
-          expect(() async {
-            await preferences.getStringList(stringKey);
-          }, throwsA(isA<TypeError>()));
-        },
-      );
+        expect(() async {
+          await preferences.getStringList(stringKey);
+        }, throwsA(isA<TypeError>()));
+      });
     });
 
     group('withCache', () {
-      Future<(SharedPreferencesWithCache, Map<String, Object?>)>
-          getPreferences() async {
+      Future<
+          (
+            SharedPreferencesWithCache,
+            Map<String, Object?>,
+          )> getPreferences() async {
         final Map<String, Object?> cache = <String, Object?>{};
         final SharedPreferencesWithCache preferences =
             await SharedPreferencesWithCache.create(
@@ -464,7 +458,7 @@ void main() {
       testWidgets('reloading', (WidgetTester _) async {
         final (
           SharedPreferencesWithCache preferences,
-          Map<String, Object?> cache,
+          Map<String, Object?> cache
         ) = await getPreferences();
         await preferences.clear();
         await preferences.setString(stringKey, testString);
@@ -496,7 +490,7 @@ void main() {
           preferences.setBool(boolKey, testBool),
           preferences.setInt(intKey, testInt),
           preferences.setDouble(doubleKey, testDouble),
-          preferences.setStringList(listKey, testList),
+          preferences.setStringList(listKey, testList)
         ]);
 
         final Set<String> keys = preferences.keys;
@@ -517,7 +511,7 @@ void main() {
           preferences.setBool(boolKey, testBool),
           preferences.setInt(intKey, testInt),
           preferences.setDouble(doubleKey, testDouble),
-          preferences.setStringList(listKey, testList),
+          preferences.setStringList(listKey, testList)
         ]);
         await preferences.clear();
         expect(preferences.getString(stringKey), null);
@@ -529,8 +523,11 @@ void main() {
     });
 
     group('withCache with filter', () {
-      Future<(SharedPreferencesWithCache, Map<String, Object?>)>
-          getPreferences() async {
+      Future<
+          (
+            SharedPreferencesWithCache,
+            Map<String, Object?>,
+          )> getPreferences() async {
         final Map<String, Object?> cache = <String, Object?>{};
         final SharedPreferencesWithCache preferences =
             await SharedPreferencesWithCache.create(
@@ -549,17 +546,14 @@ void main() {
         return (preferences, cache);
       }
 
-      testWidgets('throws ArgumentError if key is not included in filter', (
-        WidgetTester _,
-      ) async {
+      testWidgets('throws ArgumentError if key is not included in filter',
+          (WidgetTester _) async {
         final (SharedPreferencesWithCache preferences, _) =
             await getPreferences();
         const String key = 'testKey';
 
-        expect(
-          () async => preferences.setString(key, 'test'),
-          throwsArgumentError,
-        );
+        expect(() async => preferences.setString(key, 'test'),
+            throwsArgumentError);
       });
 
       testWidgets('set and get String', (WidgetTester _) async {
@@ -602,12 +596,11 @@ void main() {
         expect(preferences.getStringList(listKey), testList);
       });
 
-      testWidgets('get StringList handles List<Object?>', (
-        WidgetTester _,
-      ) async {
+      testWidgets('get StringList handles List<Object?>',
+          (WidgetTester _) async {
         final (
           SharedPreferencesWithCache preferences,
-          Map<String, Object?> cache,
+          Map<String, Object?> cache
         ) = await getPreferences();
         final List<Object?> listObject = <Object?>['one', 'two'];
         cache[listKey] = listObject;
@@ -617,7 +610,7 @@ void main() {
       testWidgets('reloading', (WidgetTester _) async {
         final (
           SharedPreferencesWithCache preferences,
-          Map<String, Object?> cache,
+          Map<String, Object?> cache
         ) = await getPreferences();
         await preferences.clear();
         await preferences.setString(stringKey, testString);
@@ -648,7 +641,7 @@ void main() {
           preferences.setBool(boolKey, testBool),
           preferences.setInt(intKey, testInt),
           preferences.setDouble(doubleKey, testDouble),
-          preferences.setStringList(listKey, testList),
+          preferences.setStringList(listKey, testList)
         ]);
 
         final Set<String> keys = preferences.keys;
@@ -669,7 +662,7 @@ void main() {
           preferences.setBool(boolKey, testBool),
           preferences.setInt(intKey, testInt),
           preferences.setDouble(doubleKey, testDouble),
-          preferences.setStringList(listKey, testList),
+          preferences.setStringList(listKey, testList)
         ]);
         await preferences.clear();
 

--- a/packages/shared_preferences/example/lib/main.dart
+++ b/packages/shared_preferences/example/lib/main.dart
@@ -8,6 +8,9 @@ import 'dart:async';
 
 import 'package:flutter/material.dart';
 import 'package:shared_preferences/shared_preferences.dart';
+// #docregion migrate
+import 'package:shared_preferences/util/legacy_to_async_migration_util.dart';
+// #enddocregion migrate
 
 void main() {
   runApp(const MyApp());
@@ -35,13 +38,15 @@ class SharedPreferencesDemo extends StatefulWidget {
 class SharedPreferencesDemoState extends State<SharedPreferencesDemo> {
   final Future<SharedPreferencesWithCache> _prefs =
       SharedPreferencesWithCache.create(
-    cacheOptions: const SharedPreferencesWithCacheOptions(
-      // This cache will only accept the key 'counter'.
-      allowList: <String>{'counter'},
-    ),
-  );
+          cacheOptions: const SharedPreferencesWithCacheOptions(
+              // This cache will only accept the key 'counter'.
+              allowList: <String>{'counter'}));
   late Future<int> _counter;
   int _externalCounter = 0;
+
+  /// Completes when the preferences have been initialized, which happens after
+  /// legacy preferences have been migrated.
+  final Completer<void> _preferencesReady = Completer<void>();
 
   Future<void> _incrementCounter() async {
     final SharedPreferencesWithCache prefs = await _prefs;
@@ -58,45 +63,66 @@ class SharedPreferencesDemoState extends State<SharedPreferencesDemo> {
   /// or via some native system.
   Future<void> _getExternalCounter() async {
     final SharedPreferencesAsync prefs = SharedPreferencesAsync();
-    setState(() async {
-      _externalCounter = (await prefs.getInt('externalCounter')) ?? 0;
+    final int externalCounter = (await prefs.getInt('externalCounter')) ?? 0;
+    setState(() {
+      _externalCounter = externalCounter;
     });
+  }
+
+  Future<void> _migratePreferences() async {
+    // #docregion migrate
+    const SharedPreferencesOptions sharedPreferencesOptions =
+        SharedPreferencesOptions();
+    final SharedPreferences prefs = await SharedPreferences.getInstance();
+    await migrateLegacySharedPreferencesToSharedPreferencesAsyncIfNecessary(
+      legacySharedPreferencesInstance: prefs,
+      sharedPreferencesAsyncOptions: sharedPreferencesOptions,
+      migrationCompletedKey: 'migrationCompleted',
+    );
+    // #enddocregion migrate
   }
 
   @override
   void initState() {
     super.initState();
-    _counter = _prefs.then((SharedPreferencesWithCache prefs) {
-      return prefs.getInt('counter') ?? 0;
+    _migratePreferences().then((_) {
+      _counter = _prefs.then((SharedPreferencesWithCache prefs) {
+        return prefs.getInt('counter') ?? 0;
+      });
+      _getExternalCounter();
+      _preferencesReady.complete();
     });
-
-    _getExternalCounter();
   }
 
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: AppBar(title: const Text('SharedPreferencesWithCache Demo')),
+      appBar: AppBar(
+        title: const Text('SharedPreferencesWithCache Demo'),
+      ),
       body: Center(
-        child: FutureBuilder<int>(
-          future: _counter,
-          builder: (BuildContext context, AsyncSnapshot<int> snapshot) {
-            switch (snapshot.connectionState) {
-              case ConnectionState.none:
-              case ConnectionState.waiting:
-                return const CircularProgressIndicator();
-              case ConnectionState.active:
-              case ConnectionState.done:
-                if (snapshot.hasError) {
-                  return Text('Error: ${snapshot.error}');
-                } else {
-                  return Text(
-                    'Button tapped ${snapshot.data ?? 0 + _externalCounter} time${(snapshot.data ?? 0 + _externalCounter) == 1 ? '' : 's'}.\n\n'
-                    'This should persist across restarts.',
-                  );
-                }
-            }
-          },
+        child: _WaitForInitialization(
+          initialized: _preferencesReady.future,
+          builder: (BuildContext context) => FutureBuilder<int>(
+            future: _counter,
+            builder: (BuildContext context, AsyncSnapshot<int> snapshot) {
+              switch (snapshot.connectionState) {
+                case ConnectionState.none:
+                case ConnectionState.waiting:
+                  return const CircularProgressIndicator();
+                case ConnectionState.active:
+                case ConnectionState.done:
+                  if (snapshot.hasError) {
+                    return Text('Error: ${snapshot.error}');
+                  } else {
+                    return Text(
+                      'Button tapped ${snapshot.data ?? 0 + _externalCounter} time${(snapshot.data ?? 0 + _externalCounter) == 1 ? '' : 's'}.\n\n'
+                      'This should persist across restarts.',
+                    );
+                  }
+              }
+            },
+          ),
         ),
       ),
       floatingActionButton: FloatingActionButton(
@@ -104,6 +130,31 @@ class SharedPreferencesDemoState extends State<SharedPreferencesDemo> {
         tooltip: 'Increment',
         child: const Icon(Icons.add),
       ),
+    );
+  }
+}
+
+/// Waits for the [initialized] future to complete before rendering [builder].
+class _WaitForInitialization extends StatelessWidget {
+  const _WaitForInitialization({
+    required this.initialized,
+    required this.builder,
+  });
+
+  final Future<void> initialized;
+  final WidgetBuilder builder;
+
+  @override
+  Widget build(BuildContext context) {
+    return FutureBuilder<void>(
+      future: initialized,
+      builder: (BuildContext context, AsyncSnapshot<void> snapshot) {
+        if (snapshot.connectionState == ConnectionState.waiting ||
+            snapshot.connectionState == ConnectionState.none) {
+          return const CircularProgressIndicator();
+        }
+        return builder(context);
+      },
     );
   }
 }

--- a/packages/shared_preferences/example/pubspec.yaml
+++ b/packages/shared_preferences/example/pubspec.yaml
@@ -3,13 +3,13 @@ description: Demonstrates how to use the shared_preferences_tizen plugin.
 publish_to: "none"
 
 environment:
-  sdk: ^3.4.0
-  flutter: ">=3.22.0"
+  sdk: ^3.6.0
+  flutter: ">=3.27.0"
 
 dependencies:
   flutter:
     sdk: flutter
-  shared_preferences: ^2.3.2
+  shared_preferences: ^2.5.3
   shared_preferences_tizen:
     path: ../
 

--- a/packages/shared_preferences/pubspec.yaml
+++ b/packages/shared_preferences/pubspec.yaml
@@ -2,11 +2,11 @@ name: shared_preferences_tizen
 description: Tizen implementation of the shared_preferences plugin.
 homepage: https://github.com/flutter-tizen/plugins
 repository: https://github.com/flutter-tizen/plugins/tree/master/packages/shared_preferences
-version: 2.3.1
+version: 2.3.2
 
 environment:
-  sdk: ^3.4.0
-  flutter: ">=3.22.0"
+  sdk: ^3.6.0
+  flutter: ">=3.27.0"
 
 flutter:
   plugin:
@@ -18,5 +18,5 @@ dependencies:
   ffi: ^2.0.1
   flutter:
     sdk: flutter
-  shared_preferences_platform_interface: ^2.4.0
+  shared_preferences_platform_interface: ^2.4.1
   tizen_interop: ^0.3.0


### PR DESCRIPTION
- Update shared_preferences to 2.5.3.
- Update shared_preferences_interface to 2.4.1.
- Update the example app and integration_test. (https://github.com/flutter/packages/pull/8398/files)
- Updates minimum supported SDK version to Flutter 3.27/Dart 3.6.