### PR TITLE
[video_player] Fix app crash issue

### DIFF
--- a/packages/video_player/CHANGELOG.md
+++ b/packages/video_player/CHANGELOG.md
@@ -1,6 +1,7 @@
-## NEXT
+## 2.5.6
 
 * Update code format.
+* Fix app crash issue when fail to seek.
 
 ## 2.5.5
 

--- a/packages/video_player/README.md
+++ b/packages/video_player/README.md
@@ -15,7 +15,7 @@ This package is not an _endorsed_ implementation of `video_player`. Therefore, y
 ```yaml
 dependencies:
   video_player: ^2.9.2
-  video_player_tizen: ^2.5.5
+  video_player_tizen: ^2.5.6
 ```
 
 Then you can import `video_player` in your Dart code:

--- a/packages/video_player/pubspec.yaml
+++ b/packages/video_player/pubspec.yaml
@@ -2,7 +2,7 @@ name: video_player_tizen
 description: Tizen implementation of the video_player plugin.
 homepage: https://github.com/flutter-tizen/plugins
 repository: https://github.com/flutter-tizen/plugins/tree/master/packages/video_player
-version: 2.5.5
+version: 2.5.6
 
 environment:
   sdk: ">=3.3.0 <4.0.0"

--- a/packages/video_player/tizen/src/video_player.cc
+++ b/packages/video_player/tizen/src/video_player.cc
@@ -582,7 +582,12 @@ void VideoPlayer::OnPlayCompleted(void *data) {
   };
   player->PushEvent(flutter::EncodableValue(result));
 
-  player->Pause();
+  try {
+    player->Pause();
+  } catch (const VideoPlayerError &error) {
+    LOG_ERROR("[VideoPlayer] Error code: %s, Error message: %s",
+              error.code().c_str(), error.message().c_str());
+  }
 }
 
 void VideoPlayer::OnInterrupted(player_interrupted_code_e code, void *data) {

--- a/packages/video_player/tizen/src/video_player_tizen_plugin.cc
+++ b/packages/video_player/tizen/src/video_player_tizen_plugin.cc
@@ -237,6 +237,7 @@ void VideoPlayerTizenPlugin::SeekTo(
                          [result]() -> void { result(std::nullopt); });
   } catch (const VideoPlayerError &error) {
     result(FlutterError(error.code(), error.message()));
+    return;
   }
 }
 

--- a/packages/video_player/tizen/src/video_player_tizen_plugin.cc
+++ b/packages/video_player/tizen/src/video_player_tizen_plugin.cc
@@ -237,7 +237,6 @@ void VideoPlayerTizenPlugin::SeekTo(
                          [result]() -> void { result(std::nullopt); });
   } catch (const VideoPlayerError &error) {
     result(FlutterError(error.code(), error.message()));
-    return;
   }
 }
 


### PR DESCRIPTION
Because pause method thorws VideoPlayerError, if call pause method, we muse be add catch the exception, otherwise the process will call terminate.

```
E/ConsoleMessage( 9835): terminate called after throwing an instance of 'VideoPlayerError'
E/ConsoleMessage( 9835): DotNET onSigabrt called on com.yeelight.station_tv_global
E/ConsoleMessage( 9835): DotNET onSigsegv called
```