### PR TITLE
[video_player_avplay] Update the way to call the SetDisplay API

### DIFF
--- a/packages/video_player_avplay/CHANGELOG.md
+++ b/packages/video_player_avplay/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.8.10
+
+* Update the way to call the `SetDisplay` API.
+
 ## 0.8.9
 
 * [DASH] Fix seek freeze issue.

--- a/packages/video_player_avplay/README.md
+++ b/packages/video_player_avplay/README.md
@@ -12,7 +12,7 @@ To use this package, add `video_player_avplay` as a dependency in your `pubspec.
 
 ```yaml
 dependencies:
-  video_player_avplay: ^0.8.9
+  video_player_avplay: ^0.8.10
 ```
 
 Then you can import `video_player_avplay` in your Dart code:

--- a/packages/video_player_avplay/pubspec.yaml
+++ b/packages/video_player_avplay/pubspec.yaml
@@ -2,7 +2,7 @@ name: video_player_avplay
 description: Flutter plugin for displaying inline video on Tizen TV devices.
 homepage: https://github.com/flutter-tizen/plugins
 repository: https://github.com/flutter-tizen/plugins/tree/master/packages/video_player_avplay
-version: 0.8.9
+version: 0.8.10
 
 environment:
   sdk: ">=3.1.0 <4.0.0"

--- a/packages/video_player_avplay/tizen/src/plus_player.cc
+++ b/packages/video_player_avplay/tizen/src/plus_player.cc
@@ -440,7 +440,7 @@ bool PlusPlayer::SetDisplay() {
     return false;
   }
   bool ret = ::SetDisplay(player_, plusplayer::DisplayType::kOverlay,
-                          resource_id, x, y, width, height);
+                          resource_id, 0, 0, width, height);
   if (!ret) {
     LOG_ERROR("[PlusPlayer] Player fail to set display.");
     return false;


### PR DESCRIPTION
Main change:
* Update the way to call the `SetDisplay` API.


The coordinates (x, y) of `SetDisplay` are relative to the offset of the Window. The position of `SetDisplay` should overlap with the Window, so the offset value should always be 0.