### PR TITLE
[tizen_package_manager] Remove Ecore API

### DIFF
--- a/packages/tizen_package_manager/CHANGELOG.md
+++ b/packages/tizen_package_manager/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.4.2
+
+* Remove Ecore API.
+
 ## 0.4.1
 
 * Fix error handling in `getPackageSizeInfo`.

--- a/packages/tizen_package_manager/README.md
+++ b/packages/tizen_package_manager/README.md
@@ -10,7 +10,7 @@ To use this package, add `tizen_package_manager` as a dependency in your `pubspe
 
 ```yaml
 dependencies:
-  tizen_package_manager: ^0.4.1
+  tizen_package_manager: ^0.4.2
 ```
 
 ### Retrieving specific package info

--- a/packages/tizen_package_manager/pubspec.yaml
+++ b/packages/tizen_package_manager/pubspec.yaml
@@ -2,7 +2,7 @@ name: tizen_package_manager
 description: Tizen package manager APIs. Used to get information about packages installed on a Tizen device.
 homepage: https://github.com/flutter-tizen/plugins
 repository: https://github.com/flutter-tizen/plugins/tree/master/packages/tizen_package_manager
-version: 0.4.1
+version: 0.4.2
 
 environment:
   sdk: ">=3.1.0 <4.0.0"

--- a/packages/tizen_package_manager/tizen/src/tizen_package_manager_plugin.cc
+++ b/packages/tizen_package_manager/tizen/src/tizen_package_manager_plugin.cc
@@ -4,7 +4,6 @@
 
 #include "tizen_package_manager_plugin.h"
 
-#include <Ecore.h>
 #include <flutter/encodable_value.h>
 #include <flutter/event_channel.h>
 #include <flutter/event_sink.h>
@@ -12,12 +11,14 @@
 #include <flutter/method_channel.h>
 #include <flutter/plugin_registrar.h>
 #include <flutter/standard_method_codec.h>
+#include <glib.h>
 
 #include <cstdint>
 #include <memory>
 #include <string>
 #include <vector>
 
+#include "log.h"
 #include "tizen_package_manager.h"
 
 namespace {
@@ -244,8 +245,10 @@ class TizenPackageManagerPlugin : public flutter::Plugin {
     // TizenPackageManager::GetAllPackagesInfo() is an expensive operation and
     // might cause unresponsiveness on low-end devices if run on the platform
     // thread.
-    ecore_thread_run(
-        [](void *data, Ecore_Thread *thread) {
+    GError *error = nullptr;
+    GThread *thread = g_thread_try_new(
+        "flutter_tizen_plugins_tizen_package_manager_all_packages",
+        [](gpointer data) -> gpointer {
           auto *result = static_cast<FlMethodResult *>(data);
 
           TizenPackageManager &package_manager =
@@ -264,14 +267,22 @@ class TizenPackageManagerPlugin : public flutter::Plugin {
                           package_manager.GetLastErrorString());
           }
           delete result;
+          return nullptr;
         },
-        nullptr,
-        [](void *data, Ecore_Thread *thread) {
-          auto *result = static_cast<FlMethodResult *>(data);
-          result->Error("Operation failed", "Failed to start a thread.");
-          delete result;
-        },
-        result.release());
+        result.get(), &error);
+
+    if (thread == nullptr) {
+      LOG_ERROR("Failed to create a thread: %s",
+                error ? error->message : "unknown error");
+      if (error) {
+        g_error_free(error);
+      }
+      result->Error("Operation failed", "Failed to start a thread.");
+      return;
+    }
+
+    result.release();
+    g_thread_unref(thread);
   }
 
   void GetPackageSizeInfo(const flutter::EncodableMap *arguments,


### PR DESCRIPTION
Replace ecore_thread_run in GetAllPackagesInfo with a GLib worker thread created via g_thread_try_new.

https://github.com/flutter-tizen/embedder/issues/146