### PR TITLE
[firebase_core] Add integration tests

### DIFF
--- a/packages/firebase_core/CHANGELOG.md
+++ b/packages/firebase_core/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## NEXT
 
+* Add integration tests based on upstream firebase_core v2.17.0.
 * Update minimum Flutter and Dart version to 3.13 and 3.1.
 * Fix new lint warnings.
 * Update code format.

--- a/packages/firebase_core/example/integration_test/firebase_core_test.dart
+++ b/packages/firebase_core/example/integration_test/firebase_core_test.dart
@@ -1,0 +1,85 @@
+// Copyright 2024 Samsung Electronics Co., Ltd. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// Integration tests ported from upstream firebase_core
+// (github.com/firebase/flutterfire), originally authored by the
+// Chromium project authors under a BSD-style license.
+
+import 'package:firebase_core/firebase_core.dart';
+import 'package:firebase_core_platform_interface/firebase_core_platform_interface.dart';
+import 'package:firebase_core_tizen_example/firebase_options.dart';
+import 'package:flutter/foundation.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:integration_test/integration_test.dart';
+
+void main() {
+  IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+
+  group('firebase_core', () {
+    final String testAppName = '[DEFAULT]';
+
+    setUpAll(() async {
+      await Firebase.initializeApp(
+        options: DefaultFirebaseOptions.currentPlatform,
+      );
+    });
+
+    test('Firebase.apps', () async {
+      final List<FirebaseApp> apps = Firebase.apps;
+      expect(apps.length, 1);
+      expect(apps[0].name, testAppName);
+      expect(apps[0].options, DefaultFirebaseOptions.currentPlatform);
+    });
+
+    test('Firebase.app()', () async {
+      final FirebaseApp app = Firebase.app(testAppName);
+      expect(app.name, testAppName);
+      expect(app.options, DefaultFirebaseOptions.currentPlatform);
+    });
+
+    test('Firebase.app() Exception', () async {
+      expect(
+        () => Firebase.app('NoApp'),
+        throwsA(noAppExists('NoApp')),
+      );
+    });
+
+    test(
+      'FirebaseApp.delete()',
+      () async {
+        await Firebase.initializeApp(
+          name: 'SecondaryApp',
+          options: DefaultFirebaseOptions.currentPlatform,
+        );
+
+        expect(Firebase.apps.length, 2);
+
+        final FirebaseApp app = Firebase.app('SecondaryApp');
+
+        await app.delete();
+
+        expect(Firebase.apps.length, 1);
+        // TODO(russellwheatley): test randomly causes an auth sign-in failure due to duplicate accounts.
+      },
+      skip: TargetPlatform.android == defaultTargetPlatform,
+    );
+
+    test('FirebaseApp.setAutomaticDataCollectionEnabled()', () async {
+      final FirebaseApp app = Firebase.app(testAppName);
+      await app.setAutomaticDataCollectionEnabled(false);
+
+      expect(app.isAutomaticDataCollectionEnabled, false);
+
+      await app.setAutomaticDataCollectionEnabled(true);
+
+      expect(app.isAutomaticDataCollectionEnabled, true);
+    });
+
+    test('FirebaseApp.setAutomaticResourceManagementEnabled()', () async {
+      final FirebaseApp app = Firebase.app(testAppName);
+
+      await app.setAutomaticResourceManagementEnabled(true);
+    });
+  });
+}

--- a/packages/firebase_core/example/integration_test/firebase_core_test.dart
+++ b/packages/firebase_core/example/integration_test/firebase_core_test.dart
@@ -17,7 +17,7 @@ void main() {
   IntegrationTestWidgetsFlutterBinding.ensureInitialized();
 
   group('firebase_core', () {
-    final String testAppName = '[DEFAULT]';
+    const String testAppName = '[DEFAULT]';
 
     setUpAll(() async {
       await Firebase.initializeApp(
@@ -33,7 +33,7 @@ void main() {
     });
 
     test('Firebase.app()', () async {
-      final FirebaseApp app = Firebase.app(testAppName);
+      final FirebaseApp app = Firebase.app();
       expect(app.name, testAppName);
       expect(app.options, DefaultFirebaseOptions.currentPlatform);
     });
@@ -66,7 +66,7 @@ void main() {
     );
 
     test('FirebaseApp.setAutomaticDataCollectionEnabled()', () async {
-      final FirebaseApp app = Firebase.app(testAppName);
+      final FirebaseApp app = Firebase.app();
       await app.setAutomaticDataCollectionEnabled(false);
 
       expect(app.isAutomaticDataCollectionEnabled, false);
@@ -77,7 +77,7 @@ void main() {
     });
 
     test('FirebaseApp.setAutomaticResourceManagementEnabled()', () async {
-      final FirebaseApp app = Firebase.app(testAppName);
+      final FirebaseApp app = Firebase.app();
 
       await app.setAutomaticResourceManagementEnabled(true);
     });

--- a/packages/firebase_core/example/integration_test/firebase_core_test.dart
+++ b/packages/firebase_core/example/integration_test/firebase_core_test.dart
@@ -2,9 +2,10 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// Integration tests ported from upstream firebase_core
-// (github.com/firebase/flutterfire), originally authored by the
-// Chromium project authors under a BSD-style license.
+// Integration tests ported from upstream firebase_core v2.17.0:
+// https://github.com/firebase/flutterfire/blob/firebase_core-v2.17.0/tests/integration_test/firebase_core/firebase_core_e2e_test.dart
+// Originally authored by the Chromium project authors under a BSD-style
+// license.
 
 import 'package:firebase_core/firebase_core.dart';
 import 'package:firebase_core_platform_interface/firebase_core_platform_interface.dart';

--- a/packages/firebase_core/example/integration_test/firebase_core_test.dart
+++ b/packages/firebase_core/example/integration_test/firebase_core_test.dart
@@ -1,4 +1,4 @@
-// Copyright 2024 Samsung Electronics Co., Ltd. All rights reserved.
+// Copyright 2026 Samsung Electronics Co., Ltd. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/packages/firebase_core/example/lib/firebase_options.dart
+++ b/packages/firebase_core/example/lib/firebase_options.dart
@@ -2,10 +2,10 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// ignore_for_file: lines_longer_than_80_chars, avoid_classes_with_only_static_members
+// ignore_for_file: lines_longer_than_80_chars, avoid_classes_with_only_static_members, no_default_cases, public_member_api_docs
 import 'package:firebase_core/firebase_core.dart' show FirebaseOptions;
 import 'package:flutter/foundation.dart'
-    show defaultTargetPlatform, kIsWeb, TargetPlatform;
+    show TargetPlatform, defaultTargetPlatform, kIsWeb;
 
 class DefaultFirebaseOptions {
   static FirebaseOptions get currentPlatform {

--- a/packages/firebase_core/example/lib/firebase_options.dart
+++ b/packages/firebase_core/example/lib/firebase_options.dart
@@ -1,0 +1,31 @@
+// Copyright 2024 Samsung Electronics Co., Ltd. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// ignore_for_file: lines_longer_than_80_chars, avoid_classes_with_only_static_members
+import 'package:firebase_core/firebase_core.dart' show FirebaseOptions;
+import 'package:flutter/foundation.dart'
+    show defaultTargetPlatform, kIsWeb, TargetPlatform;
+
+class DefaultFirebaseOptions {
+  static FirebaseOptions get currentPlatform {
+    if (kIsWeb) {
+      throw UnsupportedError('Web is not supported.');
+    }
+    switch (defaultTargetPlatform) {
+      case TargetPlatform.linux: // Tizen reports as TargetPlatform.linux
+        return linux;
+      default:
+        throw UnsupportedError(
+          'DefaultFirebaseOptions are not supported for this platform.',
+        );
+    }
+  }
+
+  static const FirebaseOptions linux = FirebaseOptions(
+    apiKey: 'AIzaSyAgUhHU8wSJgO5MVNy95tMT07NEjzMOfz0',
+    appId: '1:448618578101:ios:0b650370bb29e29cac3efc',
+    messagingSenderId: '448618578101',
+    projectId: 'react-native-firebase-testing',
+  );
+}

--- a/packages/firebase_core/example/lib/firebase_options.dart
+++ b/packages/firebase_core/example/lib/firebase_options.dart
@@ -1,4 +1,4 @@
-// Copyright 2024 Samsung Electronics Co., Ltd. All rights reserved.
+// Copyright 2026 Samsung Electronics Co., Ltd. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/packages/firebase_core/example/lib/main.dart
+++ b/packages/firebase_core/example/lib/main.dart
@@ -9,6 +9,8 @@ import 'dart:developer';
 import 'package:firebase_core/firebase_core.dart';
 import 'package:flutter/material.dart';
 
+import 'firebase_options.dart';
+
 void main() => runApp(const MyApp());
 
 class MyApp extends StatelessWidget {
@@ -16,12 +18,7 @@ class MyApp extends StatelessWidget {
 
   String get name => 'foo';
 
-  FirebaseOptions get firebaseOptions => const FirebaseOptions(
-        appId: '1:448618578101:ios:0b650370bb29e29cac3efc',
-        apiKey: 'AIzaSyAgUhHU8wSJgO5MVNy95tMT07NEjzMOfz0',
-        projectId: 'react-native-firebase-testing',
-        messagingSenderId: '448618578101',
-      );
+  FirebaseOptions get firebaseOptions => DefaultFirebaseOptions.currentPlatform;
 
   Future<void> initializeDefault() async {
     final FirebaseApp app = await Firebase.initializeApp(

--- a/packages/firebase_core/example/pubspec.yaml
+++ b/packages/firebase_core/example/pubspec.yaml
@@ -12,3 +12,13 @@ dependencies:
     path: ../
   flutter:
     sdk: flutter
+
+dev_dependencies:
+  flutter_driver:
+    sdk: flutter
+  flutter_test:
+    sdk: flutter
+  integration_test:
+    sdk: flutter
+  integration_test_tizen:
+    path: ../../integration_test/

--- a/packages/firebase_core/example/pubspec.yaml
+++ b/packages/firebase_core/example/pubspec.yaml
@@ -14,6 +14,7 @@ dependencies:
     sdk: flutter
 
 dev_dependencies:
+  firebase_core_platform_interface: ^4.5.2
   flutter_driver:
     sdk: flutter
   flutter_test:

--- a/packages/firebase_core/example/test_driver/integration_test.dart
+++ b/packages/firebase_core/example/test_driver/integration_test.dart
@@ -1,0 +1,7 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:integration_test/integration_test_driver.dart';
+
+Future<void> main() => integrationDriver();

--- a/packages/firebase_core/pubspec.yaml
+++ b/packages/firebase_core/pubspec.yaml
@@ -22,3 +22,4 @@ flutter:
 
 false_secrets:
   - /example/lib/main.dart
+  - /example/lib/firebase_options.dart


### PR DESCRIPTION
Port 6 integration test cases from upstream firebase_core (v2.17.0), since
the pub.dev package doesn't ship integration tests. Added a manually
created `firebase_options.dart` mapping Tizen's reported platform
(TargetPlatform.linux) to public test credentials.

Ported cases: Firebase.apps, Firebase.app(), Firebase.app() exception,
FirebaseApp.delete(), setAutomaticDataCollectionEnabled(),
setAutomaticResourceManagementEnabled().

Validated on RPI4 (armv7l) and TV emulator (x86_64): 6/6 passed.