### PR TITLE
Adds compatibility with `http` 1.0 in example

### DIFF
--- a/packages/audioplayers/CHANGELOG.md
+++ b/packages/audioplayers/CHANGELOG.md
@@ -1,3 +1,7 @@
+## NEXT
+
+* Adds compatibility with `http` 1.0 in example.
+
 ## 3.1.2
 
 * Update code format.

--- a/packages/audioplayers/example/pubspec.yaml
+++ b/packages/audioplayers/example/pubspec.yaml
@@ -14,7 +14,7 @@ dependencies:
   file_picker: ^8.0.3
   flutter:
     sdk: flutter
-  http: ^1.0.0
+  http: ">=0.13.0 <2.0.0"
   path_provider: ^2.0.12
   path_provider_tizen:
     path: ../../path_provider/

--- a/packages/flutter_webrtc/CHANGELOG.md
+++ b/packages/flutter_webrtc/CHANGELOG.md
@@ -3,6 +3,7 @@
 * Update minimum Flutter and Dart version to 3.13 and 3.1.
 * Fix analyze issue.
 * Update code format.
+* Adds compatibility with `http` 1.0 in example.
 
 ## 0.1.3
 

--- a/packages/flutter_webrtc/example/flutter_webrtc_demo/pubspec.yaml
+++ b/packages/flutter_webrtc/example/flutter_webrtc_demo/pubspec.yaml
@@ -13,7 +13,7 @@ dependencies:
   flutter_webrtc: 0.9.46 # Use a fixed version due to build errors.
   flutter_webrtc_tizen:
     path: ../../
-  http: ^0.13.3
+  http: ">=0.13.0 <2.0.0"
   path_provider: ^2.0.7
   path_provider_tizen: ^2.1.0
   shared_preferences: ^2.2.0

--- a/packages/video_player_avplay/CHANGELOG.md
+++ b/packages/video_player_avplay/CHANGELOG.md
@@ -1,3 +1,7 @@
+## NEXT
+
+* Adds compatibility with `http` 1.0 in example.
+
 ## 0.8.1
 
 * Update the error callback when DRM license acquisition fails.

--- a/packages/video_player_avplay/example/pubspec.yaml
+++ b/packages/video_player_avplay/example/pubspec.yaml
@@ -9,7 +9,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  http: ^0.13.0
+  http: ">=0.13.0 <2.0.0"
   video_player_avplay:
     path: ../
 

--- a/packages/video_player_videohole/CHANGELOG.md
+++ b/packages/video_player_videohole/CHANGELOG.md
@@ -1,3 +1,7 @@
+## NEXT
+
+* Adds compatibility with `http` 1.0 in example.
+
 ## 0.5.8
 
 * Add namespace to the C++ code to avoid name conflicts with other plugins.

--- a/packages/video_player_videohole/example/pubspec.yaml
+++ b/packages/video_player_videohole/example/pubspec.yaml
@@ -9,7 +9,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  http: ^0.13.0
+  http: ">=0.13.0 <2.0.0"
   video_player_videohole:
     path: ../
 


### PR DESCRIPTION
Extends http dependency from 0.13.0 to 2.0.0 in example.

+ https://github.com/flutter-tizen/plugins/pull/952