### PR TITLE
[tizen_audio_manager] Add regression integration tests

### DIFF
--- a/packages/tizen_audio_manager/CHANGELOG.md
+++ b/packages/tizen_audio_manager/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Update code format.
 * Add a 3-second delay in integration_test to support the media volume reset
   feature of the Tizen Volume app for hearing protection.
+* Add 2 integration test cases.
 
 ## 0.1.1
 

--- a/packages/tizen_audio_manager/example/integration_test/audio_manager_test.dart
+++ b/packages/tizen_audio_manager/example/integration_test/audio_manager_test.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'dart:async';
+
 import 'package:flutter_test/flutter_test.dart';
 import 'package:integration_test/integration_test.dart';
 import 'package:tizen_audio_manager/tizen_audio_manager.dart';
@@ -203,5 +205,43 @@ void main() {
     await AudioManager.volumeController.setLevel(AudioVolumeType.voip, 0);
     level = await AudioManager.volumeController.getLevel(AudioVolumeType.voip);
     expect(level, equals(0));
+  });
+
+  testWidgets('currentPlaybackType returns a valid AudioVolumeType',
+      (WidgetTester tester) async {
+    final AudioVolumeType type =
+        await AudioManager.volumeController.currentPlaybackType;
+    expect(AudioVolumeType.values, contains(type));
+  });
+
+  testWidgets('onChanged emits VolumeChangedEvent when volume is changed',
+      (WidgetTester tester) async {
+    final int originalLevel =
+        await AudioManager.volumeController.getLevel(AudioVolumeType.system);
+    final int maxLevel =
+        await AudioManager.volumeController.getMaxLevel(AudioVolumeType.system);
+    final int targetLevel = originalLevel == maxLevel ? 0 : maxLevel;
+
+    final Completer<VolumeChangedEvent> completer =
+        Completer<VolumeChangedEvent>();
+    final StreamSubscription<VolumeChangedEvent> subscription =
+        AudioManager.volumeController.onChanged
+            .listen((VolumeChangedEvent event) {
+      if (event.type == AudioVolumeType.system && !completer.isCompleted) {
+        completer.complete(event);
+      }
+    });
+
+    await AudioManager.volumeController.setLevel(
+        AudioVolumeType.system, targetLevel);
+    final VolumeChangedEvent event =
+        await completer.future.timeout(const Duration(seconds: 5));
+
+    expect(event.type, equals(AudioVolumeType.system));
+    expect(event.level, equals(targetLevel));
+
+    await AudioManager.volumeController.setLevel(
+        AudioVolumeType.system, originalLevel);
+    await subscription.cancel();
   });
 }

--- a/packages/tizen_audio_manager/example/integration_test/audio_manager_test.dart
+++ b/packages/tizen_audio_manager/example/integration_test/audio_manager_test.dart
@@ -224,24 +224,26 @@ void main() {
 
     final Completer<VolumeChangedEvent> completer =
         Completer<VolumeChangedEvent>();
-    final StreamSubscription<VolumeChangedEvent> subscription =
-        AudioManager.volumeController.onChanged
-            .listen((VolumeChangedEvent event) {
+    final StreamSubscription<VolumeChangedEvent> subscription = AudioManager
+        .volumeController.onChanged
+        .listen((VolumeChangedEvent event) {
       if (event.type == AudioVolumeType.system && !completer.isCompleted) {
         completer.complete(event);
       }
     });
 
-    await AudioManager.volumeController.setLevel(
-        AudioVolumeType.system, targetLevel);
-    final VolumeChangedEvent event =
-        await completer.future.timeout(const Duration(seconds: 5));
+    try {
+      await AudioManager.volumeController
+          .setLevel(AudioVolumeType.system, targetLevel);
+      final VolumeChangedEvent event =
+          await completer.future.timeout(const Duration(seconds: 5));
 
-    expect(event.type, equals(AudioVolumeType.system));
-    expect(event.level, equals(targetLevel));
-
-    await AudioManager.volumeController.setLevel(
-        AudioVolumeType.system, originalLevel);
-    await subscription.cancel();
+      expect(event.type, equals(AudioVolumeType.system));
+      expect(event.level, equals(targetLevel));
+    } finally {
+      await AudioManager.volumeController
+          .setLevel(AudioVolumeType.system, originalLevel);
+      await subscription.cancel();
+    }
   });
 }


### PR DESCRIPTION
Add 2 integration test cases for previously untested public API:
- currentPlaybackType returns a valid AudioVolumeType: verifies the getter returns a recognized enum value.
- onChanged emits VolumeChangedEvent when volume is changed: subscribes to the stream, triggers a volume change via setLevel, and asserts the emitted event carries the correct type and level.

All 19 tests pass on the Samsung TV emulator (T-samsung-10.0-x86_64).

https://github.com/flutter-tizen/plugins/issues/1039