### PR TITLE
[device_info_plus] Add support for `screenWidth` and `screenHeight`

### DIFF
--- a/packages/device_info_plus/CHANGELOG.md
+++ b/packages/device_info_plus/CHANGELOG.md
@@ -1,6 +1,7 @@
-## NEXT
+## 1.3.0
 
 * Update code format.
+* Add support for `screenWidth` and `screenHeight`.
 
 ## 1.2.1
 

--- a/packages/device_info_plus/README.md
+++ b/packages/device_info_plus/README.md
@@ -10,7 +10,7 @@ Add `device_info_plus_tizen` as a dependency in your `pubspec.yaml` file.
 
 ```yaml
 dependencies:
-  device_info_plus_tizen: ^1.2.1
+  device_info_plus_tizen: ^1.3.0
 ```
 
 Then you can import `device_info_plus_tizen` in your Dart code.
@@ -46,5 +46,7 @@ String modelName = tizenInfo.modelName;
 | `platformName` | `http://tizen.org/system/platform.name` |
 | `platformProcessor` | `http://tizen.org/system/platform.processor` |
 | `tizenId` | `http://tizen.org/system/tizenid` |
+| `screenWidth` | `http://tizen.org/feature/screen.width` |
+| `screenHeight` | `http://tizen.org/feature/screen.height` |
 
 For a description of each feature or system key in the list, see https://docs.tizen.org/application/native/guides/device/system.

--- a/packages/device_info_plus/example/lib/main.dart
+++ b/packages/device_info_plus/example/lib/main.dart
@@ -77,6 +77,8 @@ class _MyAppState extends State<MyApp> {
       'platformName': data.platformName,
       'platformProcessor': data.platformProcessor,
       'tizenId': data.tizenId,
+      'screenWidth': data.screenWidth,
+      'screenHeight': data.screenHeight,
     };
   }
 

--- a/packages/device_info_plus/lib/device_info_plus_tizen.dart
+++ b/packages/device_info_plus/lib/device_info_plus_tizen.dart
@@ -30,6 +30,8 @@ class TizenDeviceInfo {
     required this.platformName,
     required this.platformProcessor,
     required this.tizenId,
+    required this.screenWidth,
+    required this.screenHeight,
   });
 
   /// Device information data.
@@ -89,6 +91,12 @@ class TizenDeviceInfo {
   /// http://tizen.org/system/tizenid
   final String? tizenId;
 
+  /// http://tizen.org/feature/screen.width
+  final int screenWidth;
+
+  /// http://tizen.org/feature/screen.height
+  final int screenHeight;
+
   /// Creates a [TizenDeviceInfo] from the [map].
   static TizenDeviceInfo fromMap(Map<String, dynamic> map) {
     return TizenDeviceInfo._(
@@ -111,6 +119,8 @@ class TizenDeviceInfo {
       platformName: map['platformName'],
       platformProcessor: map['platformProcessor'],
       tizenId: map['tizenId'],
+      screenWidth: map['screenWidth'],
+      screenHeight: map['screenHeight'],
     );
   }
 
@@ -129,8 +139,7 @@ class _MethodChannelDeviceInfo {
     return TizenDeviceInfo.fromMap(
       (await channel.invokeMethod(
         'getTizenDeviceInfo',
-      ))
-          .cast<String, dynamic>(),
+      )).cast<String, dynamic>(),
     );
   }
 }

--- a/packages/device_info_plus/lib/device_info_plus_tizen.dart
+++ b/packages/device_info_plus/lib/device_info_plus_tizen.dart
@@ -139,7 +139,8 @@ class _MethodChannelDeviceInfo {
     return TizenDeviceInfo.fromMap(
       (await channel.invokeMethod(
         'getTizenDeviceInfo',
-      )).cast<String, dynamic>(),
+      ))
+          .cast<String, dynamic>(),
     );
   }
 }

--- a/packages/device_info_plus/pubspec.yaml
+++ b/packages/device_info_plus/pubspec.yaml
@@ -3,7 +3,7 @@ description: Flutter plugin providing detailed information about Tizen device
   (make, model, etc.) the app is running on.
 homepage: https://github.com/flutter-tizen/plugins
 repository: https://github.com/flutter-tizen/plugins/tree/master/packages/device_info_plus
-version: 1.2.1
+version: 1.3.0
 
 environment:
   sdk: ">=3.1.0 <4.0.0"

--- a/packages/device_info_plus/tizen/src/device_info_plus_tizen_plugin.cc
+++ b/packages/device_info_plus/tizen/src/device_info_plus_tizen_plugin.cc
@@ -50,12 +50,23 @@ class DeviceInfoPlusTizenPlugin : public flutter::Plugin {
 
       for (const auto &[key, tizen_key] : tizen_keys_) {
         auto response = flutter::EncodableValue();
-        char *value = nullptr;
-        int ret = system_info_get_platform_string(tizen_key.c_str(), &value);
-        if (ret == SYSTEM_INFO_ERROR_NONE) {
-          response = std::string(value);
-          free(value);
+        int ret = SYSTEM_INFO_ERROR_NONE;
+        if (key.compare(0, 6, "screen") == 0) {
+          int value = 0;
+          ret = system_info_get_platform_int(tizen_key.c_str(), &value);
+          if (ret == SYSTEM_INFO_ERROR_NONE) {
+            response = value;
+          }
         } else {
+          char *value = nullptr;
+          ret = system_info_get_platform_string(tizen_key.c_str(), &value);
+          if (ret == SYSTEM_INFO_ERROR_NONE) {
+            response = std::string(value);
+            free(value);
+          }
+        }
+
+        if (ret != SYSTEM_INFO_ERROR_NONE) {
           LOG_ERROR("Failed to get %s from the system: %s", tizen_key.c_str(),
                     get_error_message(ret));
         }
@@ -88,6 +99,8 @@ class DeviceInfoPlusTizenPlugin : public flutter::Plugin {
       {"platformName", "http://tizen.org/system/platform.name"},
       {"platformProcessor", "http://tizen.org/system/platform.processor"},
       {"tizenId", "http://tizen.org/system/tizenid"},
+      {"screenWidth", "http://tizen.org/feature/screen.width"},
+      {"screenHeight", "http://tizen.org/feature/screen.height"},
   };
 };
 


### PR DESCRIPTION
- Add support for `screenWidth` and `screenHeight`.

related : https://github.com/flutter-tizen/plugins/issues/895