### PR TITLE
[tizen_notification] Add integration tests and fix null check crash in show()

### DIFF
--- a/packages/tizen_notification/CHANGELOG.md
+++ b/packages/tizen_notification/CHANGELOG.md
@@ -1,5 +1,6 @@
-## NEXT
+## 0.2.1
 
+* Fix null check error when calling show() without TizenNotificationDetails.
 * Update minimum Flutter and Dart version to 3.13 and 3.1.
 * Update code format.
 

--- a/packages/tizen_notification/CHANGELOG.md
+++ b/packages/tizen_notification/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## 0.2.1
 
+* Add regression integration tests.
 * Fix null check error when calling show() without TizenNotificationDetails.
 * Update minimum Flutter and Dart version to 3.13 and 3.1.
 * Update code format.

--- a/packages/tizen_notification/README.md
+++ b/packages/tizen_notification/README.md
@@ -10,7 +10,7 @@ To use this plugin, add `tizen_notification` as a dependency in your `pubspec.ya
 
 ```yaml
 dependencies:
-  tizen_notification: ^0.2.0
+  tizen_notification: ^0.2.1
 ```
 
 Then you can import `tizen_notification` in your Dart code:

--- a/packages/tizen_notification/example/integration_test/tizen_notification_test.dart
+++ b/packages/tizen_notification/example/integration_test/tizen_notification_test.dart
@@ -16,28 +16,28 @@ void main() {
   });
 
   group('TizenNotificationPlugin', () {
-    testWidgets('show notification does not throw', (tester) async {
+    testWidgets('show notification does not throw', (WidgetTester tester) async {
       await plugin.show(1, title: 'Test Title', body: 'Test Body');
     });
 
     testWidgets('show notification with default title and body does not throw',
-        (tester) async {
+        (WidgetTester tester) async {
       await plugin.show(2);
     });
 
-    testWidgets('cancel notification does not throw', (tester) async {
+    testWidgets('cancel notification does not throw', (WidgetTester tester) async {
       await plugin.show(3, title: 'To Cancel');
       await plugin.cancel(3);
     });
 
-    testWidgets('cancelAll does not throw', (tester) async {
+    testWidgets('cancelAll does not throw', (WidgetTester tester) async {
       await plugin.show(4, title: 'Notification 1');
       await plugin.show(5, title: 'Notification 2');
       await plugin.cancelAll();
     });
 
     testWidgets('show notification with TizenNotificationDetails does not throw',
-        (tester) async {
+        (WidgetTester tester) async {
       final TizenNotificationDetails details = TizenNotificationDetails(
         properties: NotificationProperty.disableAutoDelete,
         style: NotificationStyle.tray,

--- a/packages/tizen_notification/example/integration_test/tizen_notification_test.dart
+++ b/packages/tizen_notification/example/integration_test/tizen_notification_test.dart
@@ -15,6 +15,10 @@ void main() {
     plugin = TizenNotificationPlugin();
   });
 
+  tearDown(() async {
+    await plugin.cancelAll();
+  });
+
   group('TizenNotificationPlugin', () {
     testWidgets('show notification does not throw',
         (WidgetTester tester) async {

--- a/packages/tizen_notification/example/integration_test/tizen_notification_test.dart
+++ b/packages/tizen_notification/example/integration_test/tizen_notification_test.dart
@@ -1,0 +1,54 @@
+// Copyright 2024 Samsung Electronics Co., Ltd. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:integration_test/integration_test.dart';
+import 'package:tizen_notification/tizen_notification.dart';
+
+void main() {
+  IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+
+  late TizenNotificationPlugin plugin;
+
+  setUp(() {
+    plugin = TizenNotificationPlugin();
+  });
+
+  group('TizenNotificationPlugin', () {
+    testWidgets('show notification does not throw', (tester) async {
+      await plugin.show(1, title: 'Test Title', body: 'Test Body');
+    });
+
+    testWidgets('show notification with default title and body does not throw',
+        (tester) async {
+      await plugin.show(2);
+    });
+
+    testWidgets('cancel notification does not throw', (tester) async {
+      await plugin.show(3, title: 'To Cancel');
+      await plugin.cancel(3);
+    });
+
+    testWidgets('cancelAll does not throw', (tester) async {
+      await plugin.show(4, title: 'Notification 1');
+      await plugin.show(5, title: 'Notification 2');
+      await plugin.cancelAll();
+    });
+
+    testWidgets('show notification with TizenNotificationDetails does not throw',
+        (tester) async {
+      final TizenNotificationDetails details = TizenNotificationDetails(
+        properties: NotificationProperty.disableAutoDelete,
+        style: NotificationStyle.tray,
+      );
+      await plugin.show(
+        6,
+        title: 'Detailed',
+        body: 'With details',
+        notificationDetails: details,
+      );
+      await plugin.cancel(6);
+    });
+  });
+}

--- a/packages/tizen_notification/example/integration_test/tizen_notification_test.dart
+++ b/packages/tizen_notification/example/integration_test/tizen_notification_test.dart
@@ -16,7 +16,8 @@ void main() {
   });
 
   group('TizenNotificationPlugin', () {
-    testWidgets('show notification does not throw', (WidgetTester tester) async {
+    testWidgets('show notification does not throw',
+        (WidgetTester tester) async {
       await plugin.show(1, title: 'Test Title', body: 'Test Body');
     });
 
@@ -25,7 +26,8 @@ void main() {
       await plugin.show(2);
     });
 
-    testWidgets('cancel notification does not throw', (WidgetTester tester) async {
+    testWidgets('cancel notification does not throw',
+        (WidgetTester tester) async {
       await plugin.show(3, title: 'To Cancel');
       await plugin.cancel(3);
     });
@@ -36,7 +38,8 @@ void main() {
       await plugin.cancelAll();
     });
 
-    testWidgets('show notification with TizenNotificationDetails does not throw',
+    testWidgets(
+        'show notification with TizenNotificationDetails does not throw',
         (WidgetTester tester) async {
       final TizenNotificationDetails details = TizenNotificationDetails(
         properties: NotificationProperty.disableAutoDelete,

--- a/packages/tizen_notification/example/integration_test/tizen_notification_test.dart
+++ b/packages/tizen_notification/example/integration_test/tizen_notification_test.dart
@@ -1,4 +1,4 @@
-// Copyright 2024 Samsung Electronics Co., Ltd. All rights reserved.
+// Copyright 2026 Samsung Electronics Co., Ltd. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/packages/tizen_notification/example/pubspec.yaml
+++ b/packages/tizen_notification/example/pubspec.yaml
@@ -12,5 +12,15 @@ dependencies:
   tizen_notification:
     path: ../
 
+dev_dependencies:
+  flutter_driver:
+    sdk: flutter
+  flutter_test:
+    sdk: flutter
+  integration_test:
+    sdk: flutter
+  integration_test_tizen:
+    path: ../../integration_test/
+
 flutter:
   uses-material-design: true

--- a/packages/tizen_notification/example/test_driver/integration_test.dart
+++ b/packages/tizen_notification/example/test_driver/integration_test.dart
@@ -1,0 +1,7 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:integration_test/integration_test_driver.dart';
+
+Future<void> main() => integrationDriver();

--- a/packages/tizen_notification/lib/tizen_notification.dart
+++ b/packages/tizen_notification/lib/tizen_notification.dart
@@ -30,7 +30,7 @@ class TizenNotificationPlugin {
 
     // Set disableAppLaunch automatically if appControl is unset.
     if (notificationDetails?.appControl == null) {
-      final int properties = details['properties']! as int;
+      final int properties = (details['properties'] as int?) ?? 0;
       details['properties'] =
           properties | NotificationProperty.disableAppLaunch;
     }

--- a/packages/tizen_notification/pubspec.yaml
+++ b/packages/tizen_notification/pubspec.yaml
@@ -2,7 +2,7 @@ name: tizen_notification
 description: Tizen notification APIs. Used to show and delete notifications on a Tizen device.
 homepage: https://github.com/flutter-tizen/plugins
 repository: https://github.com/flutter-tizen/plugins/tree/master/packages/tizen_notification
-version: 0.2.0
+version: 0.2.1
 
 environment:
   sdk: ">=3.1.0 <4.0.0"


### PR DESCRIPTION
Add 5 regression integration tests for the TizenNotificationPlugin API (show with title/body, show with default title/body, cancel, cancelAll, show with TizenNotificationDetails).
While adding tests, found and fixed a TypeError: show() used a null check operator (!) on the 'properties' key when no TizenNotificationDetails was provided, since that key is absent in that case. Now defaults to 0.

Bumped to 0.2.1.
