### PR TITLE
[permission_handler] Update permission_handler to 12.0.1

### DIFF
--- a/packages/permission_handler/CHANGELOG.md
+++ b/packages/permission_handler/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 1.4.3
+
+* Update permission_handler to 12.0.1.
+* Update minimum Flutter and Dart version to 3.24 and 3.5.
+
 ## 1.4.2
 
 * Fix example's type issue.

--- a/packages/permission_handler/README.md
+++ b/packages/permission_handler/README.md
@@ -20,8 +20,8 @@ You can use this plugin to ask the user for runtime permissions if your app perf
 
    ```yaml
    dependencies:
-     permission_handler: ^12.0.0
-     permission_handler_tizen: ^1.4.2
+     permission_handler: ^12.0.1
+     permission_handler_tizen: ^1.4.3
    ```
 
    Then you can import `permission_handler` in your Dart code:

--- a/packages/permission_handler/example/pubspec.yaml
+++ b/packages/permission_handler/example/pubspec.yaml
@@ -3,8 +3,8 @@ description: Demonstrates how to use the permission_handler_tizen plugin.
 publish_to: "none"
 
 environment:
-  sdk: ">=3.1.0 <4.0.0"
-  flutter: ">=3.13.0"
+  sdk: ^3.5.0
+  flutter: ">=3.24.0"
 
 dependencies:
   baseflow_plugin_template:
@@ -13,7 +13,7 @@ dependencies:
       ref: temp_fix
   flutter:
     sdk: flutter
-  permission_handler: ^12.0.0
+  permission_handler: ^12.0.1
   permission_handler_tizen:
     path: ../
   url_launcher: ^6.1.0

--- a/packages/permission_handler/pubspec.yaml
+++ b/packages/permission_handler/pubspec.yaml
@@ -2,11 +2,11 @@ name: permission_handler_tizen
 description: Tizen implementation of the permission_handler plugin.
 homepage: https://github.com/flutter-tizen/plugins
 repository: https://github.com/flutter-tizen/plugins/tree/master/packages/permission_handler
-version: 1.4.2
+version: 1.4.3
 
 environment:
-  sdk: ">=3.1.0 <4.0.0"
-  flutter: ">=3.13.0"
+  sdk: ^3.5.0
+  flutter: ">=3.24.0"
 
 flutter:
   plugin:
@@ -21,4 +21,4 @@ dependencies:
   permission_handler_platform_interface: ^4.3.0
 
 dev_dependencies:
-  flutter_lints: ^1.0.4
+  flutter_lints: ^5.0.0


### PR DESCRIPTION
Main changes:

* Update permission_handler to 12.0.1.
* Update minimum Flutter and Dart version to 3.24 and 3.5.

Fix https://github.com/flutter-tizen/plugins/issues/1006