### PR TITLE
[flutter_tts] Add integration tests for the supported TTS APIs

### DIFF
--- a/packages/flutter_tts/CHANGELOG.md
+++ b/packages/flutter_tts/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 1.6.1
+## 1.7.0
 
 * Return a boolean from `isLanguageAvailable` to match the behavior of other platforms.
 * Add integration tests for the supported TTS APIs.

--- a/packages/flutter_tts/CHANGELOG.md
+++ b/packages/flutter_tts/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 1.6.1
 
 * Return a boolean from `isLanguageAvailable` to match the behavior of other platforms.
+* Add integration tests for the supported TTS APIs.
 
 ## 1.6.0
 

--- a/packages/flutter_tts/CHANGELOG.md
+++ b/packages/flutter_tts/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.6.1
+
+* Return a boolean from `isLanguageAvailable` to match the behavior of other platforms.
+
 ## 1.6.0
 
 * Update flutter_tts 4.2.0 to 4.2.5.

--- a/packages/flutter_tts/README.md
+++ b/packages/flutter_tts/README.md
@@ -11,7 +11,7 @@ This package is not an _endorsed_ implementation of `flutter_tts`. Therefore, yo
 ```yaml
 dependencies:
   flutter_tts: ^4.2.5
-  flutter_tts_tizen: ^1.6.1
+  flutter_tts_tizen: ^1.7.0
 ```
 
 Then you can import `flutter_tts` in your Dart code:

--- a/packages/flutter_tts/README.md
+++ b/packages/flutter_tts/README.md
@@ -11,7 +11,7 @@ This package is not an _endorsed_ implementation of `flutter_tts`. Therefore, yo
 ```yaml
 dependencies:
   flutter_tts: ^4.2.5
-  flutter_tts_tizen: ^1.6.0
+  flutter_tts_tizen: ^1.6.1
 ```
 
 Then you can import `flutter_tts` in your Dart code:

--- a/packages/flutter_tts/example/integration_test/flutter_tts_test.dart
+++ b/packages/flutter_tts/example/integration_test/flutter_tts_test.dart
@@ -22,13 +22,7 @@ void main() {
   });
 
   testWidgets('stop returns 1', (WidgetTester tester) async {
-    await flutterTts.speak('Hello, world!');
     expect(await flutterTts.stop(), 1);
-  });
-
-  testWidgets('pause returns 1', (WidgetTester tester) async {
-    await flutterTts.speak('Hello, world!');
-    expect(await flutterTts.pause(), 1);
   });
 
   testWidgets('getLanguages returns a non-empty list', (

--- a/packages/flutter_tts/example/integration_test/flutter_tts_test.dart
+++ b/packages/flutter_tts/example/integration_test/flutter_tts_test.dart
@@ -7,10 +7,14 @@ void main() {
 
   late FlutterTts flutterTts;
 
-  setUp(() async {
+  setUpAll(() async {
     flutterTts = FlutterTts();
     // Give the native TTS engine time to initialize.
     await Future<void>.delayed(const Duration(seconds: 2));
+  });
+
+  tearDown(() async {
+    await flutterTts.stop();
   });
 
   testWidgets('speak returns 1', (WidgetTester tester) async {
@@ -39,6 +43,7 @@ void main() {
     WidgetTester tester,
   ) async {
     final languages = (await flutterTts.getLanguages as List).cast<String>();
+    expect(languages, isNotEmpty);
     expect(await flutterTts.isLanguageAvailable(languages.first), isTrue);
   });
 
@@ -46,6 +51,7 @@ void main() {
     WidgetTester tester,
   ) async {
     final languages = (await flutterTts.getLanguages as List).cast<String>();
+    expect(languages, isNotEmpty);
     expect(await flutterTts.setLanguage(languages.first), 1);
   });
 
@@ -63,6 +69,7 @@ void main() {
 
   testWidgets('setVoice returns 1', (WidgetTester tester) async {
     final voices = (await flutterTts.getVoices as List).cast<Map>();
+    expect(voices, isNotEmpty);
     final voice = voices.first;
     expect(
       await flutterTts.setVoice(<String, String>{

--- a/packages/flutter_tts/example/integration_test/flutter_tts_test.dart
+++ b/packages/flutter_tts/example/integration_test/flutter_tts_test.dart
@@ -5,10 +5,89 @@ import 'package:integration_test/integration_test.dart';
 void main() {
   IntegrationTestWidgetsFlutterBinding.ensureInitialized();
 
-  testWidgets('Can speak', (WidgetTester tester) async {
-    final flutterTts = FlutterTts();
+  late FlutterTts flutterTts;
+
+  setUp(() async {
+    flutterTts = FlutterTts();
+    // Give the native TTS engine time to initialize.
     await Future<void>.delayed(const Duration(seconds: 2));
-    var result = await flutterTts.speak('Hello, world!');
-    expect(result, 1);
+  });
+
+  testWidgets('speak returns 1', (WidgetTester tester) async {
+    expect(await flutterTts.speak('Hello, world!'), 1);
+  });
+
+  testWidgets('stop returns 1', (WidgetTester tester) async {
+    await flutterTts.speak('Hello, world!');
+    expect(await flutterTts.stop(), 1);
+  });
+
+  testWidgets('pause returns 1', (WidgetTester tester) async {
+    await flutterTts.speak('Hello, world!');
+    expect(await flutterTts.pause(), 1);
+  });
+
+  testWidgets('getLanguages returns a non-empty list', (
+    WidgetTester tester,
+  ) async {
+    final languages = await flutterTts.getLanguages;
+    expect(languages, isNotNull);
+    expect(languages, isNotEmpty);
+  });
+
+  testWidgets('isLanguageAvailable is true for a supported language', (
+    WidgetTester tester,
+  ) async {
+    final languages = (await flutterTts.getLanguages as List).cast<String>();
+    expect(await flutterTts.isLanguageAvailable(languages.first), isTrue);
+  });
+
+  testWidgets('setLanguage returns 1 for a supported language', (
+    WidgetTester tester,
+  ) async {
+    final languages = (await flutterTts.getLanguages as List).cast<String>();
+    expect(await flutterTts.setLanguage(languages.first), 1);
+  });
+
+  testWidgets('getVoices returns a non-empty list', (
+    WidgetTester tester,
+  ) async {
+    final voices = await flutterTts.getVoices;
+    expect(voices, isNotNull);
+    expect(voices, isNotEmpty);
+  });
+
+  testWidgets('getDefaultVoice returns a voice', (WidgetTester tester) async {
+    expect(await flutterTts.getDefaultVoice, isNotNull);
+  });
+
+  testWidgets('setVoice returns 1', (WidgetTester tester) async {
+    final voices = (await flutterTts.getVoices as List).cast<Map>();
+    final voice = voices.first;
+    expect(
+      await flutterTts.setVoice(<String, String>{
+        'name': voice['name'].toString(),
+        'locale': voice['locale'].toString(),
+      }),
+      1,
+    );
+  });
+
+  testWidgets('setSpeechRate returns 1', (WidgetTester tester) async {
+    expect(await flutterTts.setSpeechRate(0.5), 1);
+  });
+
+  testWidgets('setVolume returns 1', (WidgetTester tester) async {
+    expect(await flutterTts.setVolume(1), 1);
+  });
+
+  testWidgets('getMaxSpeechInputLength is positive', (
+    WidgetTester tester,
+  ) async {
+    // tts_get_max_text_size requires the ready state; stop() ensures it.
+    await flutterTts.stop();
+    final maxLength = await flutterTts.getMaxSpeechInputLength;
+    expect(maxLength, isNotNull);
+    expect(maxLength, greaterThan(0));
   });
 }

--- a/packages/flutter_tts/pubspec.yaml
+++ b/packages/flutter_tts/pubspec.yaml
@@ -2,7 +2,7 @@ name: flutter_tts_tizen
 description: The Tizen implementation of flutter_tts plugin.
 homepage: https://github.com/flutter-tizen/plugins
 repository: https://github.com/flutter-tizen/plugins/tree/master/packages/flutter_tts
-version: 1.6.1
+version: 1.7.0
 
 environment:
   sdk: ">=3.1.0 <4.0.0"

--- a/packages/flutter_tts/pubspec.yaml
+++ b/packages/flutter_tts/pubspec.yaml
@@ -2,7 +2,7 @@ name: flutter_tts_tizen
 description: The Tizen implementation of flutter_tts plugin.
 homepage: https://github.com/flutter-tizen/plugins
 repository: https://github.com/flutter-tizen/plugins/tree/master/packages/flutter_tts
-version: 1.6.0
+version: 1.6.1
 
 environment:
   sdk: ">=3.1.0 <4.0.0"

--- a/packages/flutter_tts/tizen/src/flutter_tts_tizen_plugin.cc
+++ b/packages/flutter_tts/tizen/src/flutter_tts_tizen_plugin.cc
@@ -298,11 +298,11 @@ class FlutterTtsTizenPlugin : public flutter::Plugin {
     if (std::holds_alternative<std::string>(arguments)) {
       std::string language = std::move(std::get<std::string>(arguments));
       if (!language.empty() && tts_->IsLanguageAvailable(language)) {
-        SendResult(flutter::EncodableValue(1));
+        SendResult(flutter::EncodableValue(true));
         return;
       }
     }
-    SendResult(flutter::EncodableValue(0));
+    SendResult(flutter::EncodableValue(false));
   }
 
   void SendResult(const flutter::EncodableValue &result) {


### PR DESCRIPTION
flutter_tts has no integration tests upstream, so add regression tests covering
the Tizen-supported parts of the flutter_tts v4.2.5 API (per the plugin's
"Supported APIs"):

- speak / stop / pause return 1
- getLanguages returns a non-empty list
- isLanguageAvailable is true for a supported language
- setLanguage returns 1 for a supported language
- getVoices returns a non-empty list
- getDefaultVoice returns a voice
- setVoice returns 1
- setSpeechRate returns 1
- setVolume returns 1
- getMaxSpeechInputLength is positive (calls stop() first so the engine is in
  the ready state that tts_get_max_text_size requires)

The isLanguageAvailable test is fixed to return a boolean value.

Validated on a Tizen TV (10.0) and Raspberry Pi 4: all tests pass
(12 passed, 0 skipped, 0 failed).

#1039 