### PR TITLE
[geolocator, permission_handler] Fix build failure in example

### DIFF
--- a/packages/geolocator/CHANGELOG.md
+++ b/packages/geolocator/CHANGELOG.md
@@ -1,7 +1,8 @@
-## NEXT
+## 1.0.7
 
 * Update minimum Flutter and Dart version to 3.13 and 3.1.
 * Update code format.
+* Fix build failure in example.
 
 ## 1.0.6
 

--- a/packages/geolocator/README.md
+++ b/packages/geolocator/README.md
@@ -11,7 +11,7 @@ The Tizen implementation of [`geolocator`](https://pub.dev/packages/geolocator).
  ```yaml
 dependencies:
   geolocator: ^8.0.0
-  geolocator_tizen: ^1.0.6
+  geolocator_tizen: ^1.0.7
 ```
 
 Then you can import `geolocator` in your Dart code:

--- a/packages/geolocator/example/pubspec.yaml
+++ b/packages/geolocator/example/pubspec.yaml
@@ -7,7 +7,7 @@ environment:
   flutter: ">=3.13.0"
 
 dependencies:
-  baseflow_plugin_template: ^2.1.2
+  baseflow_plugin_template: 2.1.2
   cupertino_icons: ^1.0.1+1
   flutter:
     sdk: flutter

--- a/packages/geolocator/pubspec.yaml
+++ b/packages/geolocator/pubspec.yaml
@@ -2,7 +2,7 @@ name: geolocator_tizen
 description: Tizen implementation of the geolocator plugin.
 homepage: https://github.com/flutter-tizen/plugins
 repository: https://github.com/flutter-tizen/plugins/tree/master/packages/geolocator
-version: 1.0.6
+version: 1.0.7
 
 environment:
   sdk: ">=3.1.0 <4.0.0"

--- a/packages/permission_handler/CHANGELOG.md
+++ b/packages/permission_handler/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.4.2
+
+* Fix build failure in example.
+
 ## 1.4.1
 
 * Update README.

--- a/packages/permission_handler/README.md
+++ b/packages/permission_handler/README.md
@@ -21,7 +21,7 @@ You can use this plugin to ask the user for runtime permissions if your app perf
    ```yaml
    dependencies:
      permission_handler: ^12.0.0
-     permission_handler_tizen: ^1.4.1
+     permission_handler_tizen: ^1.4.2
    ```
 
    Then you can import `permission_handler` in your Dart code:

--- a/packages/permission_handler/example/pubspec.yaml
+++ b/packages/permission_handler/example/pubspec.yaml
@@ -7,7 +7,7 @@ environment:
   flutter: ">=3.13.0"
 
 dependencies:
-  baseflow_plugin_template: ^2.1.2
+  baseflow_plugin_template: 2.1.2
   flutter:
     sdk: flutter
   permission_handler: ^12.0.0

--- a/packages/permission_handler/pubspec.yaml
+++ b/packages/permission_handler/pubspec.yaml
@@ -2,7 +2,7 @@ name: permission_handler_tizen
 description: Tizen implementation of the permission_handler plugin.
 homepage: https://github.com/flutter-tizen/plugins
 repository: https://github.com/flutter-tizen/plugins/tree/master/packages/permission_handler
-version: 1.4.1
+version: 1.4.2
 
 environment:
   sdk: ">=3.1.0 <4.0.0"


### PR DESCRIPTION
There is an issue with version 2.2.0 of the `baseflow_plugin_template` package used in each plugin example. Therefore, fixed the version to 2.1.2.