### PR TITLE
[video_player_avplay] Fix type missmatch

### DIFF
--- a/packages/video_player_avplay/CHANGELOG.md
+++ b/packages/video_player_avplay/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 0.7.2
+* Fix type missmatch.
+
 ## 0.7.1
 * Fix an assertion issue when getting AD information.
 

--- a/packages/video_player_avplay/README.md
+++ b/packages/video_player_avplay/README.md
@@ -12,7 +12,7 @@ To use this package, add `video_player_avplay` as a dependency in your `pubspec.
 
 ```yaml
 dependencies:
-  video_player_avplay: ^0.7.1
+  video_player_avplay: ^0.7.2
 ```
 
 Then you can import `video_player_avplay` in your Dart code:

--- a/packages/video_player_avplay/pubspec.yaml
+++ b/packages/video_player_avplay/pubspec.yaml
@@ -2,7 +2,7 @@ name: video_player_avplay
 description: Flutter plugin for displaying inline video on Tizen TV devices.
 homepage: https://github.com/flutter-tizen/plugins
 repository: https://github.com/flutter-tizen/plugins/tree/master/packages/video_player_avplay
-version: 0.7.1
+version: 0.7.2
 
 environment:
   sdk: ">=3.1.0 <4.0.0"

--- a/packages/video_player_avplay/tizen/src/plus_player.cc
+++ b/packages/video_player_avplay/tizen/src/plus_player.cc
@@ -1359,13 +1359,13 @@ void PlusPlayer::OnStateChangedToPlaying(void *user_data) {
 
 void PlusPlayer::OnADEventFromDash(const char *ad_data, void *user_data) {
   const char *prefix = "AD_INFO: ";
-  char *data = strstr(ad_data, prefix);
+  const char *data = strstr(ad_data, prefix);
   if (!data) {
     LOG_ERROR("[PlusPlayer] Invalid ad_data.");
     return;
   }
   data += strlen(prefix);
-  data[strlen(data) - 1] = '\0';
+  const_cast<char *>(data)[strlen(data) - 1] = '\0';
   LOG_INFO("[PlusPlayer] AD info: %s", data);
 
   rapidjson::Document doc;


### PR DESCRIPTION
fix to below error on tizen 10.0 rootstrap

```
src/plus_player.cc:1366:9: error: cannot initialize a variable of type 'char *' with an rvalue of type 'const char *'
  char *data = strstr(ad_data, prefix);
        ^      ~~~~~~~~~~~~~~~~~~~~~~~
```