### PR TITLE
[tizen_log] Add integration tests

### DIFF
--- a/packages/tizen_log/CHANGELOG.md
+++ b/packages/tizen_log/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## NEXT
 
+* Add regression integration tests.
 * Update minimum Flutter and Dart version to 3.13 and 3.1.
 * Fix new lint warnings.
 * Update code format.

--- a/packages/tizen_log/example/integration_test/tizen_log_test.dart
+++ b/packages/tizen_log/example/integration_test/tizen_log_test.dart
@@ -36,7 +36,8 @@ void main() {
       expect(() => Log.fatal(tag, 'fatal message'), returnsNormally);
     });
 
-    testWidgets('isDebugEnabled is false by default', (WidgetTester tester) async {
+    testWidgets('isDebugEnabled is false by default',
+        (WidgetTester tester) async {
       expect(Log.isDebugEnabled, isFalse);
     });
 

--- a/packages/tizen_log/example/integration_test/tizen_log_test.dart
+++ b/packages/tizen_log/example/integration_test/tizen_log_test.dart
@@ -12,36 +12,36 @@ void main() {
   const String tag = 'TizenLogTest';
 
   group('Log', () {
-    testWidgets('verbose does not throw', (tester) async {
+    testWidgets('verbose does not throw', (WidgetTester tester) async {
       expect(() => Log.verbose(tag, 'verbose message'), returnsNormally);
     });
 
-    testWidgets('debug does not throw', (tester) async {
+    testWidgets('debug does not throw', (WidgetTester tester) async {
       expect(() => Log.debug(tag, 'debug message'), returnsNormally);
     });
 
-    testWidgets('info does not throw', (tester) async {
+    testWidgets('info does not throw', (WidgetTester tester) async {
       expect(() => Log.info(tag, 'info message'), returnsNormally);
     });
 
-    testWidgets('warn does not throw', (tester) async {
+    testWidgets('warn does not throw', (WidgetTester tester) async {
       expect(() => Log.warn(tag, 'warn message'), returnsNormally);
     });
 
-    testWidgets('error does not throw', (tester) async {
+    testWidgets('error does not throw', (WidgetTester tester) async {
       expect(() => Log.error(tag, 'error message'), returnsNormally);
     });
 
-    testWidgets('fatal does not throw', (tester) async {
+    testWidgets('fatal does not throw', (WidgetTester tester) async {
       expect(() => Log.fatal(tag, 'fatal message'), returnsNormally);
     });
 
-    testWidgets('isDebugEnabled is false by default', (tester) async {
+    testWidgets('isDebugEnabled is false by default', (WidgetTester tester) async {
       expect(Log.isDebugEnabled, isFalse);
     });
 
     testWidgets('log with optional file, func, and line does not throw',
-        (tester) async {
+        (WidgetTester tester) async {
       expect(
         () => Log.info(
           tag,

--- a/packages/tizen_log/example/integration_test/tizen_log_test.dart
+++ b/packages/tizen_log/example/integration_test/tizen_log_test.dart
@@ -1,0 +1,57 @@
+// Copyright 2026 Samsung Electronics Co., Ltd. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:integration_test/integration_test.dart';
+import 'package:tizen_log/tizen_log.dart';
+
+void main() {
+  IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+
+  const String tag = 'TizenLogTest';
+
+  group('Log', () {
+    testWidgets('verbose does not throw', (tester) async {
+      expect(() => Log.verbose(tag, 'verbose message'), returnsNormally);
+    });
+
+    testWidgets('debug does not throw', (tester) async {
+      expect(() => Log.debug(tag, 'debug message'), returnsNormally);
+    });
+
+    testWidgets('info does not throw', (tester) async {
+      expect(() => Log.info(tag, 'info message'), returnsNormally);
+    });
+
+    testWidgets('warn does not throw', (tester) async {
+      expect(() => Log.warn(tag, 'warn message'), returnsNormally);
+    });
+
+    testWidgets('error does not throw', (tester) async {
+      expect(() => Log.error(tag, 'error message'), returnsNormally);
+    });
+
+    testWidgets('fatal does not throw', (tester) async {
+      expect(() => Log.fatal(tag, 'fatal message'), returnsNormally);
+    });
+
+    testWidgets('isDebugEnabled is false by default', (tester) async {
+      expect(Log.isDebugEnabled, isFalse);
+    });
+
+    testWidgets('log with optional file, func, and line does not throw',
+        (tester) async {
+      expect(
+        () => Log.info(
+          tag,
+          'message with metadata',
+          file: 'test.dart',
+          func: 'main',
+          line: 1,
+        ),
+        returnsNormally,
+      );
+    });
+  });
+}

--- a/packages/tizen_log/example/pubspec.yaml
+++ b/packages/tizen_log/example/pubspec.yaml
@@ -12,5 +12,15 @@ dependencies:
   tizen_log:
     path: ../
 
+dev_dependencies:
+  flutter_driver:
+    sdk: flutter
+  flutter_test:
+    sdk: flutter
+  integration_test:
+    sdk: flutter
+  integration_test_tizen:
+    path: ../../integration_test/
+
 flutter:
   uses-material-design: true

--- a/packages/tizen_log/example/test_driver/integration_test.dart
+++ b/packages/tizen_log/example/test_driver/integration_test.dart
@@ -1,0 +1,7 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:integration_test/integration_test_driver.dart';
+
+Future<void> main() => integrationDriver();


### PR DESCRIPTION
Add 8 regression integration tests for the public Log API (verbose, debug, info, warn, error, fatal, isDebugEnabled default, and the optional file/func/line parameters), since tizen_log is Tizen-only and has no upstream test suite to port from.