### PR TITLE
[google_sign_in_tizen] Adds compatibility with `http` 1.0

### DIFF
--- a/packages/google_sign_in/CHANGELOG.md
+++ b/packages/google_sign_in/CHANGELOG.md
@@ -1,6 +1,7 @@
-## NEXT
+## 0.1.5
 
 * Update code format.
+* Adds compatibility with `http` 1.0.
 
 ## 0.1.4
 

--- a/packages/google_sign_in/README.md
+++ b/packages/google_sign_in/README.md
@@ -11,7 +11,7 @@ This package is not an _endorsed_ implementation of `google_sign_in`. Therefore,
 ```yaml
 dependencies:
   google_sign_in: ^5.4.1
-  google_sign_in_tizen: ^0.1.4
+  google_sign_in_tizen: ^0.1.5
 ```
 
 For detailed usage on how to use `google_sign_in`, see https://pub.dev/packages/google_sign_in#usage.

--- a/packages/google_sign_in/example/pubspec.yaml
+++ b/packages/google_sign_in/example/pubspec.yaml
@@ -12,7 +12,7 @@ dependencies:
   google_sign_in: ^5.4.1
   google_sign_in_tizen:
     path: ../
-  http: ^0.13.0
+  http: ">=0.13.0 <2.0.0"
 
 dev_dependencies:
   flutter_driver:

--- a/packages/google_sign_in/pubspec.yaml
+++ b/packages/google_sign_in/pubspec.yaml
@@ -2,7 +2,7 @@ name: google_sign_in_tizen
 description: Tizen implementation of the google_sign_in plugin.
 homepage: https://github.com/flutter-tizen/plugins
 repository: https://github.com/flutter-tizen/plugins/tree/master/packages/google_sign_in
-version: 0.1.4
+version: 0.1.5
 
 environment:
   sdk: ">=3.1.0 <4.0.0"
@@ -23,7 +23,7 @@ dependencies:
   flutter_secure_storage_tizen: ^0.1.0
   flutter_svg: ^1.1.5
   google_sign_in_platform_interface: ^2.3.0
-  http: ^0.13.4
+  http: ">=0.13.0 <2.0.0"
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
Extends http dependency from 0.13.0 to 2.0.0.

refer to: https://github.com/flutter/packages/pull/4147
related issue: https://github.com/flutter-tizen/plugins/issues/951