### PR TITLE
[flutter_tts] Fix integration_test issue

### DIFF
--- a/packages/flutter_tts/example/integration_test/flutter_tts_test.dart
+++ b/packages/flutter_tts/example/integration_test/flutter_tts_test.dart
@@ -7,6 +7,7 @@ void main() {
 
   testWidgets('Can speak', (WidgetTester tester) async {
     final flutterTts = FlutterTts();
+    await Future<void>.delayed(const Duration(seconds: 2));
     var result = await flutterTts.speak('Hello, world!');
     expect(result, 1);
   });


### PR DESCRIPTION
After running the integration_test, it needs some time to run the TTS engine.