### PR TITLE
[audioplayers] Update audioplayers to 6.6.0

### DIFF
--- a/packages/audioplayers/CHANGELOG.md
+++ b/packages/audioplayers/CHANGELOG.md
@@ -1,6 +1,10 @@
-## NEXT
+## 3.1.3
 
 * Adds compatibility with `http` 1.0 in example.
+* Update audioplayers to 6.6.0.
+* Update audioplayers_platform_interface to 7.1.1.
+* Update minimum Flutter and Dart version to 3.27 and 3.6.
+* Update limitations in README.
 
 ## 3.1.2
 

--- a/packages/audioplayers/README.md
+++ b/packages/audioplayers/README.md
@@ -10,8 +10,8 @@ This package is not an _endorsed_ implementation of `audioplayers`. Therefore, y
 
 ```yaml
 dependencies:
-  audioplayers: ^6.4.0
-  audioplayers_tizen: ^3.1.2
+  audioplayers: ^6.6.0
+  audioplayers_tizen: ^3.1.3
 
 ```
 
@@ -56,10 +56,10 @@ For detailed information on Tizen privileges, see [Tizen Docs: API Privileges](h
 - [x] `AudioPlayer.setReleaseMode`
 - [x] `AudioPlayer.setPlaybackRate`
 - [x] `AudioPlayer.setSource`
-- [x] `AudioPlayer.setSourceUrl`
+- [x] `AudioPlayer.setSourceUrl`(`String? mimeType` not supported)
 - [x] `AudioPlayer.setSourceDeviceFile`
 - [x] `AudioPlayer.setSourceAsset`
-- [x] `AudioPlayer.setSourceBytes`
+- [x] `AudioPlayer.setSourceBytes`(`String? mimeType` not supported)
 - [x] `AudioPlayer.getDuration`
 - [x] `AudioPlayer.getCurrentPosition`
 - [x] `AudioPlayer.dispose`

--- a/packages/audioplayers/example/lib/main.dart
+++ b/packages/audioplayers/example/lib/main.dart
@@ -51,15 +51,12 @@ class _ExampleAppState extends State<_ExampleApp> {
                 'Player stopped!',
                 textKey: Key('toast-player-stopped-$index'),
               );
-              break;
             case PlayerState.completed:
               toast(
                 'Player complete!',
                 textKey: Key('toast-player-complete-$index'),
               );
-              break;
             default:
-              break;
           }
         }),
       );
@@ -86,7 +83,6 @@ class _ExampleAppState extends State<_ExampleApp> {
         setState(() {
           audioPlayers.add(AudioPlayer()..setReleaseMode(ReleaseMode.stop));
         });
-        break;
       case PopupAction.remove:
         setState(() {
           if (audioPlayers.isNotEmpty) {
@@ -100,7 +96,6 @@ class _ExampleAppState extends State<_ExampleApp> {
             selectedPlayerIdx = audioPlayers.length - 1;
           }
         });
-        break;
     }
   }
 

--- a/packages/audioplayers/example/pubspec.yaml
+++ b/packages/audioplayers/example/pubspec.yaml
@@ -7,7 +7,7 @@ environment:
   flutter: ">=3.13.0"
 
 dependencies:
-  audioplayers: ^6.4.0
+  audioplayers: ^6.6.0
   audioplayers_tizen:
     path: ../
   collection: ^1.16.0
@@ -21,7 +21,7 @@ dependencies:
   provider: ^6.0.5
 
 dev_dependencies:
-  flame_lint: ^1.0.0
+  flame_lint: ^1.4.1
   flutter_driver:
     sdk: flutter
   flutter_test:

--- a/packages/audioplayers/pubspec.yaml
+++ b/packages/audioplayers/pubspec.yaml
@@ -2,11 +2,11 @@ name: audioplayers_tizen
 description: Tizen implementation of the audioplayers plugin.
 homepage: https://github.com/flutter-tizen/plugins
 repository: https://github.com/flutter-tizen/plugins/tree/master/packages/audioplayers
-version: 3.1.2
+version: 3.1.3
 
 environment:
-  sdk: ">=3.1.0 <4.0.0"
-  flutter: ">=3.13.0"
+  sdk: ^3.6.0
+  flutter: ">=3.27.0"
 
 flutter:
   plugin:
@@ -16,9 +16,9 @@ flutter:
         fileName: audioplayers_tizen_plugin.h
 
 dependencies:
-  audioplayers_platform_interface: ^7.1.0
+  audioplayers_platform_interface: ^7.1.1
   flutter:
     sdk: flutter
 
 dev_dependencies:
-  flame_lint: ^1.0.0
+  flame_lint: ^1.4.1

--- a/packages/audioplayers/tizen/src/audioplayers_tizen_plugin.cc
+++ b/packages/audioplayers/tizen/src/audioplayers_tizen_plugin.cc
@@ -268,10 +268,10 @@ class AudioplayersTizenPlugin : public flutter::Plugin {
       } else if (method_name == "emitError") {
         auto code = GetRequiredArg<std::string>(arguments, "code");
         auto message = GetRequiredArg<std::string>(arguments, "message");
-        event_sinks_[player_id]->Error(code, message, flutter::EncodableValue());
+        event_sinks_[player_id]->Error(code, message,
+                                       flutter::EncodableValue());
         result->Success();
-      }
-      else {
+      } else {
         result->NotImplemented();
       }
     } catch (const std::invalid_argument &error) {

--- a/packages/audioplayers/tizen/src/audioplayers_tizen_plugin.cc
+++ b/packages/audioplayers/tizen/src/audioplayers_tizen_plugin.cc
@@ -180,6 +180,12 @@ class AudioplayersTizenPlugin : public flutter::Plugin {
       if (method_name == "setSourceBytes") {
         std::vector<uint8_t> bytes =
             GetRequiredArg<std::vector<uint8_t>>(arguments, "bytes");
+
+        std::string mime_type;
+        if (GetValueFromEncodableMap(arguments, "mimeType", mime_type)) {
+          player->OnLog("mimeType parameter is not supported on Tizen.");
+        }
+
         player->SetDataSource(bytes);
         result->Success();
       } else if (method_name == "resume") {
@@ -212,6 +218,12 @@ class AudioplayersTizenPlugin : public flutter::Plugin {
         if (is_local && url.find(file_protocol_prefix) == 0) {
           url = url.substr(file_protocol_prefix.length());
         }
+
+        std::string mime_type;
+        if (GetValueFromEncodableMap(arguments, "mimeType", mime_type)) {
+          player->OnLog("mimeType parameter is not supported on Tizen.");
+        }
+
         player->SetUrl(url);
         result->Success();
       } else if (method_name == "setPlaybackRate") {
@@ -253,7 +265,13 @@ class AudioplayersTizenPlugin : public flutter::Plugin {
         auto message = GetRequiredArg<std::string>(arguments, "message");
         player->OnLog(message);
         result->Success();
-      } else {
+      } else if (method_name == "emitError") {
+        auto code = GetRequiredArg<std::string>(arguments, "code");
+        auto message = GetRequiredArg<std::string>(arguments, "message");
+        event_sinks_[player_id]->Error(code, message, flutter::EncodableValue());
+        result->Success();
+      }
+      else {
         result->NotImplemented();
       }
     } catch (const std::invalid_argument &error) {


### PR DESCRIPTION
Fix https://github.com/flutter-tizen/plugins/issues/977
Main changes:
* Update audioplayers to 6.6.0.
* Update audioplayers_platform_interface to 7.1.1.
* Update minimum Flutter and Dart version to 3.27 and 3.6.
* Update limitations in README.