### PR TITLE
[ci] Exclude flutter_inappwebview from integration_test

### DIFF
--- a/.github/recipe.yaml
+++ b/.github/recipe.yaml
@@ -3,7 +3,6 @@ plugins:
   connectivity_plus: ["tv-9.0"]
   device_info_plus: ["tv-9.0"]
   flutter_secure_storage: ["tv-9.0"]
-  flutter_inappwebview: ["tv-9.0"]
   flutter_tts: ["tv-9.0"]
   integration_test: ["tv-9.0"]
   keyboard_detection: ["tv-9.0"]
@@ -48,6 +47,10 @@ plugins:
   # https://github.com/flutter-tizen/plugins/pull/397#issuecomment-1139299838
   webview_flutter: []
   webview_flutter_lwe: []
+
+  # Temporarily disabled due to crash error on TV emulator.
+  # https://github.com/flutter-tizen/plugins/pull/1026#issuecomment-4592217771
+  flutter_inappwebview: []
 
   # Temporarily disabled due to the test runner not responding issue.
   google_maps_flutter: []


### PR DESCRIPTION
A crash was detected in the `evas_object_del(webview_instance_)` code during testing on the TV Emulator (local environment).
https://github.com/flutter-tizen/plugins/pull/1026#issuecomment-4592217771
It was confirmed that test passed results were not being aggregated in the existing CI.
Therefore, the TV Emulator is excluded from testing.
https://github.com/flutter-tizen/plugins/actions/runs/26739594969/job/78800202262#step:5:44