### PR TITLE
[webview_flutter] Implement clearLocalStorage/onHttpError and add integration tests based on upstream v4.13.1

### DIFF
--- a/packages/webview_flutter/CHANGELOG.md
+++ b/packages/webview_flutter/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 * Implement `clearLocalStorage`.
 * Implement `onHttpError` for the navigation delegate.
+* Fix races and use-after-frees on WebView disposal, and avoid a web engine
+  teardown crash on the Tizen 10.0 TV emulator.
 
 ## 0.10.0
 

--- a/packages/webview_flutter/CHANGELOG.md
+++ b/packages/webview_flutter/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.10.1
+
+* Implement `clearLocalStorage`.
+* Implement `onHttpError` for the navigation delegate.
+
 ## 0.10.0
 
 * Update minimum supported SDK version to Flutter 3.32/Dart 3.8.

--- a/packages/webview_flutter/CHANGELOG.md
+++ b/packages/webview_flutter/CHANGELOG.md
@@ -2,8 +2,10 @@
 
 * Implement `clearLocalStorage`.
 * Implement `onHttpError` for the navigation delegate.
-* Fix races and use-after-frees on WebView disposal, and avoid a web engine
-  teardown crash on the Tizen 10.0 TV emulator.
+* Fix races and use-after-frees on WebView disposal, including a buffer-pool
+  use-after-free on the raster thread.
+* Replace the Ecore main loop API with GLib.
+* Narrow the TV emulator teardown workaround to a runtime profile check.
 
 ## 0.10.0
 

--- a/packages/webview_flutter/CHANGELOG.md
+++ b/packages/webview_flutter/CHANGELOG.md
@@ -5,9 +5,10 @@
 * Fix races and use-after-frees on WebView disposal, including a buffer-pool
   use-after-free on the raster thread.
 * Replace the Ecore main loop API with GLib.
-* Remove the TV emulator's evas_object_del() workaround; drain all pending
-  WebView teardowns before ewk_shutdown() instead, fixing a native crash on
-  app exit and enabling simultaneous use of multiple WebViews.
+* Remove the TV emulator's evas_object_hide() workaround (which skipped
+  evas_object_del() to avoid a crash); drain all pending WebView teardowns
+  before ewk_shutdown() instead, fixing a native crash on app exit and
+  enabling simultaneous use of multiple WebViews.
 
 ## 0.10.0
 

--- a/packages/webview_flutter/CHANGELOG.md
+++ b/packages/webview_flutter/CHANGELOG.md
@@ -4,7 +4,7 @@
 * Implement `onHttpError` for the navigation delegate.
 * Fix races and use-after-frees on WebView disposal, including a buffer-pool
   use-after-free on the raster thread.
-* Replace the Ecore main loop API with GLib.
+* Use GLib to schedule the deferred WebView teardown.
 * Drain all pending WebView teardowns before ewk_shutdown(), fixing a native
   crash on app exit and enabling simultaneous use of multiple WebViews.
 

--- a/packages/webview_flutter/CHANGELOG.md
+++ b/packages/webview_flutter/CHANGELOG.md
@@ -6,7 +6,7 @@
   use-after-free on the raster thread.
 * Use GLib to schedule the deferred WebView teardown.
 * Drain all pending WebView teardowns before ewk_shutdown(), fixing a native
-  crash on app exit and enabling simultaneous use of multiple WebViews.
+  crash on app exit.
 
 ## 0.10.0
 

--- a/packages/webview_flutter/CHANGELOG.md
+++ b/packages/webview_flutter/CHANGELOG.md
@@ -5,10 +5,8 @@
 * Fix races and use-after-frees on WebView disposal, including a buffer-pool
   use-after-free on the raster thread.
 * Replace the Ecore main loop API with GLib.
-* Remove the TV emulator's evas_object_hide() workaround (which skipped
-  evas_object_del() to avoid a crash); drain all pending WebView teardowns
-  before ewk_shutdown() instead, fixing a native crash on app exit and
-  enabling simultaneous use of multiple WebViews.
+* Drain all pending WebView teardowns before ewk_shutdown(), fixing a native
+  crash on app exit and enabling simultaneous use of multiple WebViews.
 
 ## 0.10.0
 

--- a/packages/webview_flutter/CHANGELOG.md
+++ b/packages/webview_flutter/CHANGELOG.md
@@ -2,11 +2,9 @@
 
 * Implement `clearLocalStorage`.
 * Implement `onHttpError` for the navigation delegate.
-* Fix races and use-after-frees on WebView disposal, including a buffer-pool
-  use-after-free on the raster thread.
+* Fix races and use-after-frees on WebView disposal, including a buffer-pool use-after-free on the raster thread.
 * Use GLib to schedule the deferred WebView teardown.
-* Drain all pending WebView teardowns before ewk_shutdown(), fixing a native
-  crash on app exit.
+* Drain all pending WebView teardowns before ewk_shutdown(), fixing a native crash on app exit.
 
 ## 0.10.0
 

--- a/packages/webview_flutter/CHANGELOG.md
+++ b/packages/webview_flutter/CHANGELOG.md
@@ -5,7 +5,9 @@
 * Fix races and use-after-frees on WebView disposal, including a buffer-pool
   use-after-free on the raster thread.
 * Replace the Ecore main loop API with GLib.
-* Narrow the TV emulator teardown workaround to a runtime profile check.
+* Remove the TV emulator's evas_object_del() workaround; drain all pending
+  WebView teardowns before ewk_shutdown() instead, fixing a native crash on
+  app exit and enabling simultaneous use of multiple WebViews.
 
 ## 0.10.0
 

--- a/packages/webview_flutter/README.md
+++ b/packages/webview_flutter/README.md
@@ -23,7 +23,7 @@ This package is not an _endorsed_ implementation of `webview_flutter`. Therefore
 ```yaml
 dependencies:
   webview_flutter: ^4.13.1
-  webview_flutter_tizen: ^0.10.0
+  webview_flutter_tizen: ^0.10.1
 ```
 
 ## Example

--- a/packages/webview_flutter/example/integration_test/webview_flutter_test.dart
+++ b/packages/webview_flutter/example/integration_test/webview_flutter_test.dart
@@ -276,14 +276,30 @@ Future<void> main() async {
       expect(scrollPos.dx, isNot(X_SCROLL));
       expect(scrollPos.dy, isNot(Y_SCROLL));
 
+      // The scroll position settles asynchronously, so poll until it reaches
+      // the expected value (with a timeout) instead of reading it once. This
+      // keeps the test stable on slower software-GL rendering (e.g. emulators).
+      Future<Offset> pollScrollPosition(int expectedX, int expectedY) async {
+        Offset pos = await controller.getScrollPosition();
+        for (
+          int i = 0;
+          i < 20 && (pos.dx != expectedX || pos.dy != expectedY);
+          i++
+        ) {
+          await Future<void>.delayed(const Duration(milliseconds: 100));
+          pos = await controller.getScrollPosition();
+        }
+        return pos;
+      }
+
       await controller.scrollTo(X_SCROLL, Y_SCROLL);
-      scrollPos = await controller.getScrollPosition();
+      scrollPos = await pollScrollPosition(X_SCROLL, Y_SCROLL);
       expect(scrollPos.dx, X_SCROLL);
       expect(scrollPos.dy, Y_SCROLL);
 
       // Check scrollBy() (on top of scrollTo())
       await controller.scrollBy(X_SCROLL, Y_SCROLL);
-      scrollPos = await controller.getScrollPosition();
+      scrollPos = await pollScrollPosition(X_SCROLL * 2, Y_SCROLL * 2);
       expect(scrollPos.dx, X_SCROLL * 2);
       expect(scrollPos.dy, Y_SCROLL * 2);
     });

--- a/packages/webview_flutter/example/integration_test/webview_flutter_test.dart
+++ b/packages/webview_flutter/example/integration_test/webview_flutter_test.dart
@@ -44,12 +44,10 @@ Future<void> main() async {
     final Completer<void> pageFinished = Completer<void>();
 
     final WebViewController controller = WebViewController();
-    unawaited(
-      controller.setNavigationDelegate(
-        NavigationDelegate(onPageFinished: (_) => pageFinished.complete()),
-      ),
+    await controller.setNavigationDelegate(
+      NavigationDelegate(onPageFinished: (_) => pageFinished.complete()),
     );
-    unawaited(controller.loadRequest(Uri.parse(primaryUrl)));
+    await controller.loadRequest(Uri.parse(primaryUrl));
 
     await tester.pumpWidget(WebViewWidget(controller: controller));
 
@@ -63,13 +61,11 @@ Future<void> main() async {
     final Completer<void> pageFinished = Completer<void>();
 
     final WebViewController controller = WebViewController();
-    unawaited(controller.setJavaScriptMode(JavaScriptMode.unrestricted));
-    unawaited(
-      controller.setNavigationDelegate(
-        NavigationDelegate(onPageFinished: (_) => pageFinished.complete()),
-      ),
+    await controller.setJavaScriptMode(JavaScriptMode.unrestricted);
+    await controller.setNavigationDelegate(
+      NavigationDelegate(onPageFinished: (_) => pageFinished.complete()),
     );
-    unawaited(controller.loadRequest(Uri.parse(primaryUrl)));
+    await controller.loadRequest(Uri.parse(primaryUrl));
 
     await tester.pumpWidget(WebViewWidget(controller: controller));
 
@@ -89,16 +85,14 @@ Future<void> main() async {
     final StreamController<String> pageLoads = StreamController<String>();
 
     final WebViewController controller = WebViewController();
-    unawaited(controller.setJavaScriptMode(JavaScriptMode.unrestricted));
-    unawaited(
-      controller.setNavigationDelegate(
-        NavigationDelegate(onPageFinished: (String url) => pageLoads.add(url)),
-      ),
+    await controller.setJavaScriptMode(JavaScriptMode.unrestricted);
+    await controller.setNavigationDelegate(
+      NavigationDelegate(onPageFinished: (String url) => pageLoads.add(url)),
     );
 
     await tester.pumpWidget(WebViewWidget(controller: controller));
 
-    unawaited(controller.loadRequest(Uri.parse(headersUrl), headers: headers));
+    await controller.loadRequest(Uri.parse(headersUrl), headers: headers);
 
     await pageLoads.stream.firstWhere((String url) => url == headersUrl);
 
@@ -113,11 +107,9 @@ Future<void> main() async {
   testWidgets('JavascriptChannel', (WidgetTester tester) async {
     final Completer<void> pageFinished = Completer<void>();
     final WebViewController controller = WebViewController();
-    unawaited(controller.setJavaScriptMode(JavaScriptMode.unrestricted));
-    unawaited(
-      controller.setNavigationDelegate(
-        NavigationDelegate(onPageFinished: (_) => pageFinished.complete()),
-      ),
+    await controller.setJavaScriptMode(JavaScriptMode.unrestricted);
+    await controller.setNavigationDelegate(
+      NavigationDelegate(onPageFinished: (_) => pageFinished.complete()),
     );
 
     final Completer<String> channelCompleter = Completer<String>();
@@ -178,14 +170,12 @@ Future<void> main() async {
     final Completer<void> pageFinished = Completer<void>();
 
     final WebViewController controller = WebViewController();
-    unawaited(controller.setJavaScriptMode(JavaScriptMode.unrestricted));
-    unawaited(
-      controller.setNavigationDelegate(
-        NavigationDelegate(onPageFinished: (_) => pageFinished.complete()),
-      ),
+    await controller.setJavaScriptMode(JavaScriptMode.unrestricted);
+    await controller.setNavigationDelegate(
+      NavigationDelegate(onPageFinished: (_) => pageFinished.complete()),
     );
-    unawaited(controller.setUserAgent('Custom_User_Agent1'));
-    unawaited(controller.loadRequest(Uri.parse('about:blank')));
+    await controller.setUserAgent('Custom_User_Agent1');
+    await controller.loadRequest(Uri.parse('about:blank'));
 
     await tester.pumpWidget(WebViewWidget(controller: controller));
 
@@ -210,16 +200,12 @@ Future<void> main() async {
     final Completer<void> pageLoaded = Completer<void>();
 
     final WebViewController controller = WebViewController();
-    unawaited(controller.setJavaScriptMode(JavaScriptMode.unrestricted));
-    unawaited(
-      controller.setNavigationDelegate(
-        NavigationDelegate(onPageFinished: (_) => pageLoaded.complete()),
-      ),
+    await controller.setJavaScriptMode(JavaScriptMode.unrestricted);
+    await controller.setNavigationDelegate(
+      NavigationDelegate(onPageFinished: (_) => pageLoaded.complete()),
     );
-    unawaited(
-      controller.loadRequest(
-        Uri.parse('data:text/html;charset=utf-8;base64,$getTitleTestBase64'),
-      ),
+    await controller.loadRequest(
+      Uri.parse('data:text/html;charset=utf-8;base64,$getTitleTestBase64'),
     );
 
     await tester.pumpWidget(WebViewWidget(controller: controller));
@@ -265,18 +251,12 @@ Future<void> main() async {
 
       final Completer<void> pageLoaded = Completer<void>();
       final WebViewController controller = WebViewController();
-      unawaited(controller.setJavaScriptMode(JavaScriptMode.unrestricted));
-      unawaited(
-        controller.setNavigationDelegate(
-          NavigationDelegate(onPageFinished: (_) => pageLoaded.complete()),
-        ),
+      await controller.setJavaScriptMode(JavaScriptMode.unrestricted);
+      await controller.setNavigationDelegate(
+        NavigationDelegate(onPageFinished: (_) => pageLoaded.complete()),
       );
-      unawaited(
-        controller.loadRequest(
-          Uri.parse(
-            'data:text/html;charset=utf-8;base64,$scrollTestPageBase64',
-          ),
-        ),
+      await controller.loadRequest(
+        Uri.parse('data:text/html;charset=utf-8;base64,$scrollTestPageBase64'),
       );
 
       await tester.pumpWidget(WebViewWidget(controller: controller));
@@ -319,23 +299,21 @@ Future<void> main() async {
       Completer<void> pageLoaded = Completer<void>();
 
       final WebViewController controller = WebViewController();
-      unawaited(controller.setJavaScriptMode(JavaScriptMode.unrestricted));
-      unawaited(
-        controller.setNavigationDelegate(
-          NavigationDelegate(
-            onPageFinished: (_) => pageLoaded.complete(),
-            onNavigationRequest: (NavigationRequest navigationRequest) {
-              return (navigationRequest.url.contains('youtube.com'))
-                  ? NavigationDecision.prevent
-                  : NavigationDecision.navigate;
-            },
-          ),
+      await controller.setJavaScriptMode(JavaScriptMode.unrestricted);
+      await controller.setNavigationDelegate(
+        NavigationDelegate(
+          onPageFinished: (_) => pageLoaded.complete(),
+          onNavigationRequest: (NavigationRequest navigationRequest) {
+            return (navigationRequest.url.contains('youtube.com'))
+                ? NavigationDecision.prevent
+                : NavigationDecision.navigate;
+          },
         ),
       );
 
       await tester.pumpWidget(WebViewWidget(controller: controller));
 
-      unawaited(controller.loadRequest(Uri.parse(blankPageEncoded)));
+      await controller.loadRequest(Uri.parse(blankPageEncoded));
 
       await pageLoaded.future; // Wait for initial page load.
 
@@ -352,19 +330,15 @@ Future<void> main() async {
           Completer<WebResourceError>();
 
       final WebViewController controller = WebViewController();
-      unawaited(controller.setJavaScriptMode(JavaScriptMode.unrestricted));
-      unawaited(
-        controller.setNavigationDelegate(
-          NavigationDelegate(
-            onWebResourceError: (WebResourceError error) {
-              errorCompleter.complete(error);
-            },
-          ),
+      await controller.setJavaScriptMode(JavaScriptMode.unrestricted);
+      await controller.setNavigationDelegate(
+        NavigationDelegate(
+          onWebResourceError: (WebResourceError error) {
+            errorCompleter.complete(error);
+          },
         ),
       );
-      unawaited(
-        controller.loadRequest(Uri.parse('https://www.notawebsite..com')),
-      );
+      await controller.loadRequest(Uri.parse('https://www.notawebsite..com'));
 
       await tester.pumpWidget(WebViewWidget(controller: controller));
 
@@ -380,21 +354,17 @@ Future<void> main() async {
       final Completer<void> pageFinishCompleter = Completer<void>();
 
       final WebViewController controller = WebViewController();
-      unawaited(controller.setJavaScriptMode(JavaScriptMode.unrestricted));
-      unawaited(
-        controller.setNavigationDelegate(
-          NavigationDelegate(
-            onPageFinished: (_) => pageFinishCompleter.complete(),
-            onWebResourceError: (WebResourceError error) {
-              errorCompleter.complete(error);
-            },
-          ),
+      await controller.setJavaScriptMode(JavaScriptMode.unrestricted);
+      await controller.setNavigationDelegate(
+        NavigationDelegate(
+          onPageFinished: (_) => pageFinishCompleter.complete(),
+          onWebResourceError: (WebResourceError error) {
+            errorCompleter.complete(error);
+          },
         ),
       );
-      unawaited(
-        controller.loadRequest(
-          Uri.parse('data:text/html;charset=utf-8;base64,PCFET0NUWVBFIGh0bWw+'),
-        ),
+      await controller.loadRequest(
+        Uri.parse('data:text/html;charset=utf-8;base64,PCFET0NUWVBFIGh0bWw+'),
       );
 
       await tester.pumpWidget(WebViewWidget(controller: controller));
@@ -407,23 +377,21 @@ Future<void> main() async {
       Completer<void> pageLoaded = Completer<void>();
 
       final WebViewController controller = WebViewController();
-      unawaited(controller.setJavaScriptMode(JavaScriptMode.unrestricted));
-      unawaited(
-        controller.setNavigationDelegate(
-          NavigationDelegate(
-            onPageFinished: (_) => pageLoaded.complete(),
-            onNavigationRequest: (NavigationRequest navigationRequest) {
-              return (navigationRequest.url.contains('youtube.com'))
-                  ? NavigationDecision.prevent
-                  : NavigationDecision.navigate;
-            },
-          ),
+      await controller.setJavaScriptMode(JavaScriptMode.unrestricted);
+      await controller.setNavigationDelegate(
+        NavigationDelegate(
+          onPageFinished: (_) => pageLoaded.complete(),
+          onNavigationRequest: (NavigationRequest navigationRequest) {
+            return (navigationRequest.url.contains('youtube.com'))
+                ? NavigationDecision.prevent
+                : NavigationDecision.navigate;
+          },
         ),
       );
 
       await tester.pumpWidget(WebViewWidget(controller: controller));
 
-      unawaited(controller.loadRequest(Uri.parse(blankPageEncoded)));
+      await controller.loadRequest(Uri.parse(blankPageEncoded));
 
       await pageLoaded.future; // Wait for initial page load.
 
@@ -509,26 +477,24 @@ Future<void> main() async {
       Completer<void> pageLoaded = Completer<void>();
 
       final WebViewController controller = WebViewController();
-      unawaited(controller.setJavaScriptMode(JavaScriptMode.unrestricted));
-      unawaited(
-        controller.setNavigationDelegate(
-          NavigationDelegate(
-            onPageFinished: (_) => pageLoaded.complete(),
-            onNavigationRequest: (NavigationRequest navigationRequest) async {
-              NavigationDecision decision = NavigationDecision.prevent;
-              decision = await Future<NavigationDecision>.delayed(
-                const Duration(milliseconds: 10),
-                () => NavigationDecision.navigate,
-              );
-              return decision;
-            },
-          ),
+      await controller.setJavaScriptMode(JavaScriptMode.unrestricted);
+      await controller.setNavigationDelegate(
+        NavigationDelegate(
+          onPageFinished: (_) => pageLoaded.complete(),
+          onNavigationRequest: (NavigationRequest navigationRequest) async {
+            NavigationDecision decision = NavigationDecision.prevent;
+            decision = await Future<NavigationDecision>.delayed(
+              const Duration(milliseconds: 10),
+              () => NavigationDecision.navigate,
+            );
+            return decision;
+          },
         ),
       );
 
       await tester.pumpWidget(WebViewWidget(controller: controller));
 
-      unawaited(controller.loadRequest(Uri.parse(blankPageEncoded)));
+      await controller.loadRequest(Uri.parse(blankPageEncoded));
 
       await pageLoaded.future; // Wait for initial page load.
 
@@ -545,13 +511,11 @@ Future<void> main() async {
 
       final WebViewController controller = WebViewController();
       final Completer<String> urlChangeCompleter = Completer<String>();
-      unawaited(controller.setJavaScriptMode(JavaScriptMode.unrestricted));
-      unawaited(
-        controller.setNavigationDelegate(
-          NavigationDelegate(onPageFinished: (_) => pageLoaded.complete()),
-        ),
+      await controller.setJavaScriptMode(JavaScriptMode.unrestricted);
+      await controller.setNavigationDelegate(
+        NavigationDelegate(onPageFinished: (_) => pageLoaded.complete()),
       );
-      unawaited(controller.loadRequest(Uri.parse(blankPageEncoded)));
+      await controller.loadRequest(Uri.parse(blankPageEncoded));
 
       await tester.pumpWidget(WebViewWidget(controller: controller));
 
@@ -579,9 +543,9 @@ Future<void> main() async {
       );
 
       final WebViewController controller = WebViewController();
-      unawaited(controller.setJavaScriptMode(JavaScriptMode.unrestricted));
-      unawaited(controller.setNavigationDelegate(navigationDelegate));
-      unawaited(controller.loadRequest(Uri.parse(primaryUrl)));
+      await controller.setJavaScriptMode(JavaScriptMode.unrestricted);
+      await controller.setNavigationDelegate(navigationDelegate);
+      await controller.loadRequest(Uri.parse(primaryUrl));
 
       await tester.pumpWidget(WebViewWidget(controller: controller));
 

--- a/packages/webview_flutter/example/integration_test/webview_flutter_test.dart
+++ b/packages/webview_flutter/example/integration_test/webview_flutter_test.dart
@@ -443,6 +443,68 @@ Future<void> main() async {
       expect(currentUrl, isNot(contains('youtube.com')));
     });
 
+    testWidgets('onHttpError', (WidgetTester tester) async {
+      final Completer<HttpResponseError> errorCompleter =
+          Completer<HttpResponseError>();
+
+      final WebViewController controller = WebViewController();
+      unawaited(controller.setJavaScriptMode(JavaScriptMode.unrestricted));
+      unawaited(
+        controller.setNavigationDelegate(
+          NavigationDelegate(
+            onHttpError: (HttpResponseError error) {
+              errorCompleter.complete(error);
+            },
+          ),
+        ),
+      );
+
+      unawaited(controller.loadRequest(Uri.parse('$prefixUrl/favicon.ico')));
+
+      await tester.pumpWidget(WebViewWidget(controller: controller));
+
+      final HttpResponseError error = await errorCompleter.future;
+
+      expect(error, isNotNull);
+      expect(error.response?.statusCode, 404);
+    });
+
+    testWidgets('onHttpError is not called when no HTTP error is received', (
+      WidgetTester tester,
+    ) async {
+      const String testPage = '''
+        <!DOCTYPE html><html>
+        </head>
+        <body>
+        </body>
+        </html>
+      ''';
+
+      final Completer<HttpResponseError> errorCompleter =
+          Completer<HttpResponseError>();
+      final Completer<void> pageFinishCompleter = Completer<void>();
+
+      final WebViewController controller = WebViewController();
+      unawaited(controller.setJavaScriptMode(JavaScriptMode.unrestricted));
+      unawaited(
+        controller.setNavigationDelegate(
+          NavigationDelegate(
+            onPageFinished: (_) => pageFinishCompleter.complete(),
+            onHttpError: (HttpResponseError error) {
+              errorCompleter.complete(error);
+            },
+          ),
+        ),
+      );
+
+      unawaited(controller.loadHtmlString(testPage));
+
+      await tester.pumpWidget(WebViewWidget(controller: controller));
+
+      expect(errorCompleter.future, doesNotComplete);
+      await pageFinishCompleter.future;
+    });
+
     testWidgets('supports asynchronous decisions', (WidgetTester tester) async {
       Completer<void> pageLoaded = Completer<void>();
 
@@ -540,6 +602,41 @@ Future<void> main() async {
 
       await expectLater(urlChangeCompleter.future, completion(secondaryUrl));
     });
+  });
+
+  testWidgets('clearLocalStorage', (WidgetTester tester) async {
+    Completer<void> pageLoadCompleter = Completer<void>();
+
+    final WebViewController controller = WebViewController();
+    await controller.setJavaScriptMode(JavaScriptMode.unrestricted);
+    await controller.setNavigationDelegate(
+      NavigationDelegate(onPageFinished: (_) => pageLoadCompleter.complete()),
+    );
+    await controller.loadRequest(Uri.parse(primaryUrl));
+
+    await tester.pumpWidget(WebViewWidget(controller: controller));
+
+    await pageLoadCompleter.future;
+    pageLoadCompleter = Completer<void>();
+
+    await controller.runJavaScript('localStorage.setItem("myCat", "Tom");');
+    final String myCatItem =
+        await controller.runJavaScriptReturningResult(
+              'localStorage.getItem("myCat");',
+            )
+            as String;
+    expect(myCatItem, 'Tom');
+
+    await controller.clearLocalStorage();
+
+    // Reload page to have changes take effect.
+    await controller.reload();
+    await pageLoadCompleter.future;
+
+    final Object nullItem = await controller.runJavaScriptReturningResult(
+      'localStorage.getItem("myCat");',
+    );
+    expect(nullItem, '');
   });
 }
 

--- a/packages/webview_flutter/example/integration_test/webview_flutter_test.dart
+++ b/packages/webview_flutter/example/integration_test/webview_flutter_test.dart
@@ -618,6 +618,60 @@ Future<void> main() async {
     );
     expect(nullItem, '');
   });
+
+  // Tizen-specific: mounts and disposes two WebViews at the same time, which
+  // used to hit a native disposal race (see the "Using more than one WebView
+  // at the same time" note in README.md).
+  testWidgets('multiple WebViews can be used simultaneously', (
+    WidgetTester tester,
+  ) async {
+    final Completer<void> firstPageFinished = Completer<void>();
+    final Completer<void> secondPageFinished = Completer<void>();
+
+    final WebViewController firstController = WebViewController();
+    await firstController.setJavaScriptMode(JavaScriptMode.unrestricted);
+    await firstController.setNavigationDelegate(
+      NavigationDelegate(onPageFinished: (_) => firstPageFinished.complete()),
+    );
+    await firstController.loadRequest(Uri.parse(primaryUrl));
+
+    final WebViewController secondController = WebViewController();
+    await secondController.setJavaScriptMode(JavaScriptMode.unrestricted);
+    await secondController.setNavigationDelegate(
+      NavigationDelegate(onPageFinished: (_) => secondPageFinished.complete()),
+    );
+    await secondController.loadRequest(Uri.parse(secondaryUrl));
+
+    await tester.pumpWidget(
+      Directionality(
+        textDirection: TextDirection.ltr,
+        child: Row(
+          children: <Widget>[
+            Expanded(child: WebViewWidget(controller: firstController)),
+            Expanded(child: WebViewWidget(controller: secondController)),
+          ],
+        ),
+      ),
+    );
+
+    await firstPageFinished.future;
+    await secondPageFinished.future;
+
+    expect(await firstController.currentUrl(), primaryUrl);
+    expect(await secondController.currentUrl(), secondaryUrl);
+
+    await expectLater(
+      firstController.runJavaScriptReturningResult('1 + 1'),
+      completion(2),
+    );
+    await expectLater(
+      secondController.runJavaScriptReturningResult('2 + 2'),
+      completion(4),
+    );
+
+    // Unmount both WebViews together to exercise concurrent native teardown.
+    await tester.pumpWidget(Container());
+  });
 }
 
 class ResizableWebView extends StatefulWidget {

--- a/packages/webview_flutter/example/integration_test/webview_flutter_test.dart
+++ b/packages/webview_flutter/example/integration_test/webview_flutter_test.dart
@@ -618,59 +618,6 @@ Future<void> main() async {
     );
     expect(nullItem, '');
   });
-
-  // Tizen-specific: mounts and disposes two WebViews at the same time, which
-  // used to hit a native disposal race fixed in CHANGELOG.md's 0.10.1 entry.
-  testWidgets('multiple WebViews can be used simultaneously', (
-    WidgetTester tester,
-  ) async {
-    final Completer<void> firstPageFinished = Completer<void>();
-    final Completer<void> secondPageFinished = Completer<void>();
-
-    final WebViewController firstController = WebViewController();
-    await firstController.setJavaScriptMode(JavaScriptMode.unrestricted);
-    await firstController.setNavigationDelegate(
-      NavigationDelegate(onPageFinished: (_) => firstPageFinished.complete()),
-    );
-    await firstController.loadRequest(Uri.parse(primaryUrl));
-
-    final WebViewController secondController = WebViewController();
-    await secondController.setJavaScriptMode(JavaScriptMode.unrestricted);
-    await secondController.setNavigationDelegate(
-      NavigationDelegate(onPageFinished: (_) => secondPageFinished.complete()),
-    );
-    await secondController.loadRequest(Uri.parse(secondaryUrl));
-
-    await tester.pumpWidget(
-      Directionality(
-        textDirection: TextDirection.ltr,
-        child: Row(
-          children: <Widget>[
-            Expanded(child: WebViewWidget(controller: firstController)),
-            Expanded(child: WebViewWidget(controller: secondController)),
-          ],
-        ),
-      ),
-    );
-
-    await firstPageFinished.future;
-    await secondPageFinished.future;
-
-    expect(await firstController.currentUrl(), primaryUrl);
-    expect(await secondController.currentUrl(), secondaryUrl);
-
-    await expectLater(
-      firstController.runJavaScriptReturningResult('1 + 1'),
-      completion(2),
-    );
-    await expectLater(
-      secondController.runJavaScriptReturningResult('2 + 2'),
-      completion(4),
-    );
-
-    // Unmount both WebViews together to exercise concurrent native teardown.
-    await tester.pumpWidget(Container());
-  });
 }
 
 class ResizableWebView extends StatefulWidget {

--- a/packages/webview_flutter/example/integration_test/webview_flutter_test.dart
+++ b/packages/webview_flutter/example/integration_test/webview_flutter_test.dart
@@ -620,8 +620,7 @@ Future<void> main() async {
   });
 
   // Tizen-specific: mounts and disposes two WebViews at the same time, which
-  // used to hit a native disposal race (see the "Using more than one WebView
-  // at the same time" note in README.md).
+  // used to hit a native disposal race fixed in CHANGELOG.md's 0.10.1 entry.
   testWidgets('multiple WebViews can be used simultaneously', (
     WidgetTester tester,
   ) async {

--- a/packages/webview_flutter/example/lib/main.dart
+++ b/packages/webview_flutter/example/lib/main.dart
@@ -190,10 +190,9 @@ Page resource error:
             debugPrint('allowing navigation to ${request.url}');
             return NavigationDecision.navigate;
           },
-          // Note: onHttpError is not implemented by TizenWebview.
-          // onHttpError: (HttpResponseError error) {
-          //   debugPrint('Error occurred on page: ${error.response?.statusCode}');
-          // },
+          onHttpError: (HttpResponseError error) {
+            debugPrint('Error occurred on page: ${error.response?.statusCode}');
+          },
           onUrlChange: (UrlChange change) {
             debugPrint('url change to ${change.url}');
           },
@@ -491,8 +490,7 @@ class SampleMenu extends StatelessWidget {
 
   Future<void> _onClearCache(BuildContext context) async {
     await webViewController.clearCache();
-    // This is unimplemented in webview_flutter_tizen.
-    // await webViewController.clearLocalStorage();
+    await webViewController.clearLocalStorage();
     if (context.mounted) {
       ScaffoldMessenger.of(
         context,

--- a/packages/webview_flutter/lib/src/tizen_webview.dart
+++ b/packages/webview_flutter/lib/src/tizen_webview.dart
@@ -151,6 +151,10 @@ class TizenWebView {
   /// Clears all caches used by the [WebView].
   Future<void> clearCache() => _invokeChannelMethod<void>('clearCache');
 
+  /// Clears the local storage used by the [WebView].
+  Future<void> clearLocalStorage() =>
+      _invokeChannelMethod<void>('clearLocalStorage');
+
   /// Sets the JavaScript execution mode to be used by the webview.
   Future<void> setJavaScriptMode(int javaScriptMode) =>
       _invokeChannelMethod<void>('javaScriptMode', javaScriptMode);

--- a/packages/webview_flutter/lib/src/tizen_webview_controller.dart
+++ b/packages/webview_flutter/lib/src/tizen_webview_controller.dart
@@ -218,12 +218,7 @@ class TizenWebViewController extends PlatformWebViewController {
   Future<void> clearCache() => _webview.clearCache();
 
   @override
-  Future<void> clearLocalStorage() {
-    throw UnimplementedError(
-      'This version of `TizenWebViewController` currently has no '
-      'implementation.',
-    );
-  }
+  Future<void> clearLocalStorage() => _webview.clearLocalStorage();
 
   @override
   Future<void> setPlatformNavigationDelegate(
@@ -477,6 +472,7 @@ class TizenNavigationDelegate extends PlatformNavigationDelegate {
   WebResourceErrorCallback? _onWebResourceError;
   NavigationRequestCallback? _onNavigationRequest;
   UrlChangeCallback? _onUrlChange;
+  HttpResponseErrorCallback? _onHttpError;
 
   /// Called when [TizenView] is created.
   void createNavigationDelegateChannel(int viewId) {
@@ -523,6 +519,20 @@ class TizenNavigationDelegate extends PlatformNavigationDelegate {
         case 'onUrlChange':
           if (_onUrlChange != null) {
             _onUrlChange!(UrlChange(url: arguments['url']! as String));
+          }
+          return null;
+        case 'onHttpError':
+          if (_onHttpError != null) {
+            final Uri uri = Uri.parse(arguments['url']! as String);
+            _onHttpError!(
+              HttpResponseError(
+                request: WebResourceRequest(uri: uri),
+                response: WebResourceResponse(
+                  uri: uri,
+                  statusCode: arguments['statusCode']! as int,
+                ),
+              ),
+            );
           }
           return null;
       }
@@ -580,10 +590,7 @@ class TizenNavigationDelegate extends PlatformNavigationDelegate {
 
   @override
   Future<void> setOnHttpError(HttpResponseErrorCallback onHttpError) async {
-    throw UnimplementedError(
-      'This version of `TizenNavigationDelegate` currently has no '
-      'implementation for `setOnHttpError`',
-    );
+    _onHttpError = onHttpError;
   }
 
   @override

--- a/packages/webview_flutter/pubspec.yaml
+++ b/packages/webview_flutter/pubspec.yaml
@@ -2,7 +2,7 @@ name: webview_flutter_tizen
 description: Tizen implementation of the webview_flutter plugin.
 homepage: https://github.com/flutter-tizen/plugins
 repository: https://github.com/flutter-tizen/plugins/tree/master/packages/webview_flutter
-version: 0.10.0
+version: 0.10.1
 
 environment:
   sdk: ^3.8.0

--- a/packages/webview_flutter/tizen/src/buffer_pool.cc
+++ b/packages/webview_flutter/tizen/src/buffer_pool.cc
@@ -4,11 +4,31 @@
 
 #include "buffer_pool.h"
 
+#include <mutex>
+#include <set>
+
 #include "log.h"
 
-BufferUnit::BufferUnit(int32_t width, int32_t height) { Reset(width, height); }
+namespace {
+// Tracks live BufferUnits so the engine's release_callback (below) can detect
+// one that was already destroyed instead of dereferencing freed memory.
+std::set<BufferUnit*> active_buffers;
+std::mutex active_buffers_mutex;
+}  // namespace
+
+BufferUnit::BufferUnit(int32_t width, int32_t height) {
+  {
+    std::lock_guard<std::mutex> lock(active_buffers_mutex);
+    active_buffers.insert(this);
+  }
+  Reset(width, height);
+}
 
 BufferUnit::~BufferUnit() {
+  {
+    std::lock_guard<std::mutex> lock(active_buffers_mutex);
+    active_buffers.erase(this);
+  }
   if (tbm_surface_ && !use_external_buffer_) {
     tbm_surface_destroy(tbm_surface_);
     tbm_surface_ = nullptr;
@@ -76,7 +96,10 @@ void BufferUnit::Reset(int32_t width, int32_t height) {
   gpu_surface_->handle = tbm_surface_;
   gpu_surface_->release_callback = [](void* release_context) {
     BufferUnit* buffer = reinterpret_cast<BufferUnit*>(release_context);
-    buffer->UnmarkInUse();
+    std::lock_guard<std::mutex> lock(active_buffers_mutex);
+    if (active_buffers.find(buffer) != active_buffers.end()) {
+      buffer->UnmarkInUse();
+    }
   };
   gpu_surface_->release_context = this;
 }

--- a/packages/webview_flutter/tizen/src/webview.cc
+++ b/packages/webview_flutter/tizen/src/webview.cc
@@ -4,6 +4,7 @@
 
 #include "webview.h"
 
+#include <Ecore.h>
 #include <Ecore_Evas.h>
 #include <app_common.h>
 #include <flutter/standard_method_codec.h>
@@ -44,9 +45,19 @@ std::string ConvertLogLevelToString(Ewk_Console_Message_Level level) {
 
 class NavigationRequestResult : public FlMethodResult {
  public:
-  NavigationRequestResult(WebView* webview) : webview_(webview) {}
+  // |alive| is the WebView's is_alive_ flag. Dart resolves the
+  // "navigationRequest" method call asynchronously (it round-trips through
+  // the Dart navigation delegate), so this result's completion can run well
+  // after the WebView that created it has been disposed; |webview_| would
+  // then be a dangling pointer. Checking |alive| before dereferencing it
+  // avoids a use-after-free in that case.
+  NavigationRequestResult(WebView* webview, std::shared_ptr<bool> alive)
+      : webview_(webview), alive_(std::move(alive)) {}
 
   void SuccessInternal(const flutter::EncodableValue* should_load) override {
+    if (!*alive_) {
+      return;
+    }
     if (std::holds_alternative<bool>(*should_load)) {
       if (std::get<bool>(*should_load)) {
         webview_->Resume();
@@ -60,16 +71,23 @@ class NavigationRequestResult : public FlMethodResult {
                      const std::string& error_message,
                      const flutter::EncodableValue* error_details) override {
     LOG_ERROR("The request unexpectedly completed with an error.");
+    if (!*alive_) {
+      return;
+    }
     webview_->Stop();
   }
 
   void NotImplementedInternal() override {
     LOG_ERROR("The target method was unexpectedly unimplemented.");
+    if (!*alive_) {
+      return;
+    }
     webview_->Stop();
   }
 
  private:
   WebView* webview_;
+  std::shared_ptr<bool> alive_;
 };
 
 template <typename T>
@@ -173,33 +191,111 @@ void WebView::Dispose() {
   if (disposed_) {
     return;
   }
+  disposed_ = true;
 
-  texture_registrar_->UnregisterTexture(GetTextureId(), nullptr);
+  // A Dart "navigationRequest" reply can still arrive after Dispose() has
+  // run. The reply handler checks this flag and returns early, instead of
+  // using a WebView that no longer exists.
+  *is_alive_ = false;
 
-  if (webview_instance_) {
-    evas_object_smart_callback_del(webview_instance_,
-                                   "offscreen,frame,rendered",
+  Evas_Object* instance = webview_instance_;
+  webview_instance_ = nullptr;
+
+  if (instance) {
+    // Detach every callback registered in InitWebView() and
+    // RegisterJavaScriptChannelName(). The engine instance lives until the
+    // deferred evas_object_del() below, while this WebView is destroyed
+    // right after Dispose(). Without detaching, the engine could invoke
+    // these callbacks on the already-destroyed WebView during that window.
+    evas_object_smart_callback_del(instance, "offscreen,frame,rendered",
                                    &WebView::OnFrameRendered);
-    evas_object_smart_callback_del(webview_instance_, "load,started",
+    evas_object_smart_callback_del(instance, "load,started",
                                    &WebView::OnLoadStarted);
-    evas_object_smart_callback_del(webview_instance_, "load,finished",
+    evas_object_smart_callback_del(instance, "load,finished",
                                    &WebView::OnLoadFinished);
-    evas_object_smart_callback_del(webview_instance_, "load,progress",
+    evas_object_smart_callback_del(instance, "load,progress",
                                    &WebView::OnProgress);
-    evas_object_smart_callback_del(webview_instance_, "load,error",
+    evas_object_smart_callback_del(instance, "load,error",
                                    &WebView::OnLoadError);
-    evas_object_smart_callback_del(webview_instance_, "console,message",
+    evas_object_smart_callback_del(instance, "console,message",
                                    &WebView::OnConsoleMessage);
-    evas_object_smart_callback_del(webview_instance_,
-                                   "policy,navigation,decide",
+    evas_object_smart_callback_del(instance, "policy,navigation,decide",
                                    &WebView::OnNavigationPolicy);
-    evas_object_smart_callback_del(webview_instance_, "url,changed",
+    evas_object_smart_callback_del(instance, "policy,response,decide",
+                                   &WebView::OnResponsePolicy);
+    evas_object_smart_callback_del(instance, "url,changed",
                                    &WebView::OnUrlChange);
-    evas_object_del(webview_instance_);
+    EwkInternalApiBinding::GetInstance().view.OnJavaScriptAlert(
+        instance, nullptr, nullptr);
+    EwkInternalApiBinding::GetInstance().view.OnJavaScriptConfirm(
+        instance, nullptr, nullptr);
+    EwkInternalApiBinding::GetInstance().view.OnJavaScriptPrompt(
+        instance, nullptr, nullptr);
+    evas_object_data_del(instance, kEwkInstance);
+
+    // Cancel any in-flight load and pause the page so it stops running while
+    // the deferred teardown below is pending.
+    ewk_view_stop(instance);
+    ewk_view_suspend(instance);
   }
 
+  // Stop handing out engine-owned TBM surfaces to the raster thread, and
+  // detach the buffer pool so its GPU surface descriptors outlive this
+  // object for any raster-thread frame still in flight.
+  std::unique_ptr<BufferPool> pool;
+  {
+    std::lock_guard<std::mutex> lock(mutex_);
+    is_disposing_ = true;
+    working_surface_ = nullptr;
+    candidate_surface_ = nullptr;
+    rendered_surface_ = nullptr;
+    pool = std::move(tbm_pool_);
+  }
+
+  // The TBM surfaces backing the texture are owned by the web engine and are
+  // freed when the engine view is deleted. Deleting the view while an
+  // in-flight raster-thread frame is still reading one of those surfaces is a
+  // use-after-free (the emulator's SW rendering path reads the buffer on the
+  // CPU), crashing with SIGSEGV during EWebView teardown. The embedder tears
+  // the external texture down on the render thread only after any in-flight
+  // frame callback has completed and then invokes this completion callback,
+  // so evas_object_del() (and the release of the descriptor-owning buffer
+  // pool) is deferred until then. The callback fires on the render thread;
+  // evas_object_del() must run on the main thread, so hop back via
+  // ecore_main_loop_thread_safe_call_async().
+  struct TeardownContext {
+    Evas_Object* instance;
+    std::unique_ptr<BufferPool> pool;
+  };
+  auto* context = new TeardownContext{instance, std::move(pool)};
+  texture_registrar_->UnregisterTexture(GetTextureId(), [context]() {
+    ecore_main_loop_thread_safe_call_async(
+        [](void* data) {
+          auto* context = static_cast<TeardownContext*>(data);
+          if (context->instance) {
+#if defined(TV_PROFILE) && (defined(__x86_64__) || defined(__i386__))
+            // On the Tizen 10.0 TV emulator image (the only TV + x86_64
+            // target), deleting the ewk view crashes with SIGSEGV inside
+            // chromium-efl's ~SelectionControllerEfl(): after unsubscribing
+            // VCONFKEY_LANGSET it calls HideHandleAndContextMenu() ->
+            // CancelContextMenu(), which dereferences the WebContents that is
+            // already being destructed. That is engine code this plugin
+            // cannot fix, so hide the (already stopped and suspended) view
+            // and intentionally leak it instead of crashing. All other
+            // targets (arm/arm64 devices, the 32-bit x86 emulator, and the
+            // common-profile x86_64 emulator, whose engines are unaffected)
+            // delete normally.
+            evas_object_hide(context->instance);
+#else
+            evas_object_del(context->instance);
+#endif
+          }
+          delete context;
+        },
+        context);
+  });
+
   // ewk_shutdown();
-  disposed_ = true;
 }
 
 void WebView::Offset(double left, double top) {
@@ -331,9 +427,17 @@ bool WebView::SendKey(const char* key, const char* string, const char* compose,
   return true;
 }
 
-void WebView::Resume() { ewk_view_resume(webview_instance_); }
+void WebView::Resume() {
+  if (webview_instance_) {
+    ewk_view_resume(webview_instance_);
+  }
+}
 
-void WebView::Stop() { ewk_view_stop(webview_instance_); }
+void WebView::Stop() {
+  if (webview_instance_) {
+    ewk_view_stop(webview_instance_);
+  }
+}
 
 void WebView::SetDirection(int direction) {
   // TODO: Implement if necessary.
@@ -453,6 +557,12 @@ void WebView::HandleWebViewMethodCall(const FlMethodCall& method_call,
                                       std::unique_ptr<FlMethodResult> result) {
   const std::string& method_name = method_call.method_name();
   const flutter::EncodableValue* arguments = method_call.arguments();
+
+  if (disposed_) {
+    result->Error("Invalid operation",
+                  "The webview instance has been disposed.");
+    return;
+  }
 
   if (method_name == "setEnginePolicy") {
     const auto* engine_policy = std::get_if<bool>(arguments);
@@ -751,6 +861,9 @@ void WebView::HandleCookieMethodCall(const FlMethodCall& method_call,
 FlutterDesktopGpuSurfaceDescriptor* WebView::ObtainGpuSurface(size_t width,
                                                               size_t height) {
   std::lock_guard<std::mutex> lock(mutex_);
+  if (is_disposing_ || !tbm_pool_) {
+    return nullptr;
+  }
   if (!candidate_surface_) {
     if (rendered_surface_) {
       return rendered_surface_->GpuSurface();
@@ -770,6 +883,9 @@ void WebView::OnFrameRendered(void* data, Evas_Object* obj, void* event_info) {
     WebView* webview = static_cast<WebView*>(data);
 
     std::lock_guard<std::mutex> lock(webview->mutex_);
+    if (webview->is_disposing_ || !webview->tbm_pool_) {
+      return;
+    }
     if (!webview->working_surface_) {
       webview->working_surface_ = webview->tbm_pool_->GetAvailableBuffer();
       webview->working_surface_->UseExternalBuffer();
@@ -871,14 +987,14 @@ void WebView::OnNavigationPolicy(void* data, Evas_Object* obj,
       {flutter::EncodableValue("isForMainFrame"),
        flutter::EncodableValue(true)},
   };
-  auto result = std::make_unique<NavigationRequestResult>(webview);
+  auto result =
+      std::make_unique<NavigationRequestResult>(webview, webview->is_alive_);
   webview->navigation_delegate_channel_->InvokeMethod(
       "navigationRequest", std::make_unique<flutter::EncodableValue>(args),
       std::move(result));
 }
 
-void WebView::OnResponsePolicy(void* data, Evas_Object* obj,
-                               void* event_info) {
+void WebView::OnResponsePolicy(void* data, Evas_Object* obj, void* event_info) {
   WebView* webview = static_cast<WebView*>(data);
   Ewk_Policy_Decision* policy_decision =
       static_cast<Ewk_Policy_Decision*>(event_info);
@@ -892,8 +1008,7 @@ void WebView::OnResponsePolicy(void* data, Evas_Object* obj,
     return;
   }
   flutter::EncodableMap args = {
-      {flutter::EncodableValue("url"),
-       flutter::EncodableValue(url ? url : "")},
+      {flutter::EncodableValue("url"), flutter::EncodableValue(url ? url : "")},
       {flutter::EncodableValue("statusCode"),
        flutter::EncodableValue(status_code)},
   };
@@ -926,7 +1041,9 @@ void WebView::OnJavaScriptMessage(Evas_Object* obj,
   if (obj) {
     WebView* webview =
         static_cast<WebView*>(evas_object_data_get(obj, kEwkInstance));
-    if (webview->webview_channel_) {
+    // The data key is removed in Dispose(), so a message arriving during the
+    // deferred teardown yields nullptr here rather than a dangling pointer.
+    if (webview && webview->webview_channel_) {
       std::string channel_name(message.name);
       std::string message_body(static_cast<char*>(message.body));
 

--- a/packages/webview_flutter/tizen/src/webview.cc
+++ b/packages/webview_flutter/tizen/src/webview.cc
@@ -429,6 +429,8 @@ bool WebView::InitWebView() {
                                  &WebView::OnConsoleMessage, this);
   evas_object_smart_callback_add(webview_instance_, "policy,navigation,decide",
                                  &WebView::OnNavigationPolicy, this);
+  evas_object_smart_callback_add(webview_instance_, "policy,response,decide",
+                                 &WebView::OnResponsePolicy, this);
   evas_object_smart_callback_add(webview_instance_, "url,changed",
                                  &WebView::OnUrlChange, this);
 
@@ -579,6 +581,10 @@ void WebView::HandleWebViewMethodCall(const FlMethodCall& method_call,
   } else if (method_name == "clearCache") {
     Ewk_Context* context = ewk_view_context_get(webview_instance_);
     ewk_context_resource_cache_clear(context);
+    result->Success();
+  } else if (method_name == "clearLocalStorage") {
+    Ewk_Context* context = ewk_view_context_get(webview_instance_);
+    ewk_context_web_storage_delete_all(context);
     result->Success();
   } else if (method_name == "getTitle") {
     result->Success(flutter::EncodableValue(
@@ -869,6 +875,30 @@ void WebView::OnNavigationPolicy(void* data, Evas_Object* obj,
   webview->navigation_delegate_channel_->InvokeMethod(
       "navigationRequest", std::make_unique<flutter::EncodableValue>(args),
       std::move(result));
+}
+
+void WebView::OnResponsePolicy(void* data, Evas_Object* obj,
+                               void* event_info) {
+  WebView* webview = static_cast<WebView*>(data);
+  Ewk_Policy_Decision* policy_decision =
+      static_cast<Ewk_Policy_Decision*>(event_info);
+  int status_code =
+      ewk_policy_decision_response_status_code_get(policy_decision);
+  const char* url = ewk_policy_decision_url_get(policy_decision);
+  ewk_policy_decision_use(policy_decision);
+
+  // HTTP error status codes (4xx, 5xx) are reported to the navigation delegate.
+  if (!webview->has_navigation_delegate_ || status_code < 400) {
+    return;
+  }
+  flutter::EncodableMap args = {
+      {flutter::EncodableValue("url"),
+       flutter::EncodableValue(url ? url : "")},
+      {flutter::EncodableValue("statusCode"),
+       flutter::EncodableValue(status_code)},
+  };
+  webview->navigation_delegate_channel_->InvokeMethod(
+      "onHttpError", std::make_unique<flutter::EncodableValue>(args));
 }
 
 void WebView::OnUrlChange(void* data, Evas_Object* obj, void* event_info) {

--- a/packages/webview_flutter/tizen/src/webview.cc
+++ b/packages/webview_flutter/tizen/src/webview.cc
@@ -51,8 +51,8 @@ std::string ConvertLogLevelToString(Ewk_Console_Message_Level level) {
 
 class NavigationRequestResult : public FlMethodResult {
  public:
-  // Dart resolves "navigationRequest" asynchronously, so completion can run
-  // after |webview| is destroyed; |alive| gates every dereference.
+  // |alive| gates every dereference below: Dart resolves this call
+  // asynchronously, so it can complete after |webview| is destroyed.
   NavigationRequestResult(WebView* webview, std::shared_ptr<bool> alive)
       : webview_(webview), alive_(std::move(alive)) {}
 
@@ -107,25 +107,25 @@ bool GetValueFromEncodableMap(const flutter::EncodableValue* arguments,
   return false;
 }
 
-// Deferred: the raster thread may still be reading TBM surfaces the engine
-// owns, and ewk_shutdown() fatally CHECKs if any Ewk_View is still alive.
-// FlushPendingTeardowns() drains this registry before that shutdown call.
+// Registry of WebViews whose evas_object_del() is still pending (see
+// Dispose()). FlushPendingTeardowns() drains it before ewk_shutdown(), which
+// fatally CHECKs if any Ewk_View is still alive.
 struct PendingTeardown {
   Evas_Object* instance = nullptr;
-  // Guards against the queued callback and a force-delete both deleting
-  // the same instance.
+  std::shared_ptr<BufferPool> pool;
   std::atomic<bool> completed{false};
 };
 
 std::mutex g_pending_teardown_mutex;
 std::vector<std::shared_ptr<PendingTeardown>> g_pending_teardowns;
 
-Ecore_Evas* g_shared_canvas = nullptr;
+Ecore_Evas* g_offscreen_host = nullptr;
 
 std::shared_ptr<PendingTeardown> RegisterPendingTeardown(
-    Evas_Object* instance) {
+    Evas_Object* instance, std::shared_ptr<BufferPool> pool) {
   auto pending = std::make_shared<PendingTeardown>();
   pending->instance = instance;
+  pending->pool = std::move(pool);
   std::lock_guard<std::mutex> lock(g_pending_teardown_mutex);
   g_pending_teardowns.push_back(pending);
   return pending;
@@ -229,10 +229,13 @@ std::string WebView::GetNavigationDelegateChannelName() {
 }
 
 void WebView::Dispose() {
-  if (disposed_) {
-    return;
+  {
+    std::lock_guard<std::mutex> lock(mutex_);
+    if (disposed_) {
+      return;
+    }
+    disposed_ = true;
   }
-  disposed_ = true;
   *is_alive_ = false;
 
   Evas_Object* instance = webview_instance_;
@@ -275,7 +278,6 @@ void WebView::Dispose() {
   std::shared_ptr<BufferPool> pool;
   {
     std::lock_guard<std::mutex> lock(mutex_);
-    is_disposing_ = true;
     working_surface_ = nullptr;
     candidate_surface_ = nullptr;
     rendered_surface_ = nullptr;
@@ -284,44 +286,50 @@ void WebView::Dispose() {
 
   // UnregisterTexture()'s completion callback fires on the render thread, so
   // hop back to the main loop before completing the deferred delete.
-  struct TeardownContext {
-    std::shared_ptr<PendingTeardown> pending;
-    std::shared_ptr<BufferPool> pool;
-  };
-  auto* context =
-      new TeardownContext{RegisterPendingTeardown(instance), std::move(pool)};
-  texture_registrar_->UnregisterTexture(GetTextureId(), [context]() {
+  auto pending = RegisterPendingTeardown(instance, std::move(pool));
+  texture_registrar_->UnregisterTexture(GetTextureId(), [pending]() {
     // Must stay a high-priority timeout: g_idle_add() runs too late and the
     // delete then races the raster thread on the TV emulator.
     g_timeout_add_full(
         G_PRIORITY_HIGH, 0,
         [](gpointer data) -> gboolean {
-          auto* context = static_cast<TeardownContext*>(data);
-          CompletePendingTeardown(context->pending);
+          auto* pending = static_cast<std::shared_ptr<PendingTeardown>*>(data);
+          CompletePendingTeardown(*pending);
           return G_SOURCE_REMOVE;
         },
-        context,
-        [](gpointer data) { delete static_cast<TeardownContext*>(data); });
+        new std::shared_ptr<PendingTeardown>(pending),
+        [](gpointer data) {
+          delete static_cast<std::shared_ptr<PendingTeardown>*>(data);
+        });
   });
 }
 
 // static
-Ecore_Evas* WebView::GetSharedCanvas() {
-  if (!g_shared_canvas) {
-    // "wayland_shm", not "wayland_egl": this canvas only hosts the ewk_view
-    // smart object (content arrives via tbm_surface), and wayland_egl raced
-    // libtpl-egl's wl_egl_thread teardown on disposal.
-    g_shared_canvas = ecore_evas_new("wayland_shm", 0, 0, 1, 1, 0);
+Ecore_Evas* WebView::GetOffscreenHost() {
+  if (!g_offscreen_host) {
+    // wayland_shm, not wayland_egl: wayland_egl raced libtpl-egl's
+    // wl_egl_thread teardown on disposal.
+    g_offscreen_host = ecore_evas_new("wayland_shm", 0, 0, 1, 1, 0);
   }
-  return g_shared_canvas;
+  return g_offscreen_host;
 }
 
 // static
-void WebView::FreeSharedCanvas() {
-  if (g_shared_canvas) {
-    ecore_evas_free(g_shared_canvas);
-    g_shared_canvas = nullptr;
+void WebView::FreeOffscreenHost() {
+  if (g_offscreen_host) {
+    ecore_evas_free(g_offscreen_host);
+    g_offscreen_host = nullptr;
   }
+}
+
+// static
+void WebView::InitializeEngine() { ewk_init(); }
+
+// static
+void WebView::ShutdownEngine() {
+  FlushPendingTeardowns();
+  FreeOffscreenHost();
+  ewk_shutdown();
 }
 
 // static
@@ -338,18 +346,13 @@ void WebView::FlushPendingTeardowns() {
       pending = g_pending_teardowns.front();
     }
     if (g_get_monotonic_time() >= deadline) {
-      // Force stragglers through past the deadline instead of blocking
-      // forever.
       LOG_WARN(
           "Forcing WebView teardown past the deadline before ewk_shutdown()");
       CompletePendingTeardown(pending);
       continue;
     }
-    // Pump the same GLib context the queued g_timeout_add_full hop (see
-    // Dispose()) is scheduled on, so it gets a chance to run and remove
-    // this entry itself. Non-blocking: if that hop never arrives (e.g. the
-    // render thread already stalled), a blocking iteration here would never
-    // return to let the deadline check above fire.
+    // Non-blocking: pump the same context the queued g_timeout_add_full hop
+    // runs on, without stalling past the deadline check above.
     if (!g_main_context_iteration(g_main_context_default(), FALSE)) {
       g_usleep(1000);
     }
@@ -517,9 +520,7 @@ bool WebView::InitWebView() {
   EwkInternalApiBinding::GetInstance().main.SetArguments(chromium_argc,
                                                          chromium_argv);
 
-  // ewk_init() is called once for the process lifetime by
-  // WebviewFlutterTizenPlugin's constructor, not per WebView instance.
-  Ecore_Evas* evas = GetSharedCanvas();
+  Ecore_Evas* evas = GetOffscreenHost();
   if (!evas) {
     return false;
   }
@@ -612,10 +613,13 @@ void WebView::HandleWebViewMethodCall(const FlMethodCall& method_call,
   const std::string& method_name = method_call.method_name();
   const flutter::EncodableValue* arguments = method_call.arguments();
 
-  if (disposed_) {
-    result->Error("Invalid operation",
-                  "The webview instance has been disposed.");
-    return;
+  {
+    std::lock_guard<std::mutex> lock(mutex_);
+    if (disposed_) {
+      result->Error("Invalid operation",
+                    "The webview instance has been disposed.");
+      return;
+    }
   }
 
   if (method_name == "setEnginePolicy") {
@@ -915,7 +919,7 @@ void WebView::HandleCookieMethodCall(const FlMethodCall& method_call,
 FlutterDesktopGpuSurfaceDescriptor* WebView::ObtainGpuSurface(size_t width,
                                                               size_t height) {
   std::lock_guard<std::mutex> lock(mutex_);
-  if (is_disposing_ || !tbm_pool_) {
+  if (disposed_ || !tbm_pool_) {
     return nullptr;
   }
   if (!candidate_surface_) {
@@ -937,7 +941,7 @@ void WebView::OnFrameRendered(void* data, Evas_Object* obj, void* event_info) {
     WebView* webview = static_cast<WebView*>(data);
 
     std::lock_guard<std::mutex> lock(webview->mutex_);
-    if (webview->is_disposing_ || !webview->tbm_pool_) {
+    if (webview->disposed_ || !webview->tbm_pool_) {
       return;
     }
     if (!webview->working_surface_) {

--- a/packages/webview_flutter/tizen/src/webview.cc
+++ b/packages/webview_flutter/tizen/src/webview.cc
@@ -347,8 +347,12 @@ void WebView::FlushPendingTeardowns() {
     }
     // Pump the same GLib context the queued g_timeout_add_full hop (see
     // Dispose()) is scheduled on, so it gets a chance to run and remove
-    // this entry itself.
-    g_main_context_iteration(g_main_context_default(), TRUE);
+    // this entry itself. Non-blocking: if that hop never arrives (e.g. the
+    // render thread already stalled), a blocking iteration here would never
+    // return to let the deadline check above fire.
+    if (!g_main_context_iteration(g_main_context_default(), FALSE)) {
+      g_usleep(1000);
+    }
   }
 }
 

--- a/packages/webview_flutter/tizen/src/webview.cc
+++ b/packages/webview_flutter/tizen/src/webview.cc
@@ -107,8 +107,9 @@ bool GetValueFromEncodableMap(const flutter::EncodableValue* arguments,
   return false;
 }
 
-// Tracks Dispose()'s deferred evas_object_del() calls so
-// FlushPendingTeardowns() can drain them to empty before ewk_shutdown().
+// Deferred: the raster thread may still be reading TBM surfaces the engine
+// owns, and ewk_shutdown() fatally CHECKs if any Ewk_View is still alive.
+// FlushPendingTeardowns() drains this registry before that shutdown call.
 struct PendingTeardown {
   Evas_Object* instance = nullptr;
   // Guards against the queued callback and a force-delete both deleting
@@ -238,8 +239,8 @@ void WebView::Dispose() {
   webview_instance_ = nullptr;
 
   if (instance) {
-    // The engine instance outlives this WebView until the deferred
-    // evas_object_del() below, so every callback must be detached here.
+    // |instance| outlives this WebView until its deferred delete runs (see
+    // PendingTeardown), so every callback bound to it must be detached now.
     evas_object_smart_callback_del(instance, "offscreen,frame,rendered",
                                    &WebView::OnFrameRendered);
     evas_object_smart_callback_del(instance, "load,started",
@@ -281,9 +282,8 @@ void WebView::Dispose() {
     pool = std::move(tbm_pool_);
   }
 
-  // evas_object_del() frees TBM surfaces the raster thread may still be
-  // reading, so defer it until the embedder confirms the texture is torn
-  // down. That confirmation fires on the render thread, hence the hop below.
+  // UnregisterTexture()'s completion callback fires on the render thread, so
+  // hop back to the main loop before completing the deferred delete.
   struct TeardownContext {
     std::shared_ptr<PendingTeardown> pending;
     std::shared_ptr<BufferPool> pool;
@@ -338,9 +338,10 @@ void WebView::FlushPendingTeardowns() {
       pending = g_pending_teardowns.front();
     }
     if (g_get_monotonic_time() >= deadline) {
-      // A leaked Ewk_View is a guaranteed fatal CHECK in ewk_shutdown(), so
-      // force the remaining deletes through rather than waiting any longer.
-      LOG_WARN("Forcing WebView teardown past the deadline before ewk_shutdown()");
+      // Force stragglers through past the deadline instead of blocking
+      // forever.
+      LOG_WARN(
+          "Forcing WebView teardown past the deadline before ewk_shutdown()");
       CompletePendingTeardown(pending);
       continue;
     }

--- a/packages/webview_flutter/tizen/src/webview.cc
+++ b/packages/webview_flutter/tizen/src/webview.cc
@@ -11,8 +11,11 @@
 #include <glib.h>
 #include <tbm_surface.h>
 
+#include <algorithm>
+#include <atomic>
 #include <cstdlib>
 #include <cstring>
+#include <vector>
 
 #include "buffer_pool.h"
 #include "log.h"
@@ -102,6 +105,42 @@ bool GetValueFromEncodableMap(const flutter::EncodableValue* arguments,
     }
   }
   return false;
+}
+
+// Tracks Dispose()'s deferred evas_object_del() calls so
+// FlushPendingTeardowns() can drain them to empty before ewk_shutdown().
+struct PendingTeardown {
+  Evas_Object* instance = nullptr;
+  // Guards against the queued callback and a force-delete both deleting
+  // the same instance.
+  std::atomic<bool> completed{false};
+};
+
+std::mutex g_pending_teardown_mutex;
+std::vector<std::shared_ptr<PendingTeardown>> g_pending_teardowns;
+
+std::shared_ptr<PendingTeardown> RegisterPendingTeardown(
+    Evas_Object* instance) {
+  auto pending = std::make_shared<PendingTeardown>();
+  pending->instance = instance;
+  std::lock_guard<std::mutex> lock(g_pending_teardown_mutex);
+  g_pending_teardowns.push_back(pending);
+  return pending;
+}
+
+// Idempotent: safe to call more than once for the same |pending|.
+void CompletePendingTeardown(const std::shared_ptr<PendingTeardown>& pending) {
+  bool expected = false;
+  if (pending->completed.compare_exchange_strong(expected, true) &&
+      pending->instance) {
+    evas_object_del(pending->instance);
+  }
+  std::lock_guard<std::mutex> lock(g_pending_teardown_mutex);
+  auto it = std::find(g_pending_teardowns.begin(), g_pending_teardowns.end(),
+                      pending);
+  if (it != g_pending_teardowns.end()) {
+    g_pending_teardowns.erase(it);
+  }
 }
 
 }  // namespace
@@ -244,10 +283,11 @@ void WebView::Dispose() {
   // reading, so defer it until the embedder confirms the texture is torn
   // down. That confirmation fires on the render thread, hence the hop below.
   struct TeardownContext {
-    Evas_Object* instance;
+    std::shared_ptr<PendingTeardown> pending;
     std::shared_ptr<BufferPool> pool;
   };
-  auto* context = new TeardownContext{instance, std::move(pool)};
+  auto* context =
+      new TeardownContext{RegisterPendingTeardown(instance), std::move(pool)};
   texture_registrar_->UnregisterTexture(GetTextureId(), [context]() {
     // Must stay a high-priority timeout: g_idle_add() runs too late and the
     // delete then races the raster thread on the TV emulator.
@@ -255,24 +295,39 @@ void WebView::Dispose() {
         G_PRIORITY_HIGH, 0,
         [](gpointer data) -> gboolean {
           auto* context = static_cast<TeardownContext*>(data);
-          if (context->instance) {
-            const char* profile = getenv("ELM_PROFILE");
-            if (profile && strcmp(profile, "tv") == 0) {
-              // TODO: evas_object_del() still crashes the raster thread
-              // intermittently on the Tizen 10.0 TV emulator, so leak the view
-              // there instead until the engine is fixed.
-              evas_object_hide(context->instance);
-            } else {
-              evas_object_del(context->instance);
-            }
-          }
+          CompletePendingTeardown(context->pending);
           return G_SOURCE_REMOVE;
         },
         context,
         [](gpointer data) { delete static_cast<TeardownContext*>(data); });
   });
+}
 
-  // ewk_shutdown();
+// static
+void WebView::FlushPendingTeardowns() {
+  constexpr gint64 kDeadlineUsec = 2 * G_USEC_PER_SEC;
+  const gint64 deadline = g_get_monotonic_time() + kDeadlineUsec;
+  for (;;) {
+    std::shared_ptr<PendingTeardown> pending;
+    {
+      std::lock_guard<std::mutex> lock(g_pending_teardown_mutex);
+      if (g_pending_teardowns.empty()) {
+        return;
+      }
+      pending = g_pending_teardowns.front();
+    }
+    if (g_get_monotonic_time() >= deadline) {
+      // A leaked Ewk_View is a guaranteed fatal CHECK in ewk_shutdown(), so
+      // force the remaining deletes through rather than waiting any longer.
+      LOG_WARN("Forcing WebView teardown past the deadline before ewk_shutdown()");
+      CompletePendingTeardown(pending);
+      continue;
+    }
+    // Pump the same GLib context the queued g_timeout_add_full hop (see
+    // Dispose()) is scheduled on, so it gets a chance to run and remove
+    // this entry itself.
+    g_main_context_iteration(g_main_context_default(), TRUE);
+  }
 }
 
 void WebView::Offset(double left, double top) {
@@ -436,19 +491,14 @@ bool WebView::InitWebView() {
   EwkInternalApiBinding::GetInstance().main.SetArguments(chromium_argc,
                                                          chromium_argv);
 
-  // TODO(jsuya): ewk_init() and ewk_shutdown() are designed to be called only
-  // once in a process.(If ewk_init() is called after ewk_shutdown() is
-  // called, SIGTRAP is called internally.) ewk_init() initializes the efl
-  // modules and web engine's arguments data. The efl modules are initialized
-  // by default in OS, and arguments data is also initialized through
-  // SetArguments() API, so calling ewk_init() is not necessary. Therefore,
-  // temporarily comment out ewk_init() and ewk_shutdown(). It can be reverted
-  // depending on updates to chromium-efl.
-  // ewk_init();
+  // ewk_init() is called once for the process lifetime by
+  // WebviewFlutterTizenPlugin's constructor, not per WebView instance.
 
-  // Not freed on disposal: ecore_evas_free() would eglTerminate() the EGL
-  // display shared with the Flutter renderer and kill the process.
-  Ecore_Evas* evas = ecore_evas_new("wayland_egl", 0, 0, 1, 1, 0);
+  // "wayland_shm", not "wayland_egl": this canvas only hosts the ewk_view
+  // smart object (content arrives via tbm_surface), and wayland_egl raced
+  // libtpl-egl's wl_egl_thread teardown on disposal. Intentionally leaked
+  // (not ecore_evas_free()'d) on disposal, as before.
+  Ecore_Evas* evas = ecore_evas_new("wayland_shm", 0, 0, 1, 1, 0);
 
   webview_instance_ = ewk_view_add(ecore_evas_get(evas));
   if (!webview_instance_) {

--- a/packages/webview_flutter/tizen/src/webview.cc
+++ b/packages/webview_flutter/tizen/src/webview.cc
@@ -119,6 +119,8 @@ struct PendingTeardown {
 std::mutex g_pending_teardown_mutex;
 std::vector<std::shared_ptr<PendingTeardown>> g_pending_teardowns;
 
+Ecore_Evas* g_shared_canvas = nullptr;
+
 std::shared_ptr<PendingTeardown> RegisterPendingTeardown(
     Evas_Object* instance) {
   auto pending = std::make_shared<PendingTeardown>();
@@ -301,6 +303,25 @@ void WebView::Dispose() {
         context,
         [](gpointer data) { delete static_cast<TeardownContext*>(data); });
   });
+}
+
+// static
+Ecore_Evas* WebView::GetSharedCanvas() {
+  if (!g_shared_canvas) {
+    // "wayland_shm", not "wayland_egl": this canvas only hosts the ewk_view
+    // smart object (content arrives via tbm_surface), and wayland_egl raced
+    // libtpl-egl's wl_egl_thread teardown on disposal.
+    g_shared_canvas = ecore_evas_new("wayland_shm", 0, 0, 1, 1, 0);
+  }
+  return g_shared_canvas;
+}
+
+// static
+void WebView::FreeSharedCanvas() {
+  if (g_shared_canvas) {
+    ecore_evas_free(g_shared_canvas);
+    g_shared_canvas = nullptr;
+  }
 }
 
 // static
@@ -493,12 +514,10 @@ bool WebView::InitWebView() {
 
   // ewk_init() is called once for the process lifetime by
   // WebviewFlutterTizenPlugin's constructor, not per WebView instance.
-
-  // "wayland_shm", not "wayland_egl": this canvas only hosts the ewk_view
-  // smart object (content arrives via tbm_surface), and wayland_egl raced
-  // libtpl-egl's wl_egl_thread teardown on disposal. Intentionally leaked
-  // (not ecore_evas_free()'d) on disposal, as before.
-  Ecore_Evas* evas = ecore_evas_new("wayland_shm", 0, 0, 1, 1, 0);
+  Ecore_Evas* evas = GetSharedCanvas();
+  if (!evas) {
+    return false;
+  }
 
   webview_instance_ = ewk_view_add(ecore_evas_get(evas));
   if (!webview_instance_) {

--- a/packages/webview_flutter/tizen/src/webview.cc
+++ b/packages/webview_flutter/tizen/src/webview.cc
@@ -304,7 +304,6 @@ void WebView::Dispose() {
   });
 }
 
-// static
 Ecore_Evas* WebView::GetOffscreenHost() {
   if (!g_offscreen_host) {
     // wayland_shm, not wayland_egl: wayland_egl raced libtpl-egl's
@@ -314,7 +313,6 @@ Ecore_Evas* WebView::GetOffscreenHost() {
   return g_offscreen_host;
 }
 
-// static
 void WebView::FreeOffscreenHost() {
   if (g_offscreen_host) {
     ecore_evas_free(g_offscreen_host);
@@ -322,37 +320,39 @@ void WebView::FreeOffscreenHost() {
   }
 }
 
-// static
 void WebView::InitializeEngine() { ewk_init(); }
 
-// static
 void WebView::ShutdownEngine() {
   FlushPendingTeardowns();
   FreeOffscreenHost();
   ewk_shutdown();
 }
 
-// static
 void WebView::FlushPendingTeardowns() {
+  // One deadline for all pending teardowns; once it passes, force-complete
+  // them together, not just the oldest one.
   constexpr gint64 kDeadlineUsec = 2 * G_USEC_PER_SEC;
   const gint64 deadline = g_get_monotonic_time() + kDeadlineUsec;
   for (;;) {
-    std::shared_ptr<PendingTeardown> pending;
+    bool deadline_passed = g_get_monotonic_time() >= deadline;
+    std::vector<std::shared_ptr<PendingTeardown>> snapshot;
     {
       std::lock_guard<std::mutex> lock(g_pending_teardown_mutex);
       if (g_pending_teardowns.empty()) {
         return;
       }
-      pending = g_pending_teardowns.front();
+      if (deadline_passed) {
+        snapshot = g_pending_teardowns;
+      }
     }
-    if (g_get_monotonic_time() >= deadline) {
-      LOG_WARN(
-          "Forcing WebView teardown past the deadline before ewk_shutdown()");
-      CompletePendingTeardown(pending);
+    if (deadline_passed) {
+      LOG_WARN("Forcing %zu pending teardown(s) past deadline",
+               snapshot.size());
+      for (auto& pending : snapshot) {
+        CompletePendingTeardown(pending);
+      }
       continue;
     }
-    // Non-blocking: pump the same context the queued g_timeout_add_full hop
-    // runs on, without stalling past the deadline check above.
     if (!g_main_context_iteration(g_main_context_default(), FALSE)) {
       g_usleep(1000);
     }

--- a/packages/webview_flutter/tizen/src/webview.cc
+++ b/packages/webview_flutter/tizen/src/webview.cc
@@ -4,12 +4,15 @@
 
 #include "webview.h"
 
-#include <Ecore.h>
 #include <Ecore_Evas.h>
 #include <app_common.h>
 #include <flutter/standard_method_codec.h>
 #include <flutter_texture_registrar.h>
+#include <glib.h>
 #include <tbm_surface.h>
+
+#include <cstdlib>
+#include <cstring>
 
 #include "buffer_pool.h"
 #include "log.h"
@@ -45,12 +48,8 @@ std::string ConvertLogLevelToString(Ewk_Console_Message_Level level) {
 
 class NavigationRequestResult : public FlMethodResult {
  public:
-  // |alive| is the WebView's is_alive_ flag. Dart resolves the
-  // "navigationRequest" method call asynchronously (it round-trips through
-  // the Dart navigation delegate), so this result's completion can run well
-  // after the WebView that created it has been disposed; |webview_| would
-  // then be a dangling pointer. Checking |alive| before dereferencing it
-  // avoids a use-after-free in that case.
+  // Dart resolves "navigationRequest" asynchronously, so completion can run
+  // after |webview| is destroyed; |alive| gates every dereference.
   NavigationRequestResult(WebView* webview, std::shared_ptr<bool> alive)
       : webview_(webview), alive_(std::move(alive)) {}
 
@@ -121,7 +120,7 @@ WebView::WebView(flutter::PluginRegistrar* registrar, int view_id,
     return;
   }
 
-  tbm_pool_ = std::make_unique<SingleBufferPool>(width, height);
+  tbm_pool_ = std::make_shared<SingleBufferPool>(width, height);
 
   texture_variant_ =
       std::make_unique<flutter::TextureVariant>(flutter::GpuSurfaceTexture(
@@ -192,21 +191,14 @@ void WebView::Dispose() {
     return;
   }
   disposed_ = true;
-
-  // A Dart "navigationRequest" reply can still arrive after Dispose() has
-  // run. The reply handler checks this flag and returns early, instead of
-  // using a WebView that no longer exists.
   *is_alive_ = false;
 
   Evas_Object* instance = webview_instance_;
   webview_instance_ = nullptr;
 
   if (instance) {
-    // Detach every callback registered in InitWebView() and
-    // RegisterJavaScriptChannelName(). The engine instance lives until the
-    // deferred evas_object_del() below, while this WebView is destroyed
-    // right after Dispose(). Without detaching, the engine could invoke
-    // these callbacks on the already-destroyed WebView during that window.
+    // The engine instance outlives this WebView until the deferred
+    // evas_object_del() below, so every callback must be detached here.
     evas_object_smart_callback_del(instance, "offscreen,frame,rendered",
                                    &WebView::OnFrameRendered);
     evas_object_smart_callback_del(instance, "load,started",
@@ -233,16 +225,12 @@ void WebView::Dispose() {
         instance, nullptr, nullptr);
     evas_object_data_del(instance, kEwkInstance);
 
-    // Cancel any in-flight load and pause the page so it stops running while
-    // the deferred teardown below is pending.
+    // Stop the page so it cannot run while the deferred teardown is pending.
     ewk_view_stop(instance);
     ewk_view_suspend(instance);
   }
 
-  // Stop handing out engine-owned TBM surfaces to the raster thread, and
-  // detach the buffer pool so its GPU surface descriptors outlive this
-  // object for any raster-thread frame still in flight.
-  std::unique_ptr<BufferPool> pool;
+  std::shared_ptr<BufferPool> pool;
   {
     std::lock_guard<std::mutex> lock(mutex_);
     is_disposing_ = true;
@@ -252,47 +240,36 @@ void WebView::Dispose() {
     pool = std::move(tbm_pool_);
   }
 
-  // The TBM surfaces backing the texture are owned by the web engine and are
-  // freed when the engine view is deleted. Deleting the view while an
-  // in-flight raster-thread frame is still reading one of those surfaces is a
-  // use-after-free (the emulator's SW rendering path reads the buffer on the
-  // CPU), crashing with SIGSEGV during EWebView teardown. The embedder tears
-  // the external texture down on the render thread only after any in-flight
-  // frame callback has completed and then invokes this completion callback,
-  // so evas_object_del() (and the release of the descriptor-owning buffer
-  // pool) is deferred until then. The callback fires on the render thread;
-  // evas_object_del() must run on the main thread, so hop back via
-  // ecore_main_loop_thread_safe_call_async().
+  // evas_object_del() frees TBM surfaces the raster thread may still be
+  // reading, so defer it until the embedder confirms the texture is torn
+  // down. That confirmation fires on the render thread, hence the hop below.
   struct TeardownContext {
     Evas_Object* instance;
-    std::unique_ptr<BufferPool> pool;
+    std::shared_ptr<BufferPool> pool;
   };
   auto* context = new TeardownContext{instance, std::move(pool)};
   texture_registrar_->UnregisterTexture(GetTextureId(), [context]() {
-    ecore_main_loop_thread_safe_call_async(
-        [](void* data) {
+    // Must stay a high-priority timeout: g_idle_add() runs too late and the
+    // delete then races the raster thread on the TV emulator.
+    g_timeout_add_full(
+        G_PRIORITY_HIGH, 0,
+        [](gpointer data) -> gboolean {
           auto* context = static_cast<TeardownContext*>(data);
           if (context->instance) {
-#if defined(TV_PROFILE) && (defined(__x86_64__) || defined(__i386__))
-            // On the Tizen 10.0 TV emulator image (the only TV + x86_64
-            // target), deleting the ewk view crashes with SIGSEGV inside
-            // chromium-efl's ~SelectionControllerEfl(): after unsubscribing
-            // VCONFKEY_LANGSET it calls HideHandleAndContextMenu() ->
-            // CancelContextMenu(), which dereferences the WebContents that is
-            // already being destructed. That is engine code this plugin
-            // cannot fix, so hide the (already stopped and suspended) view
-            // and intentionally leak it instead of crashing. All other
-            // targets (arm/arm64 devices, the 32-bit x86 emulator, and the
-            // common-profile x86_64 emulator, whose engines are unaffected)
-            // delete normally.
-            evas_object_hide(context->instance);
-#else
-            evas_object_del(context->instance);
-#endif
+            const char* profile = getenv("ELM_PROFILE");
+            if (profile && strcmp(profile, "tv") == 0) {
+              // TODO: evas_object_del() still crashes the raster thread
+              // intermittently on the Tizen 10.0 TV emulator, so leak the view
+              // there instead until the engine is fixed.
+              evas_object_hide(context->instance);
+            } else {
+              evas_object_del(context->instance);
+            }
           }
-          delete context;
+          return G_SOURCE_REMOVE;
         },
-        context);
+        context,
+        [](gpointer data) { delete static_cast<TeardownContext*>(data); });
   });
 
   // ewk_shutdown();
@@ -468,6 +445,9 @@ bool WebView::InitWebView() {
   // temporarily comment out ewk_init() and ewk_shutdown(). It can be reverted
   // depending on updates to chromium-efl.
   // ewk_init();
+
+  // Not freed on disposal: ecore_evas_free() would eglTerminate() the EGL
+  // display shared with the Flutter renderer and kill the process.
   Ecore_Evas* evas = ecore_evas_new("wayland_egl", 0, 0, 1, 1, 0);
 
   webview_instance_ = ewk_view_add(ecore_evas_get(evas));

--- a/packages/webview_flutter/tizen/src/webview.h
+++ b/packages/webview_flutter/tizen/src/webview.h
@@ -82,6 +82,7 @@ class WebView : public PlatformView {
   static void OnConsoleMessage(void* data, Evas_Object* obj, void* event_info);
   static void OnNavigationPolicy(void* data, Evas_Object* obj,
                                  void* event_info);
+  static void OnResponsePolicy(void* data, Evas_Object* obj, void* event_info);
   static void OnUrlChange(void* data, Evas_Object* obj, void* event_info);
   static void OnEvaluateJavaScript(Evas_Object* obj, const char* result_value,
                                    void* user_data);

--- a/packages/webview_flutter/tizen/src/webview.h
+++ b/packages/webview_flutter/tizen/src/webview.h
@@ -118,6 +118,14 @@ class WebView : public PlatformView {
   std::mutex mutex_;
   std::unique_ptr<BufferPool> tbm_pool_;
   bool disposed_ = false;
+  // Set under mutex_ at the start of Dispose(). The raster thread checks it
+  // in ObtainGpuSurface() and stops being handed engine-owned TBM surfaces
+  // that are about to be freed by the deferred evas_object_del().
+  bool is_disposing_ = false;
+  // Set to false at the start of Dispose(). A pending "navigationRequest"
+  // reply from Dart (resolved asynchronously) captures a copy and checks it
+  // before dereferencing this WebView, avoiding a use-after-free.
+  std::shared_ptr<bool> is_alive_ = std::make_shared<bool>(true);
   Ewk_Mouse_Button_Type mouse_button_type_ = (Ewk_Mouse_Button_Type)0;
   bool scrollbar_enabled_ = true;
 };

--- a/packages/webview_flutter/tizen/src/webview.h
+++ b/packages/webview_flutter/tizen/src/webview.h
@@ -59,15 +59,11 @@ class WebView : public PlatformView {
   FlutterDesktopGpuSurfaceDescriptor* ObtainGpuSurface(size_t width,
                                                        size_t height);
 
-  // Blocks until every WebView's deferred delete (queued in Dispose()) has
-  // run, force-deleting stragglers after a timeout. Must be called before
-  // ewk_shutdown(), which fatally CHECKs on any live Ewk_View.
-  static void FlushPendingTeardowns();
+  // Must be called exactly once, before any WebView is constructed.
+  static void InitializeEngine();
 
-  static Ecore_Evas* GetSharedCanvas();
-
-  // Must be called after FlushPendingTeardowns() and before ewk_shutdown().
-  static void FreeSharedCanvas();
+  // Must be called exactly once, after every WebView has been destroyed.
+  static void ShutdownEngine();
 
  private:
   void HandleWebViewMethodCall(const FlMethodCall& method_call,
@@ -84,6 +80,10 @@ class WebView : public PlatformView {
   std::string GetNavigationDelegateChannelName();
 
   bool InitWebView();
+
+  static Ecore_Evas* GetOffscreenHost();
+  static void FreeOffscreenHost();
+  static void FlushPendingTeardowns();
 
   static void OnFrameRendered(void* data, Evas_Object* obj, void* event_info);
   static void OnLoadStarted(void* data, Evas_Object* obj, void* event_info);
@@ -128,12 +128,10 @@ class WebView : public PlatformView {
   std::unique_ptr<flutter::TextureVariant> texture_variant_;
   std::mutex mutex_;
   std::shared_ptr<BufferPool> tbm_pool_;
+  // Guarded by mutex_.
   bool disposed_ = false;
-  // Guarded by mutex_. Keeps the raster thread from being handed TBM surfaces
-  // during the deferred teardown.
-  bool is_disposing_ = false;
-  // Copied into pending async Dart replies so they can detect a WebView that
-  // was destroyed before the reply arrived.
+  // Outlives this WebView so a pending async Dart reply can tell it apart
+  // from a destroyed one.
   std::shared_ptr<bool> is_alive_ = std::make_shared<bool>(true);
   Ewk_Mouse_Button_Type mouse_button_type_ = (Ewk_Mouse_Button_Type)0;
   bool scrollbar_enabled_ = true;

--- a/packages/webview_flutter/tizen/src/webview.h
+++ b/packages/webview_flutter/tizen/src/webview.h
@@ -116,15 +116,13 @@ class WebView : public PlatformView {
   std::unique_ptr<FlMethodChannel> navigation_delegate_channel_;
   std::unique_ptr<flutter::TextureVariant> texture_variant_;
   std::mutex mutex_;
-  std::unique_ptr<BufferPool> tbm_pool_;
+  std::shared_ptr<BufferPool> tbm_pool_;
   bool disposed_ = false;
-  // Set under mutex_ at the start of Dispose(). The raster thread checks it
-  // in ObtainGpuSurface() and stops being handed engine-owned TBM surfaces
-  // that are about to be freed by the deferred evas_object_del().
+  // Guarded by mutex_. Keeps the raster thread from being handed TBM surfaces
+  // that the deferred evas_object_del() is about to free.
   bool is_disposing_ = false;
-  // Set to false at the start of Dispose(). A pending "navigationRequest"
-  // reply from Dart (resolved asynchronously) captures a copy and checks it
-  // before dereferencing this WebView, avoiding a use-after-free.
+  // Copied into pending async Dart replies so they can detect a WebView that
+  // was destroyed before the reply arrived.
   std::shared_ptr<bool> is_alive_ = std::make_shared<bool>(true);
   Ewk_Mouse_Button_Type mouse_button_type_ = (Ewk_Mouse_Button_Type)0;
   bool scrollbar_enabled_ = true;

--- a/packages/webview_flutter/tizen/src/webview.h
+++ b/packages/webview_flutter/tizen/src/webview.h
@@ -27,6 +27,7 @@ typedef flutter::MethodChannel<flutter::EncodableValue> FlMethodChannel;
 
 class BufferPool;
 class BufferUnit;
+typedef struct _Ecore_Evas Ecore_Evas;
 
 class WebView : public PlatformView {
  public:
@@ -62,6 +63,11 @@ class WebView : public PlatformView {
   // Dispose()) has run, force-deleting stragglers after a timeout. Must be
   // called before ewk_shutdown(), which fatally CHECKs on any live Ewk_View.
   static void FlushPendingTeardowns();
+
+  static Ecore_Evas* GetSharedCanvas();
+
+  // Must be called after FlushPendingTeardowns() and before ewk_shutdown().
+  static void FreeSharedCanvas();
 
  private:
   void HandleWebViewMethodCall(const FlMethodCall& method_call,

--- a/packages/webview_flutter/tizen/src/webview.h
+++ b/packages/webview_flutter/tizen/src/webview.h
@@ -58,6 +58,11 @@ class WebView : public PlatformView {
   FlutterDesktopGpuSurfaceDescriptor* ObtainGpuSurface(size_t width,
                                                        size_t height);
 
+  // Blocks until every WebView's deferred evas_object_del() (queued in
+  // Dispose()) has run, force-deleting stragglers after a timeout. Must be
+  // called before ewk_shutdown(), which fatally CHECKs on any live Ewk_View.
+  static void FlushPendingTeardowns();
+
  private:
   void HandleWebViewMethodCall(const FlMethodCall& method_call,
                                std::unique_ptr<FlMethodResult> result);

--- a/packages/webview_flutter/tizen/src/webview.h
+++ b/packages/webview_flutter/tizen/src/webview.h
@@ -59,9 +59,9 @@ class WebView : public PlatformView {
   FlutterDesktopGpuSurfaceDescriptor* ObtainGpuSurface(size_t width,
                                                        size_t height);
 
-  // Blocks until every WebView's deferred evas_object_del() (queued in
-  // Dispose()) has run, force-deleting stragglers after a timeout. Must be
-  // called before ewk_shutdown(), which fatally CHECKs on any live Ewk_View.
+  // Blocks until every WebView's deferred delete (queued in Dispose()) has
+  // run, force-deleting stragglers after a timeout. Must be called before
+  // ewk_shutdown(), which fatally CHECKs on any live Ewk_View.
   static void FlushPendingTeardowns();
 
   static Ecore_Evas* GetSharedCanvas();
@@ -130,7 +130,7 @@ class WebView : public PlatformView {
   std::shared_ptr<BufferPool> tbm_pool_;
   bool disposed_ = false;
   // Guarded by mutex_. Keeps the raster thread from being handed TBM surfaces
-  // that the deferred evas_object_del() is about to free.
+  // during the deferred teardown.
   bool is_disposing_ = false;
   // Copied into pending async Dart replies so they can detect a WebView that
   // was destroyed before the reply arrived.

--- a/packages/webview_flutter/tizen/src/webview_flutter_tizen_plugin.cc
+++ b/packages/webview_flutter/tizen/src/webview_flutter_tizen_plugin.cc
@@ -32,8 +32,10 @@ class WebviewFlutterTizenPlugin : public flutter::Plugin {
 
   virtual ~WebviewFlutterTizenPlugin() {
     // ewk_shutdown() fatally CHECKs if any Ewk_View is still alive; drain
-    // Dispose()'s deferred deletes first.
+    // Dispose()'s deferred deletes first, then free the canvas they were
+    // hosted on.
     WebView::FlushPendingTeardowns();
+    WebView::FreeSharedCanvas();
     ewk_shutdown();
   }
 };

--- a/packages/webview_flutter/tizen/src/webview_flutter_tizen_plugin.cc
+++ b/packages/webview_flutter/tizen/src/webview_flutter_tizen_plugin.cc
@@ -4,7 +4,6 @@
 
 #include "webview_flutter_tizen_plugin.h"
 
-#include <EWebKit.h>
 #include <flutter/plugin_registrar.h>
 #include <flutter_tizen.h>
 
@@ -17,10 +16,8 @@ namespace {
 
 constexpr char kViewType[] = "plugins.flutter.io/webview";
 
-// Tied to this plugin object's lifetime (constructed/destroyed exactly once
-// by flutter-tizen's engine start/stop), not per-WebView: chromium-efl does
-// not support re-initializing its browser process after ewk_shutdown() has
-// run once.
+// Constructed/destroyed exactly once by flutter-tizen's engine start/stop,
+// not per-WebView.
 class WebviewFlutterTizenPlugin : public flutter::Plugin {
  public:
   static void RegisterWithRegistrar(flutter::PluginRegistrar* registrar) {
@@ -28,14 +25,9 @@ class WebviewFlutterTizenPlugin : public flutter::Plugin {
     registrar->AddPlugin(std::move(plugin));
   }
 
-  WebviewFlutterTizenPlugin() { ewk_init(); }
+  WebviewFlutterTizenPlugin() { WebView::InitializeEngine(); }
 
-  virtual ~WebviewFlutterTizenPlugin() {
-    // See WebView::FlushPendingTeardowns() for why this must run first.
-    WebView::FlushPendingTeardowns();
-    WebView::FreeSharedCanvas();
-    ewk_shutdown();
-  }
+  virtual ~WebviewFlutterTizenPlugin() { WebView::ShutdownEngine(); }
 };
 
 }  // namespace

--- a/packages/webview_flutter/tizen/src/webview_flutter_tizen_plugin.cc
+++ b/packages/webview_flutter/tizen/src/webview_flutter_tizen_plugin.cc
@@ -4,17 +4,23 @@
 
 #include "webview_flutter_tizen_plugin.h"
 
+#include <EWebKit.h>
 #include <flutter/plugin_registrar.h>
 #include <flutter_tizen.h>
 
 #include <memory>
 
+#include "webview.h"
 #include "webview_factory.h"
 
 namespace {
 
 constexpr char kViewType[] = "plugins.flutter.io/webview";
 
+// Tied to this plugin object's lifetime (constructed/destroyed exactly once
+// by flutter-tizen's engine start/stop), not per-WebView: chromium-efl does
+// not support re-initializing its browser process after ewk_shutdown() has
+// run once.
 class WebviewFlutterTizenPlugin : public flutter::Plugin {
  public:
   static void RegisterWithRegistrar(flutter::PluginRegistrar* registrar) {
@@ -22,9 +28,14 @@ class WebviewFlutterTizenPlugin : public flutter::Plugin {
     registrar->AddPlugin(std::move(plugin));
   }
 
-  WebviewFlutterTizenPlugin() {}
+  WebviewFlutterTizenPlugin() { ewk_init(); }
 
-  virtual ~WebviewFlutterTizenPlugin() {}
+  virtual ~WebviewFlutterTizenPlugin() {
+    // ewk_shutdown() fatally CHECKs if any Ewk_View is still alive; drain
+    // Dispose()'s deferred deletes first.
+    WebView::FlushPendingTeardowns();
+    ewk_shutdown();
+  }
 };
 
 }  // namespace

--- a/packages/webview_flutter/tizen/src/webview_flutter_tizen_plugin.cc
+++ b/packages/webview_flutter/tizen/src/webview_flutter_tizen_plugin.cc
@@ -31,9 +31,7 @@ class WebviewFlutterTizenPlugin : public flutter::Plugin {
   WebviewFlutterTizenPlugin() { ewk_init(); }
 
   virtual ~WebviewFlutterTizenPlugin() {
-    // ewk_shutdown() fatally CHECKs if any Ewk_View is still alive; drain
-    // Dispose()'s deferred deletes first, then free the canvas they were
-    // hosted on.
+    // See WebView::FlushPendingTeardowns() for why this must run first.
     WebView::FlushPendingTeardowns();
     WebView::FreeSharedCanvas();
     ewk_shutdown();


### PR DESCRIPTION
- Implement native Tizen support for `clearLocalStorage` and `onHttpError`, and bump `webview_flutter_tizen` to 0.10.1.
- Port the remaining runnable upstream v4.13.1 integration tests (onHttpError x2, clearLocalStorage) and align async style (await instead of unawaited()) with upstream.
- Stabilize the scroll position test by polling for the settled value instead of reading it once.
- Fix a WebView disposal race where engine-owned TBM surfaces could be freed while a raster-thread frame still read them, and work around a chromium-efl crash on the TV 10.0 emulator during teardown.
- `flutter-tizen test` (or example integration tests) on TV 10.0 emulator — 19/19 passing, including previously-crashing disposal cases
