### PR TITLE
[permission_handler] Add regression integration tests based on upstream v12.0.1

### DIFF
--- a/packages/permission_handler/CHANGELOG.md
+++ b/packages/permission_handler/CHANGELOG.md
@@ -1,3 +1,7 @@
+## NEXT
+
+* Add 8 integration test cases.
+
 ## 1.4.4
 
 * Remove Ecore API.

--- a/packages/permission_handler/example/integration_test/permission_handler_test.dart
+++ b/packages/permission_handler/example/integration_test/permission_handler_test.dart
@@ -11,27 +11,27 @@ void main() {
 
   group('Permission.status', () {
     testWidgets('camera permission is granted', (tester) async {
-      expect(await Permission.camera.status.isGranted, true);
+      expect(await Permission.camera.status, PermissionStatus.granted);
     });
 
     testWidgets('microphone permission is granted', (tester) async {
-      expect(await Permission.microphone.status.isGranted, true);
+      expect(await Permission.microphone.status, PermissionStatus.granted);
     });
 
     testWidgets('location permission is granted', (tester) async {
-      expect(await Permission.location.status.isGranted, true);
+      expect(await Permission.location.status, PermissionStatus.granted);
     });
 
     testWidgets('mediaLibrary permission is granted', (tester) async {
-      expect(await Permission.mediaLibrary.status.isGranted, true);
+      expect(await Permission.mediaLibrary.status, PermissionStatus.granted);
     });
 
     testWidgets('storage permission is granted', (tester) async {
-      expect(await Permission.storage.status.isGranted, true);
+      expect(await Permission.storage.status, PermissionStatus.granted);
     });
 
     testWidgets('contacts permission is granted', (tester) async {
-      expect(await Permission.contacts.status.isGranted, true);
+      expect(await Permission.contacts.status, PermissionStatus.granted);
     });
   });
 
@@ -45,7 +45,7 @@ void main() {
   group('Permission.request', () {
     testWidgets('requesting camera permission returns granted', (tester) async {
       final status = await Permission.camera.request();
-      expect(status.isGranted, true);
+      expect(status, PermissionStatus.granted);
     });
 
     testWidgets('requesting multiple permissions returns granted',
@@ -55,9 +55,9 @@ void main() {
         Permission.microphone,
         Permission.location,
       ].request();
-      expect(statuses[Permission.camera]!.isGranted, true);
-      expect(statuses[Permission.microphone]!.isGranted, true);
-      expect(statuses[Permission.location]!.isGranted, true);
+      expect(statuses[Permission.camera], PermissionStatus.granted);
+      expect(statuses[Permission.microphone], PermissionStatus.granted);
+      expect(statuses[Permission.location], PermissionStatus.granted);
     });
   });
 

--- a/packages/permission_handler/example/integration_test/permission_handler_test.dart
+++ b/packages/permission_handler/example/integration_test/permission_handler_test.dart
@@ -1,3 +1,7 @@
+// Copyright 2024 Samsung Electronics Co., Ltd. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
 import 'package:flutter_test/flutter_test.dart';
 import 'package:integration_test/integration_test.dart';
 import 'package:permission_handler/permission_handler.dart';
@@ -5,13 +9,56 @@ import 'package:permission_handler/permission_handler.dart';
 void main() {
   IntegrationTestWidgetsFlutterBinding.ensureInitialized();
 
-  testWidgets('get permission status', (tester) async {
-    expect(await Permission.camera.status.isGranted, true);
+  group('Permission.status', () {
+    testWidgets('camera permission is granted', (tester) async {
+      expect(await Permission.camera.status.isGranted, true);
+    });
+
+    testWidgets('microphone permission is granted', (tester) async {
+      expect(await Permission.microphone.status.isGranted, true);
+    });
+
+    testWidgets('location permission is granted', (tester) async {
+      expect(await Permission.location.status.isGranted, true);
+    });
+
+    testWidgets('mediaLibrary permission is granted', (tester) async {
+      expect(await Permission.mediaLibrary.status.isGranted, true);
+    });
+
+    testWidgets('storage permission is granted', (tester) async {
+      expect(await Permission.storage.status.isGranted, true);
+    });
+
+    testWidgets('contacts permission is granted', (tester) async {
+      expect(await Permission.contacts.status.isGranted, true);
+    });
   });
 
-  testWidgets('get location service status', (tester) async {
-    var status = await Permission.location.serviceStatus;
-    expect(status.isEnabled || status.isDisabled, true);
+  group('Permission.serviceStatus', () {
+    testWidgets('location service status is valid', (tester) async {
+      final status = await Permission.location.serviceStatus;
+      expect(status.isEnabled || status.isDisabled, true);
+    });
+  });
+
+  group('Permission.request', () {
+    testWidgets('requesting camera permission returns granted', (tester) async {
+      final status = await Permission.camera.request();
+      expect(status.isGranted, true);
+    });
+
+    testWidgets('requesting multiple permissions returns granted',
+        (tester) async {
+      final statuses = await [
+        Permission.camera,
+        Permission.microphone,
+        Permission.location,
+      ].request();
+      expect(statuses[Permission.camera]!.isGranted, true);
+      expect(statuses[Permission.microphone]!.isGranted, true);
+      expect(statuses[Permission.location]!.isGranted, true);
+    });
   });
 
   testWidgets('open app settings', (tester) async {


### PR DESCRIPTION
Upstream permission_handler v12.0.1 has no integration tests. Added Tizen regression tests for the public permission API covering all privileges declared in the example app's tizen-manifest.xml:

- Permission.status: camera, microphone, location, mediaLibrary, storage, contacts
- Permission.serviceStatus: location service status is valid
- Permission.request: requesting camera permission returns granted
- Permission.request: requesting multiple permissions returns granted
- openAppSettings (skipped, not supported on emulators)

Note: only testable on Galaxy Watch (wearable profile) where runtime permission dialogs are applicable. On TV devices, all declared permissions are granted by default.