### PR TITLE
[tizen_package_manager] Fix error handling in getPackageSizeInfo

### DIFF
--- a/packages/tizen_package_manager/CHANGELOG.md
+++ b/packages/tizen_package_manager/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.4.1
+
+* Fix error handling in `getPackageSizeInfo`.
+
 ## 0.4.0
 
 * Add retrieve package size information using `PackageManager.getPackageSizeInfo`.

--- a/packages/tizen_package_manager/README.md
+++ b/packages/tizen_package_manager/README.md
@@ -10,7 +10,7 @@ To use this package, add `tizen_package_manager` as a dependency in your `pubspe
 
 ```yaml
 dependencies:
-  tizen_package_manager: ^0.4.0
+  tizen_package_manager: ^0.4.1
 ```
 
 ### Retrieving specific package info

--- a/packages/tizen_package_manager/pubspec.yaml
+++ b/packages/tizen_package_manager/pubspec.yaml
@@ -2,7 +2,7 @@ name: tizen_package_manager
 description: Tizen package manager APIs. Used to get information about packages installed on a Tizen device.
 homepage: https://github.com/flutter-tizen/plugins
 repository: https://github.com/flutter-tizen/plugins/tree/master/packages/tizen_package_manager
-version: 0.4.0
+version: 0.4.1
 
 environment:
   sdk: ">=3.1.0 <4.0.0"

--- a/packages/tizen_package_manager/tizen/src/tizen_package_manager.cc
+++ b/packages/tizen_package_manager/tizen/src/tizen_package_manager.cc
@@ -235,16 +235,28 @@ void TizenPackageManager::GetPackageSizeInfo(
           long long external_data_size = 0;
           long long external_cache_size = 0;
           long long external_app_size = 0;
+          int ret = PACKAGE_MANAGER_ERROR_NONE;
 
-          package_size_info_get_data_size(size_info, &data_size);
-          package_size_info_get_cache_size(size_info, &cache_size);
-          package_size_info_get_app_size(size_info, &app_size);
-          package_size_info_get_external_data_size(size_info,
-                                                   &external_data_size);
-          package_size_info_get_external_cache_size(size_info,
-                                                    &external_cache_size);
-          package_size_info_get_external_app_size(size_info,
-                                                  &external_app_size);
+          if ((ret = package_size_info_get_data_size(size_info, &data_size)) !=
+                  PACKAGE_MANAGER_ERROR_NONE ||
+              (ret = package_size_info_get_cache_size(
+                   size_info, &cache_size)) != PACKAGE_MANAGER_ERROR_NONE ||
+              (ret = package_size_info_get_app_size(size_info, &app_size)) !=
+                  PACKAGE_MANAGER_ERROR_NONE ||
+              (ret = package_size_info_get_external_data_size(
+                   size_info, &external_data_size)) !=
+                  PACKAGE_MANAGER_ERROR_NONE ||
+              (ret = package_size_info_get_external_cache_size(
+                   size_info, &external_cache_size)) !=
+                  PACKAGE_MANAGER_ERROR_NONE ||
+              (ret = package_size_info_get_external_app_size(
+                   size_info, &external_app_size)) !=
+                  PACKAGE_MANAGER_ERROR_NONE) {
+            self->last_error_ = ret;
+            (*self->package_size_callbacks_[package_id])(package_size_info,
+                                                         false);
+            return;
+          }
 
           package_size_info.data_size = data_size;
           package_size_info.cache_size = cache_size;
@@ -253,7 +265,7 @@ void TizenPackageManager::GetPackageSizeInfo(
           package_size_info.external_cache_size = external_cache_size;
           package_size_info.external_app_size = external_app_size;
 
-          (*self->package_size_callbacks_[package_id])(package_size_info);
+          (*self->package_size_callbacks_[package_id])(package_size_info, true);
         }
       },
       this);
@@ -262,9 +274,7 @@ void TizenPackageManager::GetPackageSizeInfo(
     LOG_ERROR("package_manager_get_package_size_info failed: %s",
               get_error_message(ret));
     last_error_ = ret;
-    PackageSizeInfo package_size_info;
-    package_size_info.app_size = 0;
-    (*package_size_callbacks_[package_id])(package_size_info);
+    (*package_size_callbacks_[package_id])(PackageSizeInfo(), false);
   }
 }
 

--- a/packages/tizen_package_manager/tizen/src/tizen_package_manager.h
+++ b/packages/tizen_package_manager/tizen/src/tizen_package_manager.h
@@ -43,7 +43,8 @@ using OnPackageEvent =
     std::function<void(std::string package_id, std::string package_type,
                        PacakgeEventState state, int32_t progress)>;
 
-using OnPackageSizeEvent = std::function<void(PackageSizeInfo size_info)>;
+using OnPackageSizeEvent =
+    std::function<void(PackageSizeInfo size_info, bool success)>;
 
 class TizenPackageManager {
  public:

--- a/packages/tizen_package_manager/tizen/src/tizen_package_manager_plugin.cc
+++ b/packages/tizen_package_manager/tizen/src/tizen_package_manager_plugin.cc
@@ -285,9 +285,9 @@ class TizenPackageManagerPlugin : public flutter::Plugin {
     TizenPackageManager &package_manager = TizenPackageManager::GetInstance();
     auto shared_result = std::shared_ptr<FlMethodResult>(std::move(result));
     package_manager.GetPackageSizeInfo(
-        package_id,
-        [shared_result, &package_manager](PackageSizeInfo size_info) {
-          if (size_info.app_size == 0) {
+        package_id, [shared_result, &package_manager](PackageSizeInfo size_info,
+                                                      bool success) {
+          if (!success) {
             shared_result->Error(std::to_string(package_manager.GetLastError()),
                                  package_manager.GetLastErrorString());
             return;


### PR DESCRIPTION
Some package's app size in the TV profile returned 0.
This is a value returned normally without error from the native API, so modifying the error handling code.