### PR TITLE
[connectivity_plus] Update connectivity_plus to 7.1.0

### DIFF
--- a/packages/connectivity_plus/CHANGELOG.md
+++ b/packages/connectivity_plus/CHANGELOG.md
@@ -1,3 +1,11 @@
+## 1.3.0
+
+* Update minimum Dart version to 3.2.
+* Update connectivity_plus to 7.1.0.
+* Update connectivity_plus_platform_interface to 2.1.0.
+* Support ConnectivityResult.other type.
+* Update limitations in README.
+
 ## 1.2.2
 
 * Update the LICENSE file so that it is recognized by pub.dev.

--- a/packages/connectivity_plus/README.md
+++ b/packages/connectivity_plus/README.md
@@ -10,8 +10,8 @@ This package is not an _endorsed_ implementation of `connectivity_plus`. Therefo
 
 ```yaml
 dependencies:
-  connectivity_plus: ^6.1.0
-  connectivity_plus_tizen: ^1.2.2
+  connectivity_plus: ^7.1.0
+  connectivity_plus_tizen: ^1.3.0
 ```
 
 Then you can import `connectivity_plus` in your Dart code:
@@ -34,3 +34,4 @@ To get connectivity information using this plugin, add below lines under the `<m
 
 ## Limitations
 - Multiple connections are not supported, so only the currently connected connection type is provided.
+- `vpn` and `satellite` are not supported, because the Tizen network API does not distinguish these connection types.

--- a/packages/connectivity_plus/example/integration_test/connectivity_plus_test.dart
+++ b/packages/connectivity_plus/example/integration_test/connectivity_plus_test.dart
@@ -19,6 +19,19 @@ void main() {
     testWidgets('test connectivity result', (WidgetTester tester) async {
       final result = await connectivity.checkConnectivity();
       expect(result, isNotNull);
+      expect(result, isNotEmpty);
+      expect(result, hasLength(1));
+      expect(
+        result.single,
+        isIn(<ConnectivityResult>[
+          ConnectivityResult.bluetooth,
+          ConnectivityResult.wifi,
+          ConnectivityResult.ethernet,
+          ConnectivityResult.mobile,
+          ConnectivityResult.none,
+          ConnectivityResult.other,
+        ]),
+      );
     });
   });
 }

--- a/packages/connectivity_plus/example/pubspec.yaml
+++ b/packages/connectivity_plus/example/pubspec.yaml
@@ -3,11 +3,11 @@ description: Demonstrates how to use the connectivity_plus_tizen plugin.
 publish_to: "none"
 
 environment:
-  sdk: ">=3.1.0 <4.0.0"
+  sdk: ">=3.2.0 <4.0.0"
   flutter: ">=3.13.0"
 
 dependencies:
-  connectivity_plus: ^6.1.0
+  connectivity_plus: ^7.1.0
   connectivity_plus_tizen:
     path: ../
   flutter:

--- a/packages/connectivity_plus/pubspec.yaml
+++ b/packages/connectivity_plus/pubspec.yaml
@@ -2,11 +2,11 @@ name: connectivity_plus_tizen
 description: Tizen implementation of the connectivity_plus plugin.
 homepage: https://github.com/flutter-tizen/plugins
 repository: https://github.com/flutter-tizen/plugins/tree/master/packages/connectivity_plus
-version: 1.2.2
+version: 1.3.0
 
 environment:
-  sdk: ">=3.1.0 <4.0.0"
-  flutter: ">=3.3.0"
+  sdk: ">=3.2.0 <4.0.0"
+  flutter: ">=3.7.0"
 
 flutter:
   plugin:
@@ -16,7 +16,7 @@ flutter:
         fileName: connectivity_plus_tizen_plugin.h
 
 dependencies:
-  connectivity_plus_platform_interface: ^2.0.1
+  connectivity_plus_platform_interface: ^2.1.0
   flutter:
     sdk: flutter
 

--- a/packages/connectivity_plus/tizen/src/connectivity_plus_tizen_plugin.cc
+++ b/packages/connectivity_plus/tizen/src/connectivity_plus_tizen_plugin.cc
@@ -37,6 +37,8 @@ std::string ConnectionTypeToString(ConnectionType type) {
       return "mobile";
     case ConnectionType::kBluetooth:
       return "bluetooth";
+    case ConnectionType::kOther:
+      return "other";
     case ConnectionType::kNone:
     default:
       return "none";


### PR DESCRIPTION
* Update minimum Flutter and Dart version to 3.7 and 3.2.
* Update connectivity_plus to 7.1.0.
* Update connectivity_plus_platform_interface to 2.1.0.
* Support ConnectivityResult.other type.
* Update limitations in README.

+)#1002