### PR TITLE
[messageport] Add regression integration tests

### DIFF
--- a/packages/messageport/CHANGELOG.md
+++ b/packages/messageport/CHANGELOG.md
@@ -3,6 +3,7 @@
 * Fix new lint warnings.
 * Update minimum Flutter and Dart version to 3.13 and 3.1.
 * Update code format.
+* Add 5 integration test cases.
 
 ## 0.3.2
 

--- a/packages/messageport/example/integration_test/messageport_test.dart
+++ b/packages/messageport/example/integration_test/messageport_test.dart
@@ -110,6 +110,53 @@ void main() {
     await localPort.unregister();
   }, timeout: const Timeout(Duration(seconds: 5)));
 
+  group('LocalPort lifecycle', () {
+    testWidgets('registered reflects the register/unregister lifecycle', (
+      WidgetTester tester,
+    ) async {
+      final LocalPort localPort = await LocalPort.create(kTestPort);
+      expect(localPort.portName, equals(kTestPort));
+      expect(localPort.registered, isFalse);
+
+      localPort.register((dynamic message, [RemotePort? remotePort]) {});
+      expect(localPort.registered, isTrue);
+
+      await localPort.unregister();
+      expect(localPort.registered, isFalse);
+    }, timeout: const Timeout(Duration(seconds: 5)));
+
+    testWidgets('register throws when the port is already registered', (
+      WidgetTester tester,
+    ) async {
+      final LocalPort localPort = await LocalPort.create(kTestPort);
+      localPort.register((dynamic message, [RemotePort? remotePort]) {});
+
+      expect(
+        () =>
+            localPort.register((dynamic message, [RemotePort? remotePort]) {}),
+        throwsException,
+      );
+
+      await localPort.unregister();
+    }, timeout: const Timeout(Duration(seconds: 5)));
+
+    testWidgets('unregister is safe when not registered and when repeated', (
+      WidgetTester tester,
+    ) async {
+      final LocalPort localPort = await LocalPort.create(kTestPort);
+
+      // Unregistering before any registration must not throw.
+      await localPort.unregister();
+      expect(localPort.registered, isFalse);
+
+      // Unregister is safe to call repeatedly after a registration.
+      localPort.register((dynamic message, [RemotePort? remotePort]) {});
+      await localPort.unregister();
+      await localPort.unregister();
+      expect(localPort.registered, isFalse);
+    }, timeout: const Timeout(Duration(seconds: 5)));
+  });
+
   group('Types test', () {
     late LocalPort localPort;
     late RemotePort remotePort;
@@ -170,6 +217,19 @@ void main() {
 
     testWidgets('map', (WidgetTester tester) async {
       final Map<String, int> value = <String, int>{'a': 5, 'b': 12};
+      await checkForMessage<Map<dynamic, dynamic>>(value);
+    }, timeout: const Timeout(Duration(seconds: 5)));
+
+    testWidgets('empty string', (WidgetTester tester) async {
+      const String value = '';
+      await checkForMessage<String>(value);
+    }, timeout: const Timeout(Duration(seconds: 5)));
+
+    testWidgets('nested collection', (WidgetTester tester) async {
+      final Map<String, dynamic> value = <String, dynamic>{
+        'numbers': <int>[1, 2, 3],
+        'nested': <String, String>{'key': 'value'},
+      };
       await checkForMessage<Map<dynamic, dynamic>>(value);
     }, timeout: const Timeout(Duration(seconds: 5)));
   });

--- a/packages/messageport/example/integration_test/messageport_test.dart
+++ b/packages/messageport/example/integration_test/messageport_test.dart
@@ -115,6 +115,8 @@ void main() {
       WidgetTester tester,
     ) async {
       final LocalPort localPort = await LocalPort.create(kTestPort);
+      // Ensure the port is unregistered even if an assertion below fails.
+      addTearDown(localPort.unregister);
       expect(localPort.portName, equals(kTestPort));
       expect(localPort.registered, isFalse);
 
@@ -129,6 +131,7 @@ void main() {
       WidgetTester tester,
     ) async {
       final LocalPort localPort = await LocalPort.create(kTestPort);
+      addTearDown(localPort.unregister);
       localPort.register((dynamic message, [RemotePort? remotePort]) {});
 
       expect(
@@ -136,14 +139,13 @@ void main() {
             localPort.register((dynamic message, [RemotePort? remotePort]) {}),
         throwsException,
       );
-
-      await localPort.unregister();
     }, timeout: const Timeout(Duration(seconds: 5)));
 
     testWidgets('unregister is safe when not registered and when repeated', (
       WidgetTester tester,
     ) async {
       final LocalPort localPort = await LocalPort.create(kTestPort);
+      addTearDown(localPort.unregister);
 
       // Unregistering before any registration must not throw.
       await localPort.unregister();


### PR DESCRIPTION
Add 5 integration test cases covering previously untested public API:

- LocalPort.registered reflects the register/unregister lifecycle.
- LocalPort.register throws when the port is already registered.
- LocalPort.unregister is a no-op when the port is not registered and is safe to call repeatedly.
- Round-trip an empty string message.
- Round-trip a nested collection (list and map) message.

This is a Tizen-exclusive plugin with no upstream package. Test-only change, recorded under the existing NEXT changelog entry without a version bump. Validated on a Raspberry Pi 4 device and the TV emulator: 19 passed, 0 failed.

https://github.com/flutter-tizen/plugins/issues/1039