### PR TITLE
[tizen_app_manager] Add integration tests

### DIFF
--- a/packages/tizen_app_manager/CHANGELOG.md
+++ b/packages/tizen_app_manager/CHANGELOG.md
@@ -1,4 +1,4 @@
-## NEXT
+## 0.2.5
 
 * Fix memory leak in `AppRunningContext.packageId` by freeing the native string
   returned by `app_context_get_package_id`.

--- a/packages/tizen_app_manager/CHANGELOG.md
+++ b/packages/tizen_app_manager/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## NEXT
 
+* Fix memory leak in `AppRunningContext.packageId` by freeing the native string
+  returned by `app_context_get_package_id`.
 * Add 9 integration test cases.
 
 ## 0.2.4

--- a/packages/tizen_app_manager/CHANGELOG.md
+++ b/packages/tizen_app_manager/CHANGELOG.md
@@ -1,3 +1,7 @@
+## NEXT
+
+* Add 9 integration test cases.
+
 ## 0.2.4
 
 * Update code format.

--- a/packages/tizen_app_manager/README.md
+++ b/packages/tizen_app_manager/README.md
@@ -10,7 +10,7 @@ To use this package, add `tizen_app_manager` as a dependency in your `pubspec.ya
 
 ```yaml
 dependencies:
-  tizen_app_manager: ^0.2.4
+  tizen_app_manager: ^0.2.5
 ```
 
 ### Retrieving current app info

--- a/packages/tizen_app_manager/example/integration_test/tizen_app_manager_test.dart
+++ b/packages/tizen_app_manager/example/integration_test/tizen_app_manager_test.dart
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:integration_test/integration_test.dart';
 import 'package:tizen_app_manager/tizen_app_manager.dart';
@@ -34,5 +35,69 @@ void main() {
     // expect(context.appState, AppState.foreground);
     expect(context.processId, isPositive);
     expect(context.isTerminated, isFalse);
+  });
+
+  group('AppManager', () {
+    group('getInstalledApps', () {
+      testWidgets('returns non-empty list', (WidgetTester _) async {
+        final List<AppInfo> apps = await AppManager.getInstalledApps();
+        expect(apps, isNotEmpty);
+      });
+
+      testWidgets('includes the current app', (WidgetTester _) async {
+        final String appId = await AppManager.currentAppId;
+        final List<AppInfo> apps = await AppManager.getInstalledApps();
+        expect(apps.any((AppInfo app) => app.appId == appId), isTrue);
+      });
+    });
+
+    group('isRunning', () {
+      testWidgets('returns true for running app', (WidgetTester _) async {
+        final String appId = await AppManager.currentAppId;
+        expect(await AppManager.isRunning(appId), isTrue);
+      });
+
+      testWidgets('returns false for non-running app', (WidgetTester _) async {
+        expect(
+          await AppManager.isRunning('org.tizen.nonexistent'),
+          isFalse,
+        );
+      });
+
+      testWidgets('throws ArgumentError for empty appId', (WidgetTester _) async {
+        await expectLater(AppManager.isRunning(''), throwsArgumentError);
+      });
+    });
+
+    group('getAppInfo', () {
+      testWidgets('returns all AppInfo fields', (WidgetTester _) async {
+        final String appId = await AppManager.currentAppId;
+        final AppInfo appInfo = await AppManager.getAppInfo(appId);
+        expect(appInfo.appId, appId);
+        expect(appInfo.executablePath, isNotEmpty);
+        expect(appInfo.sharedResourcePath, isNotEmpty);
+      });
+
+      testWidgets('throws ArgumentError for empty appId', (WidgetTester _) async {
+        await expectLater(AppManager.getAppInfo(''), throwsArgumentError);
+      });
+    });
+  });
+
+  group('AppRunningContext', () {
+    testWidgets('packageId matches current app', (WidgetTester _) async {
+      final String appId = await AppManager.currentAppId;
+      final AppRunningContext context = AppRunningContext(appId: appId);
+      expect(context.packageId, 'org.tizen.tizen_app_manager_example');
+    });
+
+    testWidgets('throws PlatformException for non-running appId', (
+      WidgetTester _,
+    ) async {
+      expect(
+        () => AppRunningContext(appId: 'org.tizen.nonexistent'),
+        throwsA(isA<PlatformException>()),
+      );
+    });
   });
 }

--- a/packages/tizen_app_manager/example/integration_test/tizen_app_manager_test.dart
+++ b/packages/tizen_app_manager/example/integration_test/tizen_app_manager_test.dart
@@ -64,7 +64,8 @@ void main() {
         );
       });
 
-      testWidgets('throws ArgumentError for empty appId', (WidgetTester _) async {
+      testWidgets('throws ArgumentError for empty appId',
+          (WidgetTester _) async {
         await expectLater(AppManager.isRunning(''), throwsArgumentError);
       });
     });
@@ -78,7 +79,8 @@ void main() {
         expect(appInfo.sharedResourcePath, isNotEmpty);
       });
 
-      testWidgets('throws ArgumentError for empty appId', (WidgetTester _) async {
+      testWidgets('throws ArgumentError for empty appId',
+          (WidgetTester _) async {
         await expectLater(AppManager.getAppInfo(''), throwsArgumentError);
       });
     });

--- a/packages/tizen_app_manager/lib/src/app_context.dart
+++ b/packages/tizen_app_manager/lib/src/app_context.dart
@@ -73,7 +73,10 @@ class AppContext {
       if (ret != 0) {
         _throwPlatformException(ret);
       }
-      return packageId.value.toDartString();
+      final Pointer<Char> pkgId = packageId.value;
+      final String result = pkgId.toDartString();
+      malloc.free(pkgId);
+      return result;
     });
   }
 

--- a/packages/tizen_app_manager/pubspec.yaml
+++ b/packages/tizen_app_manager/pubspec.yaml
@@ -2,7 +2,7 @@ name: tizen_app_manager
 description: Tizen application manager APIs. Used to get app info and app running context on a Tizen device.
 homepage: https://github.com/flutter-tizen/plugins
 repository: https://github.com/flutter-tizen/plugins/tree/master/packages/tizen_app_manager
-version: 0.2.4
+version: 0.2.5
 
 environment:
   sdk: ">=3.1.0 <4.0.0"


### PR DESCRIPTION
Fix a memory leak in AppRunningContext.packageId where the native string returned by app_context_get_package_id was not freed, and add 9 integration test cases covering AppManager and AppRunningContext APIs.

https://github.com/flutter-tizen/plugins/issues/1039