### PR TITLE
[ci] Add an action to automatically close long-inactived issues

### DIFF
--- a/.github/workflows/analyze.yml
+++ b/.github/workflows/analyze.yml
@@ -1,3 +1,7 @@
+# Copyright 2025 Samsung Electronics Co., Ltd. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
 name: Analyze
 
 on: [push, pull_request]

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,3 +1,7 @@
+# Copyright 2025 Samsung Electronics Co., Ltd. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
 name: Build
 
 on: [push, pull_request]

--- a/.github/workflows/close_issue.yml
+++ b/.github/workflows/close_issue.yml
@@ -1,0 +1,36 @@
+# Copyright 2025 Samsung Electronics Co., Ltd. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
+# Configuration for close stale issues - https://github.com/actions/stale
+
+name: Close stale issues
+
+permissions:
+  issues: write
+
+on:
+  schedule:
+    - cron: "0 0 * * *"
+  workflow_dispatch:
+
+jobs:
+  lock:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v9
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          days-before-stale: 60
+          days-before-close: 0
+          only-issue-labels: ""
+          exempt-issue-labels: |
+            bug
+            enhancement
+            keep
+          close-issue-message: >
+            This page has been automatically closed since there has not been any recent activity. If you are still experiencing a similar issue, please open a new issue with additional information about the issue.
+          operations-per-run: 100
+          stale-pr-message: ""
+          days-before-pr-stale: -1
+          days-before-pr-close: -1

--- a/.github/workflows/integration_test.yml
+++ b/.github/workflows/integration_test.yml
@@ -1,3 +1,7 @@
+# Copyright 2025 Samsung Electronics Co., Ltd. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
 name: Integration Test
 
 on:
@@ -30,7 +34,7 @@ jobs:
             --recipe ./.github/recipe.yaml \
             --generate-emulators \
             --run-on-changed-packages \
-            --base-sha=$(git rev-parse HEAD^) 
+            --base-sha=$(git rev-parse HEAD^)
       - name: Run tests for all packages
         if: ${{ github.event_name == 'push' }}
         run: |

--- a/.github/workflows/pull_request_label.yml
+++ b/.github/workflows/pull_request_label.yml
@@ -1,3 +1,7 @@
+# Copyright 2025 Samsung Electronics Co., Ltd. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
 name: Pull Request Labeler
 
 on: [pull_request_target]

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,3 +1,7 @@
+# Copyright 2025 Samsung Electronics Co., Ltd. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
 name: Release
 
 on:
@@ -29,7 +33,7 @@ jobs:
         uses: lewagon/wait-on-check-action@v1.3.3
         with:
           ref: ${{ github.sha }}
-          running-workflow-name: 'release'
+          running-workflow-name: "release"
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           wait-interval: 180 # seconds
           allowed-conclusions: success


### PR DESCRIPTION
Close issue pages that have been inactive for more than 60 days. but do not close issues that have a "bug", "enhancement" or "keep" label.

+) And add license information.