### PR TITLE
Upgrade wearable_rotary compileSdkVersion to 35

### DIFF
--- a/packages/wearable_rotary/CHANGELOG.md
+++ b/packages/wearable_rotary/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.0.4
+
+- Upgrades `compileSdkVersion` to 35
+
 ## 2.0.3
 
 * Fix new lint warnings.

--- a/packages/wearable_rotary/android/build.gradle
+++ b/packages/wearable_rotary/android/build.gradle
@@ -25,7 +25,7 @@ apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 
 android {
-    compileSdkVersion 31
+    compileSdkVersion 35
 
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_1_8

--- a/packages/wearable_rotary/pubspec.yaml
+++ b/packages/wearable_rotary/pubspec.yaml
@@ -2,7 +2,7 @@ name: wearable_rotary
 description: Flutter plugin that can listen to rotary events on Wear OS and Tizen Galaxy watch devices.
 homepage: https://github.com/flutter-tizen/plugins
 repository: https://github.com/flutter-tizen/plugins/tree/master/packages/wearable_rotary
-version: 2.0.3
+version: 2.0.4
 
 environment:
   sdk: ">=3.1.0 <4.0.0"


### PR DESCRIPTION
I know this plugin is marked as discontinued, but this fixes a critical build issue