### PR TITLE
[tizen_package_manager] Add integration tests and fix icon path handling

### DIFF
--- a/packages/tizen_package_manager/CHANGELOG.md
+++ b/packages/tizen_package_manager/CHANGELOG.md
@@ -1,3 +1,7 @@
+## NEXT
+
+* Add 13 integration test cases.
+
 ## 0.4.2
 
 * Remove Ecore API.

--- a/packages/tizen_package_manager/CHANGELOG.md
+++ b/packages/tizen_package_manager/CHANGELOG.md
@@ -1,5 +1,7 @@
-## NEXT
+## 0.4.3
 
+* Return a null icon path (instead of an empty string) when a package has no
+  icon, and ignore `package_info_get_icon` failures since the icon is optional.
 * Add 13 integration test cases.
 
 ## 0.4.2

--- a/packages/tizen_package_manager/CHANGELOG.md
+++ b/packages/tizen_package_manager/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 * Return a null icon path (instead of an empty string) when a package has no
   icon, and ignore `package_info_get_icon` failures since the icon is optional.
-* Add 13 integration test cases.
+* Add 12 integration test cases.
 
 ## 0.4.2
 

--- a/packages/tizen_package_manager/example/integration_test/tizen_package_manager_test.dart
+++ b/packages/tizen_package_manager/example/integration_test/tizen_package_manager_test.dart
@@ -42,14 +42,6 @@ void main() {
   });
 
   group('PackageInfo fields', () {
-    testWidgets('installedStorageType is a valid StorageType value', (
-      WidgetTester tester,
-    ) async {
-      final PackageInfo info =
-          await PackageManager.getPackageInfo(currentPackageId);
-      expect(StorageType.values, contains(info.installedStorageType));
-    });
-
     testWidgets('iconPath is null or a non-empty string', (
       WidgetTester tester,
     ) async {
@@ -150,8 +142,11 @@ void main() {
     });
   });
 
+  // These only verify that subscribing to and cancelling the stream does not
+  // throw. Actually exercising an event requires installing/uninstalling/
+  // updating a real package on the device, which is out of scope here.
   group('event streams', () {
-    testWidgets('onInstallProgressChanged can be listened to without error', (
+    testWidgets('can subscribe to onInstallProgressChanged and cancel', (
       WidgetTester tester,
     ) async {
       final StreamSubscription<PackageEvent> subscription =
@@ -159,7 +154,7 @@ void main() {
       await subscription.cancel();
     });
 
-    testWidgets('onUninstallProgressChanged can be listened to without error', (
+    testWidgets('can subscribe to onUninstallProgressChanged and cancel', (
       WidgetTester tester,
     ) async {
       final StreamSubscription<PackageEvent> subscription =
@@ -167,7 +162,7 @@ void main() {
       await subscription.cancel();
     });
 
-    testWidgets('onUpdateProgressChanged can be listened to without error', (
+    testWidgets('can subscribe to onUpdateProgressChanged and cancel', (
       WidgetTester tester,
     ) async {
       final StreamSubscription<PackageEvent> subscription =

--- a/packages/tizen_package_manager/example/integration_test/tizen_package_manager_test.dart
+++ b/packages/tizen_package_manager/example/integration_test/tizen_package_manager_test.dart
@@ -55,9 +55,7 @@ void main() {
     ) async {
       final PackageInfo info =
           await PackageManager.getPackageInfo(currentPackageId);
-      if (info.iconPath != null) {
-        expect(info.iconPath, isNotEmpty);
-      }
+      expect(info.iconPath, anyOf(isNull, isNotEmpty));
     });
   });
 
@@ -77,25 +75,17 @@ void main() {
   });
 
   group('getPackagesInfo list items', () {
-    testWidgets('each PackageInfo item has valid field types', (
+    testWidgets('each PackageInfo item has valid field values', (
       WidgetTester tester,
     ) async {
       final List<PackageInfo> infos = await PackageManager.getPackagesInfo();
       expect(infos, isNotEmpty);
       for (final PackageInfo info in infos) {
-        expect(info.packageId, isA<String>());
+        // Field types are already guaranteed by PackageInfo.fromMap (it casts
+        // each field), so only the value-level expectations are asserted here.
         expect(info.packageId, isNotEmpty);
-        expect(info.label, isA<String>());
-        expect(info.version, isA<String>());
         expect(info.version, isNotEmpty);
-        expect(PackageType.values, contains(info.packageType));
-        expect(StorageType.values, contains(info.installedStorageType));
-        expect(info.isSystem, isA<bool>());
-        expect(info.isPreloaded, isA<bool>());
-        expect(info.isRemovable, isA<bool>());
-        if (info.iconPath != null) {
-          expect(info.iconPath, isNotEmpty);
-        }
+        expect(info.iconPath, anyOf(isNull, isNotEmpty));
       }
     });
 

--- a/packages/tizen_package_manager/example/integration_test/tizen_package_manager_test.dart
+++ b/packages/tizen_package_manager/example/integration_test/tizen_package_manager_test.dart
@@ -2,6 +2,9 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'dart:async';
+
+import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:integration_test/integration_test.dart';
 import 'package:tizen_package_manager/tizen_package_manager.dart';
@@ -36,5 +39,141 @@ void main() {
   ) async {
     final List<PackageInfo> infos = await PackageManager.getPackagesInfo();
     expect(infos.isNotEmpty, true);
+  });
+
+  group('PackageInfo fields', () {
+    testWidgets('installedStorageType is a valid StorageType value', (
+      WidgetTester tester,
+    ) async {
+      final PackageInfo info =
+          await PackageManager.getPackageInfo(currentPackageId);
+      expect(StorageType.values, contains(info.installedStorageType));
+    });
+
+    testWidgets('iconPath is null or a non-empty string', (
+      WidgetTester tester,
+    ) async {
+      final PackageInfo info =
+          await PackageManager.getPackageInfo(currentPackageId);
+      if (info.iconPath != null) {
+        expect(info.iconPath, isNotEmpty);
+      }
+    });
+  });
+
+  group('PackageSizeInfo fields', () {
+    testWidgets('all size fields are non-negative', (
+      WidgetTester tester,
+    ) async {
+      final PackageSizeInfo info =
+          await PackageManager.getPackageSizeInfo(currentPackageId);
+      expect(info.dataSize, greaterThanOrEqualTo(0));
+      expect(info.cacheSize, greaterThanOrEqualTo(0));
+      expect(info.appSize, greaterThanOrEqualTo(0));
+      expect(info.externalDataSize, greaterThanOrEqualTo(0));
+      expect(info.externalCacheSize, greaterThanOrEqualTo(0));
+      expect(info.externalAppSize, greaterThanOrEqualTo(0));
+    });
+  });
+
+  group('getPackagesInfo list items', () {
+    testWidgets('each PackageInfo item has valid field types', (
+      WidgetTester tester,
+    ) async {
+      final List<PackageInfo> infos = await PackageManager.getPackagesInfo();
+      expect(infos, isNotEmpty);
+      for (final PackageInfo info in infos) {
+        expect(info.packageId, isA<String>());
+        expect(info.packageId, isNotEmpty);
+        expect(info.label, isA<String>());
+        expect(info.version, isA<String>());
+        expect(info.version, isNotEmpty);
+        expect(PackageType.values, contains(info.packageType));
+        expect(StorageType.values, contains(info.installedStorageType));
+        expect(info.isSystem, isA<bool>());
+        expect(info.isPreloaded, isA<bool>());
+        expect(info.isRemovable, isA<bool>());
+        if (info.iconPath != null) {
+          expect(info.iconPath, isNotEmpty);
+        }
+      }
+    });
+
+    testWidgets('getPackagesInfo contains current package', (
+      WidgetTester tester,
+    ) async {
+      final List<PackageInfo> infos = await PackageManager.getPackagesInfo();
+      final Iterable<String> ids = infos.map((PackageInfo i) => i.packageId);
+      expect(ids, contains(currentPackageId));
+    });
+  });
+
+  group('getPackageInfo error paths', () {
+    test('throws ArgumentError for empty packageId', () async {
+      expect(
+        () => PackageManager.getPackageInfo(''),
+        throwsA(isA<ArgumentError>()),
+      );
+    });
+
+    test('throws PlatformException for invalid packageId', () async {
+      expect(
+        () => PackageManager.getPackageInfo('invalid.package.id.that.does.not.exist'),
+        throwsA(isA<PlatformException>()),
+      );
+    });
+  });
+
+  group('getPackageSizeInfo error paths', () {
+    test('throws ArgumentError for empty packageId', () async {
+      expect(
+        () => PackageManager.getPackageSizeInfo(''),
+        throwsA(isA<ArgumentError>()),
+      );
+    });
+
+    // NOTE: The Tizen package_manager_get_package_size_info API does not
+    // return an error for a non-existent package ID; it silently returns
+    // zero-valued size info. This is a platform limitation, so no
+    // PlatformException test is included here.
+  });
+
+  group('install error paths', () {
+    test('throws ArgumentError for empty packagePath', () async {
+      expect(
+        () => PackageManager.install(''),
+        throwsA(isA<ArgumentError>()),
+      );
+    });
+  });
+
+  group('uninstall error paths', () {
+    test('throws ArgumentError for empty packageId', () async {
+      expect(
+        () => PackageManager.uninstall(''),
+        throwsA(isA<ArgumentError>()),
+      );
+    });
+  });
+
+  group('event streams', () {
+    test('onInstallProgressChanged can be listened to without error', () async {
+      final StreamSubscription<PackageEvent> subscription =
+          PackageManager.onInstallProgressChanged.listen(null);
+      await subscription.cancel();
+    });
+
+    test('onUninstallProgressChanged can be listened to without error',
+        () async {
+      final StreamSubscription<PackageEvent> subscription =
+          PackageManager.onUninstallProgressChanged.listen(null);
+      await subscription.cancel();
+    });
+
+    test('onUpdateProgressChanged can be listened to without error', () async {
+      final StreamSubscription<PackageEvent> subscription =
+          PackageManager.onUpdateProgressChanged.listen(null);
+      await subscription.cancel();
+    });
   });
 }

--- a/packages/tizen_package_manager/example/integration_test/tizen_package_manager_test.dart
+++ b/packages/tizen_package_manager/example/integration_test/tizen_package_manager_test.dart
@@ -109,27 +109,32 @@ void main() {
   });
 
   group('getPackageInfo error paths', () {
-    test('throws ArgumentError for empty packageId', () async {
-      expect(
-        () => PackageManager.getPackageInfo(''),
-        throwsA(isA<ArgumentError>()),
+    testWidgets('throws ArgumentError for empty packageId', (
+      WidgetTester tester,
+    ) async {
+      await expectLater(
+        PackageManager.getPackageInfo(''),
+        throwsArgumentError,
       );
     });
 
-    test('throws PlatformException for invalid packageId', () async {
-      expect(
-        () => PackageManager.getPackageInfo(
-            'invalid.package.id.that.does.not.exist'),
+    testWidgets('throws PlatformException for invalid packageId', (
+      WidgetTester tester,
+    ) async {
+      await expectLater(
+        PackageManager.getPackageInfo('invalid.package.id.that.does.not.exist'),
         throwsA(isA<PlatformException>()),
       );
     });
   });
 
   group('getPackageSizeInfo error paths', () {
-    test('throws ArgumentError for empty packageId', () async {
-      expect(
-        () => PackageManager.getPackageSizeInfo(''),
-        throwsA(isA<ArgumentError>()),
+    testWidgets('throws ArgumentError for empty packageId', (
+      WidgetTester tester,
+    ) async {
+      await expectLater(
+        PackageManager.getPackageSizeInfo(''),
+        throwsArgumentError,
       );
     });
 
@@ -140,38 +145,41 @@ void main() {
   });
 
   group('install error paths', () {
-    test('throws ArgumentError for empty packagePath', () async {
-      expect(
-        () => PackageManager.install(''),
-        throwsA(isA<ArgumentError>()),
-      );
+    testWidgets('throws ArgumentError for empty packagePath', (
+      WidgetTester tester,
+    ) async {
+      await expectLater(PackageManager.install(''), throwsArgumentError);
     });
   });
 
   group('uninstall error paths', () {
-    test('throws ArgumentError for empty packageId', () async {
-      expect(
-        () => PackageManager.uninstall(''),
-        throwsA(isA<ArgumentError>()),
-      );
+    testWidgets('throws ArgumentError for empty packageId', (
+      WidgetTester tester,
+    ) async {
+      await expectLater(PackageManager.uninstall(''), throwsArgumentError);
     });
   });
 
   group('event streams', () {
-    test('onInstallProgressChanged can be listened to without error', () async {
+    testWidgets('onInstallProgressChanged can be listened to without error', (
+      WidgetTester tester,
+    ) async {
       final StreamSubscription<PackageEvent> subscription =
           PackageManager.onInstallProgressChanged.listen(null);
       await subscription.cancel();
     });
 
-    test('onUninstallProgressChanged can be listened to without error',
-        () async {
+    testWidgets('onUninstallProgressChanged can be listened to without error', (
+      WidgetTester tester,
+    ) async {
       final StreamSubscription<PackageEvent> subscription =
           PackageManager.onUninstallProgressChanged.listen(null);
       await subscription.cancel();
     });
 
-    test('onUpdateProgressChanged can be listened to without error', () async {
+    testWidgets('onUpdateProgressChanged can be listened to without error', (
+      WidgetTester tester,
+    ) async {
       final StreamSubscription<PackageEvent> subscription =
           PackageManager.onUpdateProgressChanged.listen(null);
       await subscription.cancel();

--- a/packages/tizen_package_manager/example/integration_test/tizen_package_manager_test.dart
+++ b/packages/tizen_package_manager/example/integration_test/tizen_package_manager_test.dart
@@ -118,7 +118,8 @@ void main() {
 
     test('throws PlatformException for invalid packageId', () async {
       expect(
-        () => PackageManager.getPackageInfo('invalid.package.id.that.does.not.exist'),
+        () => PackageManager.getPackageInfo(
+            'invalid.package.id.that.does.not.exist'),
         throwsA(isA<PlatformException>()),
       );
     });

--- a/packages/tizen_package_manager/pubspec.yaml
+++ b/packages/tizen_package_manager/pubspec.yaml
@@ -2,7 +2,7 @@ name: tizen_package_manager
 description: Tizen package manager APIs. Used to get information about packages installed on a Tizen device.
 homepage: https://github.com/flutter-tizen/plugins
 repository: https://github.com/flutter-tizen/plugins/tree/master/packages/tizen_package_manager
-version: 0.4.2
+version: 0.4.3
 
 environment:
   sdk: ">=3.1.0 <4.0.0"

--- a/packages/tizen_package_manager/tizen/src/tizen_package_manager.cc
+++ b/packages/tizen_package_manager/tizen/src/tizen_package_manager.cc
@@ -110,12 +110,15 @@ std::optional<PackageInfo> TizenPackageManager::GetPackageData(
   result.type = type;
   free(type);
 
+  // The icon path is optional: a package may have no icon, so a failure here is
+  // not treated as fatal. Only use the value when the call succeeds and the
+  // path is non-empty.
   char *icon_path = nullptr;
   ret = package_info_get_icon(handle, &icon_path);
-  if (icon_path && icon_path[0] != '\0') {
+  if (ret == PACKAGE_MANAGER_ERROR_NONE && icon_path && icon_path[0] != '\0') {
     result.icon_path = icon_path;
-    free(icon_path);
-  } else if (icon_path) {
+  }
+  if (icon_path) {
     free(icon_path);
   }
 

--- a/packages/tizen_package_manager/tizen/src/tizen_package_manager.cc
+++ b/packages/tizen_package_manager/tizen/src/tizen_package_manager.cc
@@ -112,8 +112,10 @@ std::optional<PackageInfo> TizenPackageManager::GetPackageData(
 
   char *icon_path = nullptr;
   ret = package_info_get_icon(handle, &icon_path);
-  if (icon_path) {
+  if (icon_path && icon_path[0] != '\0') {
     result.icon_path = icon_path;
+    free(icon_path);
+  } else if (icon_path) {
     free(icon_path);
   }
 


### PR DESCRIPTION
Adds regression integration tests for the `tizen_package_manager` plugin and fixes package icon path handling.

  ### Plugin fix
  - Return a null icon path (instead of an empty string) when a package has no icon, and only use `package_info_get_icon`'s result when the call succeeds (`PACKAGE_MANAGER_ERROR_NONE`) and the path is non-empty; always free the returned buffer. The icon is optional, so a failure is not treated as fatal.
  - Bumps the version to `0.4.3`.

  ### Integration tests
  - Add tests for `getPackageInfo`, `getPackageSizeInfo`, `getPackagesInfo`, package/size-info field validation, error paths (empty / invalid IDs), and the install/uninstall/update event streams.

  ## Test

  All tests pass on:
  - tv-9.0 emulator (x86)
  - tv-10.0 emulator (x86_64)
  - Raspberry Pi 4 (armv7 / ARM)
 
https://github.com/flutter-tizen/plugins/issues/1039