### PR TITLE
[flutter_inappwebview] Fix crash on webview dispose

### DIFF
--- a/packages/flutter_inappwebview/CHANGELOG.md
+++ b/packages/flutter_inappwebview/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.1.1
+
+- Fix a crash when a webview is disposed.
+
 ## 0.1.0
 
 - Initial release of `flutter_inappwebview_tizen`.

--- a/packages/flutter_inappwebview/README.md
+++ b/packages/flutter_inappwebview/README.md
@@ -26,8 +26,7 @@ Add the internet privilege to the app manifest:
 ```yaml
 dependencies:
   flutter_inappwebview: ^6.1.5
-  flutter_inappwebview_tizen:
-    path: ../flutter_inappwebview_tizen
+  flutter_inappwebview_tizen: ^0.1.1
 ```
 
 ```dart

--- a/packages/flutter_inappwebview/pubspec.yaml
+++ b/packages/flutter_inappwebview/pubspec.yaml
@@ -2,7 +2,7 @@ name: flutter_inappwebview_tizen
 description: Tizen implementation of the flutter_inappwebview plugin.
 homepage: https://github.com/flutter-tizen/plugins
 repository: https://github.com/flutter-tizen/plugins/tree/master/packages/flutter_inappwebview
-version: 0.1.0
+version: 0.1.1
 
 environment:
   sdk: ">=3.8.0 <4.0.0"

--- a/packages/flutter_inappwebview/tizen/src/webview.cc
+++ b/packages/flutter_inappwebview/tizen/src/webview.cc
@@ -367,10 +367,8 @@ void WebView::Dispose() {
     evas_object_del(webview_instance_);
     webview_instance_ = nullptr;
   }
-  if (ecore_evas_) {
-    ecore_evas_free(ecore_evas_);
-    ecore_evas_ = nullptr;
-  }
+
+  ecore_evas_ = nullptr;
 
   // ewk_shutdown();
 }
@@ -541,7 +539,11 @@ bool WebView::InitWebView() {
   // temporarily comment out ewk_init() and ewk_shutdown(). It can be reverted
   // depending on updates to chromium-efl.
   // ewk_init();
-  ecore_evas_ = ecore_evas_new("wayland_egl", 0, 0, 1, 1, 0);
+  static Ecore_Evas* shared_ecore_evas = nullptr;
+  if (!shared_ecore_evas) {
+    shared_ecore_evas = ecore_evas_new("wayland_egl", 0, 0, 1, 1, 0);
+  }
+  ecore_evas_ = shared_ecore_evas;
   if (!ecore_evas_) {
     LOG_ERROR("Failed to create Ecore_Evas for the WebView.");
     return false;
@@ -549,7 +551,6 @@ bool WebView::InitWebView() {
 
   webview_instance_ = ewk_view_add(ecore_evas_get(ecore_evas_));
   if (!webview_instance_) {
-    ecore_evas_free(ecore_evas_);
     ecore_evas_ = nullptr;
     return false;
   }


### PR DESCRIPTION
If WebView releases the ecore_evas used per instance in Dispose(), the EGL display shared with the flutter-tizen renderer is turned off, causing a crash on the next frame.

Share a single Ecore_Evas across all WebViews and never release it.