### PR TITLE
Fix "FocusManager used after being disposed" in integration tests

### DIFF
--- a/packages/connectivity_plus/CHANGELOG.md
+++ b/packages/connectivity_plus/CHANGELOG.md
@@ -1,3 +1,7 @@
+## NEXT
+
+* Update integration tests.
+
 ## 1.3.0
 
 * Update minimum Dart version to 3.2.

--- a/packages/connectivity_plus/example/integration_test/connectivity_plus_test.dart
+++ b/packages/connectivity_plus/example/integration_test/connectivity_plus_test.dart
@@ -16,7 +16,7 @@ void main() {
       connectivity = Connectivity();
     });
 
-    testWidgets('test connectivity result', (WidgetTester tester) async {
+    test('test connectivity result', () async {
       final result = await connectivity.checkConnectivity();
       expect(result, isNotNull);
       expect(result, isNotEmpty);

--- a/packages/device_info_plus/CHANGELOG.md
+++ b/packages/device_info_plus/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## NEXT
 
 * Add 2 integration test cases.
+* Update integration tests.
 
 ## 1.4.0
 

--- a/packages/device_info_plus/example/integration_test/device_info_plus_test.dart
+++ b/packages/device_info_plus/example/integration_test/device_info_plus_test.dart
@@ -18,13 +18,11 @@ void main() {
     tizenInfo = await deviceInfoPlugin.tizenInfo;
   });
 
-  testWidgets('Can get non-null device model', (WidgetTester tester) async {
+  test('Can get non-null device model', () async {
     expect(tizenInfo.modelName, isNotNull);
   });
 
-  testWidgets('Check all Tizen info values are available', (
-    WidgetTester tester,
-  ) async {
+  test('Check all Tizen info values are available', () async {
     expect(tizenInfo.modelName, isNotNull);
     expect(tizenInfo.cpuArch, isNotNull);
     expect(tizenInfo.nativeApiVersion, isNotNull);
@@ -56,9 +54,7 @@ void main() {
     );
   }, skip: !Platform.isLinux);
 
-  testWidgets('tizenInfo is consistent across repeated calls', (
-    WidgetTester tester,
-  ) async {
+  test('tizenInfo is consistent across repeated calls', () async {
     // Repeated calls on the same instance return the cached instance.
     final plugin1 = DeviceInfoPluginTizen();
     final first = await plugin1.tizenInfo;
@@ -71,9 +67,7 @@ void main() {
     expect(third.modelName, first.modelName);
   }, skip: !Platform.isLinux);
 
-  testWidgets('TizenDeviceInfo.fromMap round-trips through data', (
-    WidgetTester tester,
-  ) async {
+  test('TizenDeviceInfo.fromMap round-trips through data', () async {
     final data = tizenInfo.data;
     expect(data, isNotEmpty);
 

--- a/packages/flutter_secure_storage/CHANGELOG.md
+++ b/packages/flutter_secure_storage/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## NEXT
 
 * Update integration tests based on upstream flutter_secure_storage v10.2.0 (12 test cases).
+* Update integration tests.
 
 ## 0.1.3
 

--- a/packages/flutter_secure_storage/example/integration_test/flutter_secure_storage_test.dart
+++ b/packages/flutter_secure_storage/example/integration_test/flutter_secure_storage_test.dart
@@ -20,43 +20,43 @@ void main() {
   });
 
   group('Basic CRUD', () {
-    testWidgets('write and read round trip', (_) async {
+    test('write and read round trip', () async {
       await _storage.write(key: 'key1', value: 'value1');
       expect(await _storage.read(key: 'key1'), 'value1');
     });
 
-    testWidgets('read missing key returns null', (_) async {
+    test('read missing key returns null', () async {
       expect(await _storage.read(key: 'nonexistent'), isNull);
     });
 
-    testWidgets('overwrite returns new value', (_) async {
+    test('overwrite returns new value', () async {
       await _storage.write(key: 'k', value: 'first');
       await _storage.write(key: 'k', value: 'second');
       expect(await _storage.read(key: 'k'), 'second');
     });
 
-    testWidgets('containsKey true after write', (_) async {
+    test('containsKey true after write', () async {
       await _storage.write(key: 'k', value: 'v');
       expect(await _storage.containsKey(key: 'k'), isTrue);
     });
 
-    testWidgets('containsKey false for missing key', (_) async {
+    test('containsKey false for missing key', () async {
       expect(await _storage.containsKey(key: 'nonexistent'), isFalse);
     });
 
-    testWidgets('delete removes key', (_) async {
+    test('delete removes key', () async {
       await _storage.write(key: 'k', value: 'v');
       await _storage.delete(key: 'k');
       expect(await _storage.containsKey(key: 'k'), isFalse);
       expect(await _storage.read(key: 'k'), isNull);
     });
 
-    testWidgets('delete nonexistent key is no-op', (_) async {
+    test('delete nonexistent key is no-op', () async {
       await _storage.delete(key: 'never_written');
       expect(await _storage.containsKey(key: 'never_written'), isFalse);
     });
 
-    testWidgets('readAll returns all written entries', (_) async {
+    test('readAll returns all written entries', () async {
       await _storage.write(key: 'k1', value: 'v1');
       await _storage.write(key: 'k2', value: 'v2');
       final all = await _storage.readAll();
@@ -64,7 +64,7 @@ void main() {
       expect(all, containsPair('k2', 'v2'));
     });
 
-    testWidgets('deleteAll clears every key', (_) async {
+    test('deleteAll clears every key', () async {
       await _storage.write(key: 'a', value: '1');
       await _storage.write(key: 'b', value: '2');
       await _storage.deleteAll();
@@ -73,7 +73,7 @@ void main() {
   });
 
   group('Special-character keys', () {
-    testWidgets('URL key', (_) async {
+    test('URL key', () async {
       const key = 'http://example.com';
       await _storage.write(key: key, value: 'url-value');
       expect(await _storage.read(key: key), 'url-value');
@@ -82,7 +82,7 @@ void main() {
       expect(await _storage.containsKey(key: key), isFalse);
     });
 
-    testWidgets('Non-ASCII key (Latin-1)', (_) async {
+    test('Non-ASCII key (Latin-1)', () async {
       const key = 'clé';
       await _storage.write(key: key, value: key);
       expect(await _storage.read(key: key), key);
@@ -90,7 +90,7 @@ void main() {
       expect(await _storage.containsKey(key: key), isFalse);
     });
 
-    testWidgets('Case-sensitive keys', (_) async {
+    test('Case-sensitive keys', () async {
       await _storage.write(key: 'key', value: 'lower');
       await _storage.write(key: 'KEY', value: 'upper');
       expect(await _storage.read(key: 'key'), 'lower');

--- a/packages/flutter_tts/CHANGELOG.md
+++ b/packages/flutter_tts/CHANGELOG.md
@@ -1,3 +1,7 @@
+## NEXT
+
+* Update integration tests.
+
 ## 1.7.0
 
 * Return a boolean from `isLanguageAvailable` to match the behavior of other platforms.

--- a/packages/flutter_tts/example/integration_test/flutter_tts_test.dart
+++ b/packages/flutter_tts/example/integration_test/flutter_tts_test.dart
@@ -17,51 +17,43 @@ void main() {
     await flutterTts.stop();
   });
 
-  testWidgets('speak returns 1', (WidgetTester tester) async {
+  test('speak returns 1', () async {
     expect(await flutterTts.speak('Hello, world!'), 1);
   });
 
-  testWidgets('stop returns 1', (WidgetTester tester) async {
+  test('stop returns 1', () async {
     expect(await flutterTts.stop(), 1);
   });
 
-  testWidgets('getLanguages returns a non-empty list', (
-    WidgetTester tester,
-  ) async {
+  test('getLanguages returns a non-empty list', () async {
     final languages = await flutterTts.getLanguages;
     expect(languages, isNotNull);
     expect(languages, isNotEmpty);
   });
 
-  testWidgets('isLanguageAvailable is true for a supported language', (
-    WidgetTester tester,
-  ) async {
+  test('isLanguageAvailable is true for a supported language', () async {
     final languages = (await flutterTts.getLanguages as List).cast<String>();
     expect(languages, isNotEmpty);
     expect(await flutterTts.isLanguageAvailable(languages.first), isTrue);
   });
 
-  testWidgets('setLanguage returns 1 for a supported language', (
-    WidgetTester tester,
-  ) async {
+  test('setLanguage returns 1 for a supported language', () async {
     final languages = (await flutterTts.getLanguages as List).cast<String>();
     expect(languages, isNotEmpty);
     expect(await flutterTts.setLanguage(languages.first), 1);
   });
 
-  testWidgets('getVoices returns a non-empty list', (
-    WidgetTester tester,
-  ) async {
+  test('getVoices returns a non-empty list', () async {
     final voices = await flutterTts.getVoices;
     expect(voices, isNotNull);
     expect(voices, isNotEmpty);
   });
 
-  testWidgets('getDefaultVoice returns a voice', (WidgetTester tester) async {
+  test('getDefaultVoice returns a voice', () async {
     expect(await flutterTts.getDefaultVoice, isNotNull);
   });
 
-  testWidgets('setVoice returns 1', (WidgetTester tester) async {
+  test('setVoice returns 1', () async {
     final voices = (await flutterTts.getVoices as List).cast<Map>();
     expect(voices, isNotEmpty);
     final voice = voices.first;
@@ -74,17 +66,15 @@ void main() {
     );
   });
 
-  testWidgets('setSpeechRate returns 1', (WidgetTester tester) async {
+  test('setSpeechRate returns 1', () async {
     expect(await flutterTts.setSpeechRate(0.5), 1);
   });
 
-  testWidgets('setVolume returns 1', (WidgetTester tester) async {
+  test('setVolume returns 1', () async {
     expect(await flutterTts.setVolume(1), 1);
   });
 
-  testWidgets('getMaxSpeechInputLength is positive', (
-    WidgetTester tester,
-  ) async {
+  test('getMaxSpeechInputLength is positive', () async {
     // tts_get_max_text_size requires the ready state; stop() ensures it.
     await flutterTts.stop();
     final maxLength = await flutterTts.getMaxSpeechInputLength;

--- a/packages/flutter_webrtc/CHANGELOG.md
+++ b/packages/flutter_webrtc/CHANGELOG.md
@@ -1,3 +1,7 @@
+## NEXT
+
+* Update integration tests.
+
 ## 0.2.3
 
 * Fix `RTCPeerConnection.close()` to be idempotent; calling it more than once no longer throws an error.

--- a/packages/flutter_webrtc/example/flutter_webrtc_example/integration_test/flutter_webrtc_test.dart
+++ b/packages/flutter_webrtc/example/flutter_webrtc_example/integration_test/flutter_webrtc_test.dart
@@ -9,14 +9,9 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter_webrtc/flutter_webrtc.dart';
 import 'package:integration_test/integration_test.dart';
 
-const Map<String, dynamic> _kConfig = {
-  'iceServers': <Map<String, dynamic>>[],
-};
+const Map<String, dynamic> _kConfig = {'iceServers': <Map<String, dynamic>>[]};
 
-Future<void> _negotiate(
-  RTCPeerConnection pc1,
-  RTCPeerConnection pc2,
-) async {
+Future<void> _negotiate(RTCPeerConnection pc1, RTCPeerConnection pc2) async {
   pc1.onIceCandidate = (c) => pc2.addCandidate(c);
   pc2.onIceCandidate = (c) => pc1.addCandidate(c);
 
@@ -32,40 +27,52 @@ void main() {
   IntegrationTestWidgetsFlutterBinding.ensureInitialized();
 
   group('RTCPeerConnection', () {
-    testWidgets('creates with empty ice servers', (WidgetTester tester) async {
-      final pc = await createPeerConnection(_kConfig);
-      expect(pc, isNotNull);
-      await pc.close();
-    }, timeout: const Timeout(Duration(seconds: 10)));
+    test(
+      'creates with empty ice servers',
+      () async {
+        final pc = await createPeerConnection(_kConfig);
+        expect(pc, isNotNull);
+        await pc.close();
+      },
+      timeout: const Timeout(Duration(seconds: 10)),
+    );
 
-    testWidgets('createOffer returns valid SDP', (WidgetTester tester) async {
-      final pc = await createPeerConnection(_kConfig);
-      final offer = await pc.createOffer();
-      expect(offer.type, equals('offer'));
-      expect(offer.sdp, isNotEmpty);
-      await pc.close();
-    }, timeout: const Timeout(Duration(seconds: 10)));
+    test(
+      'createOffer returns valid SDP',
+      () async {
+        final pc = await createPeerConnection(_kConfig);
+        final offer = await pc.createOffer();
+        expect(offer.type, equals('offer'));
+        expect(offer.sdp, isNotEmpty);
+        await pc.close();
+      },
+      timeout: const Timeout(Duration(seconds: 10)),
+    );
 
-    testWidgets('setLocalDescription succeeds', (WidgetTester tester) async {
+    test('setLocalDescription succeeds', () async {
       final pc = await createPeerConnection(_kConfig);
       final offer = await pc.createOffer();
       await expectLater(pc.setLocalDescription(offer), completes);
       await pc.close();
     }, timeout: const Timeout(Duration(seconds: 10)));
 
-    testWidgets('createAnswer returns valid SDP', (WidgetTester tester) async {
-      final pc1 = await createPeerConnection(_kConfig);
-      final pc2 = await createPeerConnection(_kConfig);
-      final offer = await pc1.createOffer();
-      await pc2.setRemoteDescription(offer);
-      final answer = await pc2.createAnswer();
-      expect(answer.type, equals('answer'));
-      expect(answer.sdp, isNotEmpty);
-      await pc1.close();
-      await pc2.close();
-    }, timeout: const Timeout(Duration(seconds: 10)));
+    test(
+      'createAnswer returns valid SDP',
+      () async {
+        final pc1 = await createPeerConnection(_kConfig);
+        final pc2 = await createPeerConnection(_kConfig);
+        final offer = await pc1.createOffer();
+        await pc2.setRemoteDescription(offer);
+        final answer = await pc2.createAnswer();
+        expect(answer.type, equals('answer'));
+        expect(answer.sdp, isNotEmpty);
+        await pc1.close();
+        await pc2.close();
+      },
+      timeout: const Timeout(Duration(seconds: 10)),
+    );
 
-    testWidgets('close is idempotent', (WidgetTester tester) async {
+    test('close is idempotent', () async {
       final pc = await createPeerConnection(_kConfig);
       await pc.close();
       await expectLater(pc.close(), completes);
@@ -73,152 +80,167 @@ void main() {
   });
 
   group('RTCDataChannel', () {
-    testWidgets('createDataChannel returns channel with correct label',
-        (WidgetTester tester) async {
-      final pc = await createPeerConnection(_kConfig);
-      final dc = await pc.createDataChannel('test-label', RTCDataChannelInit());
-      expect(dc.label, equals('test-label'));
-      await dc.close();
-      await pc.close();
-    }, timeout: const Timeout(Duration(seconds: 10)));
+    test(
+      'createDataChannel returns channel with correct label',
+      () async {
+        final pc = await createPeerConnection(_kConfig);
+        final dc = await pc.createDataChannel(
+          'test-label',
+          RTCDataChannelInit(),
+        );
+        expect(dc.label, equals('test-label'));
+        await dc.close();
+        await pc.close();
+      },
+      timeout: const Timeout(Duration(seconds: 10)),
+    );
 
-    testWidgets('loopback text message exchange', (WidgetTester tester) async {
-      final pc1 = await createPeerConnection(_kConfig);
-      final pc2 = await createPeerConnection(_kConfig);
+    test(
+      'loopback text message exchange',
+      () async {
+        final pc1 = await createPeerConnection(_kConfig);
+        final pc2 = await createPeerConnection(_kConfig);
 
-      final dc2Completer = Completer<RTCDataChannel>();
-      pc2.onDataChannel = (channel) {
-        if (!dc2Completer.isCompleted) dc2Completer.complete(channel);
-      };
-
-      final dc1 = await pc1.createDataChannel(
-        'loopback',
-        RTCDataChannelInit()..ordered = true,
-      );
-
-      await _negotiate(pc1, pc2);
-
-      final dc2 =
-          await dc2Completer.future.timeout(const Duration(seconds: 10));
-
-      final dc1Open = Completer<void>();
-      final dc2Open = Completer<void>();
-      if (dc1.state == RTCDataChannelState.RTCDataChannelOpen) {
-        dc1Open.complete();
-      } else {
-        dc1.onDataChannelState = (s) {
-          if (s == RTCDataChannelState.RTCDataChannelOpen &&
-              !dc1Open.isCompleted) {
-            dc1Open.complete();
-          }
+        final dc2Completer = Completer<RTCDataChannel>();
+        pc2.onDataChannel = (channel) {
+          if (!dc2Completer.isCompleted) dc2Completer.complete(channel);
         };
-      }
-      if (dc2.state == RTCDataChannelState.RTCDataChannelOpen) {
-        dc2Open.complete();
-      } else {
-        dc2.onDataChannelState = (s) {
-          if (s == RTCDataChannelState.RTCDataChannelOpen &&
-              !dc2Open.isCompleted) {
-            dc2Open.complete();
-          }
+
+        final dc1 = await pc1.createDataChannel(
+          'loopback',
+          RTCDataChannelInit()..ordered = true,
+        );
+
+        await _negotiate(pc1, pc2);
+
+        final dc2 = await dc2Completer.future.timeout(
+          const Duration(seconds: 10),
+        );
+
+        final dc1Open = Completer<void>();
+        final dc2Open = Completer<void>();
+        if (dc1.state == RTCDataChannelState.RTCDataChannelOpen) {
+          dc1Open.complete();
+        } else {
+          dc1.onDataChannelState = (s) {
+            if (s == RTCDataChannelState.RTCDataChannelOpen &&
+                !dc1Open.isCompleted) {
+              dc1Open.complete();
+            }
+          };
+        }
+        if (dc2.state == RTCDataChannelState.RTCDataChannelOpen) {
+          dc2Open.complete();
+        } else {
+          dc2.onDataChannelState = (s) {
+            if (s == RTCDataChannelState.RTCDataChannelOpen &&
+                !dc2Open.isCompleted) {
+              dc2Open.complete();
+            }
+          };
+        }
+
+        await Future.wait([
+          dc1Open.future.timeout(const Duration(seconds: 10)),
+          dc2Open.future.timeout(const Duration(seconds: 10)),
+        ]);
+
+        final dc2Received = Completer<String>();
+        dc2.onMessage = (msg) {
+          if (!dc2Received.isCompleted) dc2Received.complete(msg.text);
         };
-      }
+        await dc1.send(RTCDataChannelMessage('hello from dc1'));
+        expect(
+          await dc2Received.future.timeout(const Duration(seconds: 5)),
+          equals('hello from dc1'),
+        );
 
-      await Future.wait([
-        dc1Open.future.timeout(const Duration(seconds: 10)),
-        dc2Open.future.timeout(const Duration(seconds: 10)),
-      ]);
-
-      final dc2Received = Completer<String>();
-      dc2.onMessage = (msg) {
-        if (!dc2Received.isCompleted) dc2Received.complete(msg.text);
-      };
-      await dc1.send(RTCDataChannelMessage('hello from dc1'));
-      expect(
-        await dc2Received.future.timeout(const Duration(seconds: 5)),
-        equals('hello from dc1'),
-      );
-
-      final dc1Received = Completer<String>();
-      dc1.onMessage = (msg) {
-        if (!dc1Received.isCompleted) dc1Received.complete(msg.text);
-      };
-      await dc2.send(RTCDataChannelMessage('hello from dc2'));
-      expect(
-        await dc1Received.future.timeout(const Duration(seconds: 5)),
-        equals('hello from dc2'),
-      );
-
-      await dc1.close();
-      await dc2.close();
-      await pc1.close();
-      await pc2.close();
-    }, timeout: const Timeout(Duration(seconds: 60)));
-
-    testWidgets('loopback binary message exchange',
-        (WidgetTester tester) async {
-      final pc1 = await createPeerConnection(_kConfig);
-      final pc2 = await createPeerConnection(_kConfig);
-
-      final dc2Completer = Completer<RTCDataChannel>();
-      pc2.onDataChannel = (channel) {
-        if (!dc2Completer.isCompleted) dc2Completer.complete(channel);
-      };
-
-      final dc1 = await pc1.createDataChannel(
-        'binary',
-        RTCDataChannelInit()..ordered = true,
-      );
-
-      await _negotiate(pc1, pc2);
-
-      final dc2 =
-          await dc2Completer.future.timeout(const Duration(seconds: 10));
-
-      final dc1Open = Completer<void>();
-      final dc2Open = Completer<void>();
-      if (dc1.state == RTCDataChannelState.RTCDataChannelOpen) {
-        dc1Open.complete();
-      } else {
-        dc1.onDataChannelState = (s) {
-          if (s == RTCDataChannelState.RTCDataChannelOpen &&
-              !dc1Open.isCompleted) {
-            dc1Open.complete();
-          }
+        final dc1Received = Completer<String>();
+        dc1.onMessage = (msg) {
+          if (!dc1Received.isCompleted) dc1Received.complete(msg.text);
         };
-      }
-      if (dc2.state == RTCDataChannelState.RTCDataChannelOpen) {
-        dc2Open.complete();
-      } else {
-        dc2.onDataChannelState = (s) {
-          if (s == RTCDataChannelState.RTCDataChannelOpen &&
-              !dc2Open.isCompleted) {
-            dc2Open.complete();
-          }
+        await dc2.send(RTCDataChannelMessage('hello from dc2'));
+        expect(
+          await dc1Received.future.timeout(const Duration(seconds: 5)),
+          equals('hello from dc2'),
+        );
+
+        await dc1.close();
+        await dc2.close();
+        await pc1.close();
+        await pc2.close();
+      },
+      timeout: const Timeout(Duration(seconds: 60)),
+    );
+
+    test(
+      'loopback binary message exchange',
+      () async {
+        final pc1 = await createPeerConnection(_kConfig);
+        final pc2 = await createPeerConnection(_kConfig);
+
+        final dc2Completer = Completer<RTCDataChannel>();
+        pc2.onDataChannel = (channel) {
+          if (!dc2Completer.isCompleted) dc2Completer.complete(channel);
         };
-      }
 
-      await Future.wait([
-        dc1Open.future.timeout(const Duration(seconds: 10)),
-        dc2Open.future.timeout(const Duration(seconds: 10)),
-      ]);
+        final dc1 = await pc1.createDataChannel(
+          'binary',
+          RTCDataChannelInit()..ordered = true,
+        );
 
-      final payload = Uint8List.fromList([1, 2, 3, 4, 5]);
+        await _negotiate(pc1, pc2);
 
-      final dc2Received = Completer<Uint8List>();
-      dc2.onMessage = (msg) {
-        if (!dc2Received.isCompleted) dc2Received.complete(msg.binary);
-      };
-      await dc1.send(RTCDataChannelMessage.fromBinary(payload));
-      expect(
-        await dc2Received.future.timeout(const Duration(seconds: 5)),
-        equals(payload),
-      );
+        final dc2 = await dc2Completer.future.timeout(
+          const Duration(seconds: 10),
+        );
 
-      await dc1.close();
-      await dc2.close();
-      await pc1.close();
-      await pc2.close();
-    }, timeout: const Timeout(Duration(seconds: 60)));
+        final dc1Open = Completer<void>();
+        final dc2Open = Completer<void>();
+        if (dc1.state == RTCDataChannelState.RTCDataChannelOpen) {
+          dc1Open.complete();
+        } else {
+          dc1.onDataChannelState = (s) {
+            if (s == RTCDataChannelState.RTCDataChannelOpen &&
+                !dc1Open.isCompleted) {
+              dc1Open.complete();
+            }
+          };
+        }
+        if (dc2.state == RTCDataChannelState.RTCDataChannelOpen) {
+          dc2Open.complete();
+        } else {
+          dc2.onDataChannelState = (s) {
+            if (s == RTCDataChannelState.RTCDataChannelOpen &&
+                !dc2Open.isCompleted) {
+              dc2Open.complete();
+            }
+          };
+        }
+
+        await Future.wait([
+          dc1Open.future.timeout(const Duration(seconds: 10)),
+          dc2Open.future.timeout(const Duration(seconds: 10)),
+        ]);
+
+        final payload = Uint8List.fromList([1, 2, 3, 4, 5]);
+
+        final dc2Received = Completer<Uint8List>();
+        dc2.onMessage = (msg) {
+          if (!dc2Received.isCompleted) dc2Received.complete(msg.binary);
+        };
+        await dc1.send(RTCDataChannelMessage.fromBinary(payload));
+        expect(
+          await dc2Received.future.timeout(const Duration(seconds: 5)),
+          equals(payload),
+        );
+
+        await dc1.close();
+        await dc2.close();
+        await pc1.close();
+        await pc2.close();
+      },
+      timeout: const Timeout(Duration(seconds: 60)),
+    );
   });
 }

--- a/packages/geolocator/CHANGELOG.md
+++ b/packages/geolocator/CHANGELOG.md
@@ -1,3 +1,7 @@
+## NEXT
+
+* Update integration tests.
+
 ## 1.0.8
 
 * Remove Ecore API.

--- a/packages/geolocator/example/integration_test/geolocator_test.dart
+++ b/packages/geolocator/example/integration_test/geolocator_test.dart
@@ -13,27 +13,27 @@ import 'package:integration_test/integration_test.dart';
 Future<void> main() async {
   IntegrationTestWidgetsFlutterBinding.ensureInitialized();
 
-  testWidgets('request permission', (WidgetTester tester) async {
+  test('request permission', () async {
     expect(await Geolocator.requestPermission(), LocationPermission.always);
   }, timeout: const Timeout(Duration(seconds: 10)));
 
-  testWidgets('check permission', (WidgetTester tester) async {
+  test('check permission', () async {
     expect(await Geolocator.checkPermission(), LocationPermission.always);
   }, timeout: const Timeout(Duration(seconds: 10)));
 
-  testWidgets('is location service enabled', (WidgetTester tester) async {
+  test('is location service enabled', () async {
     expect(await Geolocator.isLocationServiceEnabled(), true);
   }, timeout: const Timeout(Duration(seconds: 10)));
 
-  testWidgets('get current position', (WidgetTester tester) async {
+  test('get current position', () async {
     expect(await Geolocator.getCurrentPosition(), isA<Position>());
   }, timeout: const Timeout(Duration(seconds: 10)));
 
-  testWidgets('get last known position', (WidgetTester tester) async {
+  test('get last known position', () async {
     expect(await Geolocator.getLastKnownPosition(), isA<Position>());
   }, timeout: const Timeout(Duration(seconds: 10)));
 
-  testWidgets('listen location', (WidgetTester tester) async {
+  test('listen location', () async {
     final Completer<Object> completer = Completer<Object>();
     final StreamSubscription<Position> subscription =
         Geolocator.getPositionStream().listen(

--- a/packages/google_sign_in/CHANGELOG.md
+++ b/packages/google_sign_in/CHANGELOG.md
@@ -1,3 +1,7 @@
+## NEXT
+
+* Update integration tests.
+
 ## 0.2.0
 
 * Update `google_sign_in_platform_interface` to 3.1.0.

--- a/packages/google_sign_in/example/integration_test/google_sign_in_test.dart
+++ b/packages/google_sign_in/example/integration_test/google_sign_in_test.dart
@@ -11,7 +11,7 @@ import 'package:integration_test/integration_test.dart';
 void main() {
   IntegrationTestWidgetsFlutterBinding.ensureInitialized();
 
-  testWidgets('Can initialize the plugin', (WidgetTester tester) async {
+  test('Can initialize the plugin', () async {
     GoogleSignInTizen.setCredentials(
       clientId: credentials.clientId,
       clientSecret: credentials.clientSecret,

--- a/packages/in_app_purchase/CHANGELOG.md
+++ b/packages/in_app_purchase/CHANGELOG.md
@@ -1,3 +1,7 @@
+## NEXT
+
+* Update integration tests.
+
 ## 0.1.5
 
 * Update in_app_purchase to 3.2.3

--- a/packages/in_app_purchase/example/integration_test/in_app_purchase_test.dart
+++ b/packages/in_app_purchase/example/integration_test/in_app_purchase_test.dart
@@ -9,7 +9,7 @@ import 'package:integration_test/integration_test.dart';
 void main() {
   IntegrationTestWidgetsFlutterBinding.ensureInitialized();
 
-  testWidgets('Can create InAppPurchase instance', (WidgetTester tester) async {
+  test('Can create InAppPurchase instance', () async {
     final InAppPurchase iapInstance = InAppPurchase.instance;
     expect(iapInstance, isNotNull);
   });

--- a/packages/keyboard_detection/CHANGELOG.md
+++ b/packages/keyboard_detection/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## NEXT
 
 * Add 18 integration test cases.
+* Update integration tests.
 
 ## 0.1.0
 

--- a/packages/keyboard_detection/example/integration_test/keyboard_detection_tizen_test.dart
+++ b/packages/keyboard_detection/example/integration_test/keyboard_detection_tizen_test.dart
@@ -15,9 +15,10 @@ void main() {
   const String channelName = 'tizen/internal/inputpanel';
   const StandardMethodCodec codec = StandardMethodCodec();
 
-  Future<void> emit(WidgetTester tester, Map<String, Object?> payload) async {
+  Future<void> emit(Map<String, Object?> payload) async {
     final ByteData data = codec.encodeSuccessEnvelope(payload);
-    await tester.binding.defaultBinaryMessenger.handlePlatformMessage(
+    await TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .handlePlatformMessage(
       channelName,
       data,
       (_) {},
@@ -25,7 +26,7 @@ void main() {
   }
 
   group('state reporting', () {
-    testWidgets('starts in the unknown state', (WidgetTester tester) async {
+    test('starts in the unknown state', () async {
       final KeyboardDetectionController controller =
           KeyboardDetectionController();
       expect(controller.state, KeyboardState.unknown);
@@ -33,89 +34,84 @@ void main() {
       await controller.dispose();
     });
 
-    testWidgets('reports visibling on will_show event',
-        (WidgetTester tester) async {
+    test('reports visibling on will_show event', () async {
       final KeyboardDetectionController controller =
           KeyboardDetectionController();
-      await emit(tester, <String, Object?>{'state': 'will_show'});
-      await tester.pump();
+      await emit(<String, Object?>{'state': 'will_show'});
+      await Future<void>.delayed(Duration.zero);
       expect(controller.state, KeyboardState.visibling);
       expect(controller.stateAsBool(), isFalse);
       expect(controller.stateAsBool(true), isTrue);
       await controller.dispose();
     });
 
-    testWidgets('reports visible on show event', (WidgetTester tester) async {
+    test('reports visible on show event', () async {
       final KeyboardDetectionController controller =
           KeyboardDetectionController();
-      await emit(tester, <String, Object?>{'state': 'show'});
-      await tester.pump();
+      await emit(<String, Object?>{'state': 'show'});
+      await Future<void>.delayed(Duration.zero);
       expect(controller.state, KeyboardState.visible);
       expect(controller.stateAsBool(), isTrue);
       await controller.dispose();
     });
 
-    testWidgets('reports hiding on will_hide event',
-        (WidgetTester tester) async {
+    test('reports hiding on will_hide event', () async {
       final KeyboardDetectionController controller =
           KeyboardDetectionController();
-      await emit(tester, <String, Object?>{'state': 'show'});
-      await tester.pump();
-      await emit(tester, <String, Object?>{'state': 'will_hide'});
-      await tester.pump();
+      await emit(<String, Object?>{'state': 'show'});
+      await Future<void>.delayed(Duration.zero);
+      await emit(<String, Object?>{'state': 'will_hide'});
+      await Future<void>.delayed(Duration.zero);
       expect(controller.state, KeyboardState.hiding);
       expect(controller.stateAsBool(), isTrue);
       expect(controller.stateAsBool(true), isFalse);
       await controller.dispose();
     });
 
-    testWidgets('reports hidden on hide event', (WidgetTester tester) async {
+    test('reports hidden on hide event', () async {
       final KeyboardDetectionController controller =
           KeyboardDetectionController();
-      await emit(tester, <String, Object?>{'state': 'show'});
-      await tester.pump();
-      await emit(tester, <String, Object?>{'state': 'hide'});
-      await tester.pump();
+      await emit(<String, Object?>{'state': 'show'});
+      await Future<void>.delayed(Duration.zero);
+      await emit(<String, Object?>{'state': 'hide'});
+      await Future<void>.delayed(Duration.zero);
       expect(controller.state, KeyboardState.hidden);
       expect(controller.stateAsBool(), isFalse);
       await controller.dispose();
     });
 
-    testWidgets('falls back to unknown for an unrecognized event',
-        (WidgetTester tester) async {
+    test('falls back to unknown for an unrecognized event', () async {
       final KeyboardDetectionController controller =
           KeyboardDetectionController();
-      await emit(tester, <String, Object?>{'state': 'show'});
-      await tester.pump();
-      await emit(tester, <String, Object?>{'state': 'something_else'});
-      await tester.pump();
+      await emit(<String, Object?>{'state': 'show'});
+      await Future<void>.delayed(Duration.zero);
+      await emit(<String, Object?>{'state': 'something_else'});
+      await Future<void>.delayed(Duration.zero);
       expect(controller.state, KeyboardState.unknown);
       await controller.dispose();
     });
 
-    testWidgets('ignores events without a valid state field',
-        (WidgetTester tester) async {
+    test('ignores events without a valid state field', () async {
       final KeyboardDetectionController controller =
           KeyboardDetectionController();
       // Reach a known state first, so the assertions verify that the invalid
       // events are ignored (state preserved) rather than merely matching the
       // initial unknown state.
-      await emit(tester, <String, Object?>{'state': 'show'});
-      await tester.pump();
+      await emit(<String, Object?>{'state': 'show'});
+      await Future<void>.delayed(Duration.zero);
       expect(controller.state, KeyboardState.visible);
-      await emit(tester, <String, Object?>{'noState': true});
-      await tester.pump();
+      await emit(<String, Object?>{'noState': true});
+      await Future<void>.delayed(Duration.zero);
       expect(controller.state, KeyboardState.visible);
-      await emit(tester, <String, Object?>{'state': 123});
-      await tester.pump();
+      await emit(<String, Object?>{'state': 123});
+      await Future<void>.delayed(Duration.zero);
       expect(controller.state, KeyboardState.visible);
       await controller.dispose();
     });
   });
 
   group('keyboard metrics', () {
-    testWidgets('size, width and position are zero before any event',
-        (WidgetTester tester) async {
+    test('size, width and position are zero before any event', () async {
       final KeyboardDetectionController controller =
           KeyboardDetectionController();
       expect(controller.size, 0);
@@ -125,18 +121,17 @@ void main() {
       await controller.dispose();
     });
 
-    testWidgets('updates metrics from a show event carrying dimensions',
-        (WidgetTester tester) async {
+    test('updates metrics from a show event carrying dimensions', () async {
       final KeyboardDetectionController controller =
           KeyboardDetectionController();
-      await emit(tester, <String, Object?>{
+      await emit(<String, Object?>{
         'state': 'show',
         'width': 1080.0,
         'height': 420.0,
         'x': 0.0,
         'y': 1500.0,
       });
-      await tester.pump();
+      await Future<void>.delayed(Duration.zero);
       expect(controller.width, 1080.0);
       expect(controller.size, 420.0);
       expect(controller.position, const Offset(0, 1500));
@@ -144,35 +139,34 @@ void main() {
       await controller.dispose();
     });
 
-    testWidgets('ensureSizeLoaded completes once metrics arrive',
-        (WidgetTester tester) async {
+    test('ensureSizeLoaded completes once metrics arrive', () async {
       final KeyboardDetectionController controller =
           KeyboardDetectionController();
       final Future<void> sizeLoaded = controller.ensureSizeLoaded;
-      await emit(tester, <String, Object?>{
+      await emit(<String, Object?>{
         'state': 'show',
         'width': 1080.0,
         'height': 420.0,
       });
-      await tester.pump();
+      await Future<void>.delayed(Duration.zero);
       await expectLater(sizeLoaded, completes);
       expect(controller.isSizeLoaded, isTrue);
       await controller.dispose();
     });
 
-    testWidgets('resets metrics to zero on hide', (WidgetTester tester) async {
+    test('resets metrics to zero on hide', () async {
       final KeyboardDetectionController controller =
           KeyboardDetectionController();
-      await emit(tester, <String, Object?>{
+      await emit(<String, Object?>{
         'state': 'show',
         'width': 1080.0,
         'height': 420.0,
         'x': 0.0,
         'y': 1500.0,
       });
-      await tester.pump();
-      await emit(tester, <String, Object?>{'state': 'hide'});
-      await tester.pump();
+      await Future<void>.delayed(Duration.zero);
+      await emit(<String, Object?>{'state': 'hide'});
+      await Future<void>.delayed(Duration.zero);
       expect(controller.width, 0);
       expect(controller.size, 0);
       expect(controller.position, Offset.zero);
@@ -181,19 +175,18 @@ void main() {
   });
 
   group('notifications', () {
-    testWidgets('stream emits state changes in order',
-        (WidgetTester tester) async {
+    test('stream emits state changes in order', () async {
       final KeyboardDetectionController controller =
           KeyboardDetectionController();
       final List<KeyboardState> seen = <KeyboardState>[];
       final StreamSubscription<KeyboardState> subscription =
           controller.stream.listen(seen.add);
-      await emit(tester, <String, Object?>{'state': 'will_show'});
-      await tester.pump();
-      await emit(tester, <String, Object?>{'state': 'show'});
-      await tester.pump();
-      await emit(tester, <String, Object?>{'state': 'hide'});
-      await tester.pump();
+      await emit(<String, Object?>{'state': 'will_show'});
+      await Future<void>.delayed(Duration.zero);
+      await emit(<String, Object?>{'state': 'show'});
+      await Future<void>.delayed(Duration.zero);
+      await emit(<String, Object?>{'state': 'hide'});
+      await Future<void>.delayed(Duration.zero);
       expect(seen, <KeyboardState>[
         KeyboardState.visibling,
         KeyboardState.visible,
@@ -203,15 +196,14 @@ void main() {
       await controller.dispose();
     });
 
-    testWidgets('onChanged is invoked on every state change',
-        (WidgetTester tester) async {
+    test('onChanged is invoked on every state change', () async {
       final List<KeyboardState> seen = <KeyboardState>[];
       final KeyboardDetectionController controller =
           KeyboardDetectionController(onChanged: seen.add);
-      await emit(tester, <String, Object?>{'state': 'show'});
-      await tester.pump();
-      await emit(tester, <String, Object?>{'state': 'hide'});
-      await tester.pump();
+      await emit(<String, Object?>{'state': 'show'});
+      await Future<void>.delayed(Duration.zero);
+      await emit(<String, Object?>{'state': 'hide'});
+      await Future<void>.delayed(Duration.zero);
       expect(seen, <KeyboardState>[
         KeyboardState.visible,
         KeyboardState.hidden,
@@ -221,8 +213,7 @@ void main() {
   });
 
   group('registered callbacks', () {
-    testWidgets('a registered callback receives state changes',
-        (WidgetTester tester) async {
+    test('a registered callback receives state changes', () async {
       final KeyboardDetectionController controller =
           KeyboardDetectionController();
       final List<KeyboardState> seen = <KeyboardState>[];
@@ -230,10 +221,10 @@ void main() {
         seen.add(state);
         return true;
       });
-      await emit(tester, <String, Object?>{'state': 'show'});
-      await tester.pump();
-      await emit(tester, <String, Object?>{'state': 'hide'});
-      await tester.pump();
+      await emit(<String, Object?>{'state': 'show'});
+      await Future<void>.delayed(Duration.zero);
+      await emit(<String, Object?>{'state': 'hide'});
+      await Future<void>.delayed(Duration.zero);
       expect(seen, <KeyboardState>[
         KeyboardState.visible,
         KeyboardState.hidden,
@@ -241,8 +232,7 @@ void main() {
       await controller.dispose();
     });
 
-    testWidgets('a callback returning false unregisters itself',
-        (WidgetTester tester) async {
+    test('a callback returning false unregisters itself', () async {
       final KeyboardDetectionController controller =
           KeyboardDetectionController();
       int calls = 0;
@@ -250,16 +240,15 @@ void main() {
         calls++;
         return false;
       });
-      await emit(tester, <String, Object?>{'state': 'show'});
-      await tester.pump();
-      await emit(tester, <String, Object?>{'state': 'hide'});
-      await tester.pump();
+      await emit(<String, Object?>{'state': 'show'});
+      await Future<void>.delayed(Duration.zero);
+      await emit(<String, Object?>{'state': 'hide'});
+      await Future<void>.delayed(Duration.zero);
       expect(calls, 1);
       await controller.dispose();
     });
 
-    testWidgets('unregisterCallback stops further invocations',
-        (WidgetTester tester) async {
+    test('unregisterCallback stops further invocations', () async {
       final KeyboardDetectionController controller =
           KeyboardDetectionController();
       final List<KeyboardState> seen = <KeyboardState>[];
@@ -269,17 +258,16 @@ void main() {
       }
 
       controller.registerCallback(callback);
-      await emit(tester, <String, Object?>{'state': 'show'});
-      await tester.pump();
+      await emit(<String, Object?>{'state': 'show'});
+      await Future<void>.delayed(Duration.zero);
       controller.unregisterCallback(callback);
-      await emit(tester, <String, Object?>{'state': 'hide'});
-      await tester.pump();
+      await emit(<String, Object?>{'state': 'hide'});
+      await Future<void>.delayed(Duration.zero);
       expect(seen, <KeyboardState>[KeyboardState.visible]);
       await controller.dispose();
     });
 
-    testWidgets('unregisterAllCallbacks removes every callback',
-        (WidgetTester tester) async {
+    test('unregisterAllCallbacks removes every callback', () async {
       final KeyboardDetectionController controller =
           KeyboardDetectionController();
       int first = 0;
@@ -292,11 +280,11 @@ void main() {
         second++;
         return true;
       });
-      await emit(tester, <String, Object?>{'state': 'show'});
-      await tester.pump();
+      await emit(<String, Object?>{'state': 'show'});
+      await Future<void>.delayed(Duration.zero);
       controller.unregisterAllCallbacks();
-      await emit(tester, <String, Object?>{'state': 'hide'});
-      await tester.pump();
+      await emit(<String, Object?>{'state': 'hide'});
+      await Future<void>.delayed(Duration.zero);
       expect(first, 1);
       expect(second, 1);
       await controller.dispose();
@@ -304,16 +292,15 @@ void main() {
   });
 
   group('lifecycle', () {
-    testWidgets('does not report state changes after dispose',
-        (WidgetTester tester) async {
+    test('does not report state changes after dispose', () async {
       final KeyboardDetectionController controller =
           KeyboardDetectionController();
-      await emit(tester, <String, Object?>{'state': 'show'});
-      await tester.pump();
+      await emit(<String, Object?>{'state': 'show'});
+      await Future<void>.delayed(Duration.zero);
       expect(controller.state, KeyboardState.visible);
       await controller.dispose();
-      await emit(tester, <String, Object?>{'state': 'hide'});
-      await tester.pump();
+      await emit(<String, Object?>{'state': 'hide'});
+      await Future<void>.delayed(Duration.zero);
       expect(controller.state, KeyboardState.visible);
     });
   });

--- a/packages/messageport/CHANGELOG.md
+++ b/packages/messageport/CHANGELOG.md
@@ -4,6 +4,7 @@
 * Update minimum Flutter and Dart version to 3.13 and 3.1.
 * Update code format.
 * Add 5 integration test cases.
+* Update integration tests.
 
 ## 0.3.2
 

--- a/packages/messageport/example/integration_test/messageport_test.dart
+++ b/packages/messageport/example/integration_test/messageport_test.dart
@@ -14,17 +14,17 @@ const String kTestAppId = 'org.tizen.messageport_tizen_example';
 void main() {
   IntegrationTestWidgetsFlutterBinding.ensureInitialized();
 
-  testWidgets('Create non trusted local port', (WidgetTester tester) async {
+  test('Create non trusted local port', () async {
     final LocalPort port = await LocalPort.create(kTestPort, trusted: false);
     expect(port.trusted, isFalse);
   }, timeout: const Timeout(Duration(seconds: 5)));
 
-  testWidgets('Create trusted local port', (WidgetTester tester) async {
+  test('Create trusted local port', () async {
     final LocalPort port = await LocalPort.create(kTestPort);
     expect(port.trusted, isTrue);
   }, timeout: const Timeout(Duration(seconds: 5)));
 
-  testWidgets('Create remote port', (WidgetTester tester) async {
+  test('Create remote port', () async {
     final LocalPort localPort = await LocalPort.create(kTestPort);
     localPort.register((dynamic message, [RemotePort? remotePort]) {});
 
@@ -38,9 +38,9 @@ void main() {
     await localPort.unregister();
   }, timeout: const Timeout(Duration(seconds: 5)));
 
-  testWidgets(
+  test(
     'Create trusted remote port from not trusted',
-    (WidgetTester tester) async {
+    () async {
       final LocalPort localPort = await LocalPort.create(
         kTestPort,
         trusted: false,
@@ -57,7 +57,7 @@ void main() {
     timeout: const Timeout(Duration(seconds: 5)),
   );
 
-  testWidgets('Check for remote', (WidgetTester tester) async {
+  test('Check for remote', () async {
     final LocalPort localPort = await LocalPort.create(kTestPort);
     localPort.register((dynamic message, [RemotePort? remotePort]) {});
 
@@ -71,7 +71,7 @@ void main() {
     expect(await remotePort.check(), isFalse);
   }, timeout: const Timeout(Duration(seconds: 5)));
 
-  testWidgets('Send simple message', (WidgetTester tester) async {
+  test('Send simple message', () async {
     final LocalPort localPort = await LocalPort.create(kTestPort);
     final Completer<dynamic> completer = Completer<dynamic>();
     localPort.register((dynamic message, [RemotePort? remotePort]) {
@@ -88,7 +88,7 @@ void main() {
     await localPort.unregister();
   }, timeout: const Timeout(Duration(seconds: 5)));
 
-  testWidgets('Send message with local port', (WidgetTester tester) async {
+  test('Send message with local port', () async {
     final LocalPort localPort = await LocalPort.create(kTestPort);
     final Completer<List<dynamic>> completer = Completer<List<dynamic>>();
     localPort.register((dynamic message, [RemotePort? remotePort]) {
@@ -111,7 +111,7 @@ void main() {
   }, timeout: const Timeout(Duration(seconds: 5)));
 
   group('LocalPort lifecycle', () {
-    testWidgets('registered reflects the register/unregister lifecycle', (
+    test('registered reflects the register/unregister lifecycle', (
       WidgetTester tester,
     ) async {
       final LocalPort localPort = await LocalPort.create(kTestPort);
@@ -127,7 +127,7 @@ void main() {
       expect(localPort.registered, isFalse);
     }, timeout: const Timeout(Duration(seconds: 5)));
 
-    testWidgets('register throws when the port is already registered', (
+    test('register throws when the port is already registered', (
       WidgetTester tester,
     ) async {
       final LocalPort localPort = await LocalPort.create(kTestPort);
@@ -141,7 +141,7 @@ void main() {
       );
     }, timeout: const Timeout(Duration(seconds: 5)));
 
-    testWidgets('unregister is safe when not registered and when repeated', (
+    test('unregister is safe when not registered and when repeated', (
       WidgetTester tester,
     ) async {
       final LocalPort localPort = await LocalPort.create(kTestPort);
@@ -188,46 +188,46 @@ void main() {
       expect(receivedMessage, equals(message));
     }
 
-    testWidgets('null', (WidgetTester tester) async {
+    test('null', () async {
       await checkForMessage(null);
     }, timeout: const Timeout(Duration(seconds: 5)));
 
-    testWidgets('bool', (WidgetTester tester) async {
+    test('bool', () async {
       const bool value = true;
       await checkForMessage<bool>(value);
     }, timeout: const Timeout(Duration(seconds: 5)));
 
-    testWidgets('int', (WidgetTester tester) async {
+    test('int', () async {
       const int value = 834;
       await checkForMessage<int>(value);
     }, timeout: const Timeout(Duration(seconds: 5)));
 
-    testWidgets('double', (WidgetTester tester) async {
+    test('double', () async {
       const double value = 12.847;
       await checkForMessage<double>(value);
     }, timeout: const Timeout(Duration(seconds: 5)));
 
-    testWidgets('string', (WidgetTester tester) async {
+    test('string', () async {
       const String value = 'Short string message';
       await checkForMessage<String>(value);
     }, timeout: const Timeout(Duration(seconds: 5)));
 
-    testWidgets('list', (WidgetTester tester) async {
+    test('list', () async {
       final List<int> value = <int>[1, 5, 8, 12, 0, 2];
       await checkForMessage<List<dynamic>>(value);
     }, timeout: const Timeout(Duration(seconds: 5)));
 
-    testWidgets('map', (WidgetTester tester) async {
+    test('map', () async {
       final Map<String, int> value = <String, int>{'a': 5, 'b': 12};
       await checkForMessage<Map<dynamic, dynamic>>(value);
     }, timeout: const Timeout(Duration(seconds: 5)));
 
-    testWidgets('empty string', (WidgetTester tester) async {
+    test('empty string', () async {
       const String value = '';
       await checkForMessage<String>(value);
     }, timeout: const Timeout(Duration(seconds: 5)));
 
-    testWidgets('nested collection', (WidgetTester tester) async {
+    test('nested collection', () async {
       final Map<String, dynamic> value = <String, dynamic>{
         'numbers': <int>[1, 2, 3],
         'nested': <String, String>{'key': 'value'},

--- a/packages/messageport/example/integration_test/messageport_test.dart
+++ b/packages/messageport/example/integration_test/messageport_test.dart
@@ -111,9 +111,7 @@ void main() {
   }, timeout: const Timeout(Duration(seconds: 5)));
 
   group('LocalPort lifecycle', () {
-    test('registered reflects the register/unregister lifecycle', (
-      WidgetTester tester,
-    ) async {
+    test('registered reflects the register/unregister lifecycle', () async {
       final LocalPort localPort = await LocalPort.create(kTestPort);
       // Ensure the port is unregistered even if an assertion below fails.
       addTearDown(localPort.unregister);
@@ -127,9 +125,7 @@ void main() {
       expect(localPort.registered, isFalse);
     }, timeout: const Timeout(Duration(seconds: 5)));
 
-    test('register throws when the port is already registered', (
-      WidgetTester tester,
-    ) async {
+    test('register throws when the port is already registered', () async {
       final LocalPort localPort = await LocalPort.create(kTestPort);
       addTearDown(localPort.unregister);
       localPort.register((dynamic message, [RemotePort? remotePort]) {});
@@ -141,9 +137,7 @@ void main() {
       );
     }, timeout: const Timeout(Duration(seconds: 5)));
 
-    test('unregister is safe when not registered and when repeated', (
-      WidgetTester tester,
-    ) async {
+    test('unregister is safe when not registered and when repeated', () async {
       final LocalPort localPort = await LocalPort.create(kTestPort);
       addTearDown(localPort.unregister);
 

--- a/packages/network_info_plus/CHANGELOG.md
+++ b/packages/network_info_plus/CHANGELOG.md
@@ -1,3 +1,7 @@
+## NEXT
+
+* Update integration tests.
+
 ## 1.1.6
 
 * Update network_info_plus_platform_interface to 2.0.0.

--- a/packages/network_info_plus/example/integration_test/network_info_plus_test.dart
+++ b/packages/network_info_plus/example/integration_test/network_info_plus_test.dart
@@ -15,7 +15,7 @@ void main() {
     networkInfo = NetworkInfo();
   });
 
-  testWidgets('test non-null network value', (WidgetTester tester) async {
+  test('test non-null network value', () async {
     expect(networkInfo.getWifiName(), isNotNull);
     expect(networkInfo.getWifiBSSID(), isNotNull);
     expect(networkInfo.getWifiIP(), isNotNull);

--- a/packages/path_provider/CHANGELOG.md
+++ b/packages/path_provider/CHANGELOG.md
@@ -1,3 +1,7 @@
+## NEXT
+
+* Update integration tests.
+
 ## 2.3.0
 
 * Update path_provider to 2.1.5.

--- a/packages/path_provider/example/integration_test/path_provider_test.dart
+++ b/packages/path_provider/example/integration_test/path_provider_test.dart
@@ -10,12 +10,12 @@ import 'package:path_provider/path_provider.dart';
 void main() {
   IntegrationTestWidgetsFlutterBinding.ensureInitialized();
 
-  testWidgets('getTemporaryDirectory', (WidgetTester tester) async {
+  test('getTemporaryDirectory', () async {
     final Directory result = await getTemporaryDirectory();
     _verifySampleFile(result, 'temporaryDirectory');
   });
 
-  testWidgets('getApplicationDocumentsDirectory', (WidgetTester tester) async {
+  test('getApplicationDocumentsDirectory', () async {
     final Directory result = await getApplicationDocumentsDirectory();
     if (Platform.isMacOS) {
       // _verifySampleFile causes hangs in driver when sandboxing is disabled
@@ -28,17 +28,17 @@ void main() {
     }
   });
 
-  testWidgets('getApplicationSupportDirectory', (WidgetTester tester) async {
+  test('getApplicationSupportDirectory', () async {
     final Directory result = await getApplicationSupportDirectory();
     _verifySampleFile(result, 'applicationSupport');
   });
 
-  testWidgets('getApplicationCacheDirectory', (WidgetTester tester) async {
+  test('getApplicationCacheDirectory', () async {
     final Directory result = await getApplicationCacheDirectory();
     _verifySampleFile(result, 'applicationCache');
   });
 
-  testWidgets('getLibraryDirectory', (WidgetTester tester) async {
+  test('getLibraryDirectory', () async {
     if (Platform.isIOS) {
       final Directory result = await getLibraryDirectory();
       _verifySampleFile(result, 'library');
@@ -48,7 +48,7 @@ void main() {
     }
   });
 
-  testWidgets('getExternalStorageDirectory', (WidgetTester tester) async {
+  test('getExternalStorageDirectory', () async {
     if (Platform.isIOS) {
       final Future<Directory?> result = getExternalStorageDirectory();
       await expectLater(result, throwsA(isInstanceOf<UnsupportedError>()));
@@ -58,7 +58,7 @@ void main() {
     }
   });
 
-  testWidgets('getExternalCacheDirectories', (WidgetTester tester) async {
+  test('getExternalCacheDirectories', () async {
     if (Platform.isIOS) {
       final Future<List<Directory>?> result = getExternalCacheDirectories();
       await expectLater(result, throwsA(isInstanceOf<UnsupportedError>()));
@@ -71,7 +71,7 @@ void main() {
     }
   });
 
-  testWidgets('getDownloadsDirectory', (WidgetTester tester) async {
+  test('getDownloadsDirectory', () async {
     final Directory? result = await getDownloadsDirectory();
     if (result != null) {
       _verifySampleFile(result, 'downloads');
@@ -90,9 +90,7 @@ void main() {
   ];
 
   for (final StorageDirectory? type in allDirs) {
-    testWidgets('getExternalStorageDirectories (type: $type)', (
-      WidgetTester tester,
-    ) async {
+    test('getExternalStorageDirectories (type: $type)', () async {
       if (Platform.isIOS) {
         final Future<List<Directory>?> result = getExternalStorageDirectories();
         await expectLater(result, throwsA(isInstanceOf<UnsupportedError>()));

--- a/packages/permission_handler/CHANGELOG.md
+++ b/packages/permission_handler/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## NEXT
 
 * Add 8 integration test cases.
+* Update integration tests.
 
 ## 1.4.4
 

--- a/packages/permission_handler/example/integration_test/permission_handler_test.dart
+++ b/packages/permission_handler/example/integration_test/permission_handler_test.dart
@@ -10,46 +10,45 @@ void main() {
   IntegrationTestWidgetsFlutterBinding.ensureInitialized();
 
   group('Permission.status', () {
-    testWidgets('camera permission is granted', (tester) async {
+    test('camera permission is granted', () async {
       expect(await Permission.camera.status, PermissionStatus.granted);
     });
 
-    testWidgets('microphone permission is granted', (tester) async {
+    test('microphone permission is granted', () async {
       expect(await Permission.microphone.status, PermissionStatus.granted);
     });
 
-    testWidgets('location permission is granted', (tester) async {
+    test('location permission is granted', () async {
       expect(await Permission.location.status, PermissionStatus.granted);
     });
 
-    testWidgets('mediaLibrary permission is granted', (tester) async {
+    test('mediaLibrary permission is granted', () async {
       expect(await Permission.mediaLibrary.status, PermissionStatus.granted);
     });
 
-    testWidgets('storage permission is granted', (tester) async {
+    test('storage permission is granted', () async {
       expect(await Permission.storage.status, PermissionStatus.granted);
     });
 
-    testWidgets('contacts permission is granted', (tester) async {
+    test('contacts permission is granted', () async {
       expect(await Permission.contacts.status, PermissionStatus.granted);
     });
   });
 
   group('Permission.serviceStatus', () {
-    testWidgets('location service status is valid', (tester) async {
+    test('location service status is valid', () async {
       final status = await Permission.location.serviceStatus;
       expect(status.isEnabled || status.isDisabled, true);
     });
   });
 
   group('Permission.request', () {
-    testWidgets('requesting camera permission returns granted', (tester) async {
+    test('requesting camera permission returns granted', () async {
       final status = await Permission.camera.request();
       expect(status, PermissionStatus.granted);
     });
 
-    testWidgets('requesting multiple permissions returns granted',
-        (tester) async {
+    test('requesting multiple permissions returns granted', () async {
       final statuses = await [
         Permission.camera,
         Permission.microphone,
@@ -61,7 +60,7 @@ void main() {
     });
   });
 
-  testWidgets('open app settings', (tester) async {
+  test('open app settings', () async {
     expect(await openAppSettings(), true);
   }, skip: true);
 }

--- a/packages/shared_preferences/CHANGELOG.md
+++ b/packages/shared_preferences/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## NEXT
 
 * Add 12 integration test cases for the legacy-to-async migration utility.
+* Update integration tests.
 
 ## 2.3.3
 

--- a/packages/shared_preferences/example/integration_test/shared_preferences_test.dart
+++ b/packages/shared_preferences/example/integration_test/shared_preferences_test.dart
@@ -33,44 +33,44 @@ void main() {
     late SharedPreferences preferences;
 
     void runAllTests() {
-      testWidgets('set and get String', (WidgetTester _) async {
+      test('set and get String', () async {
         expect(preferences.get('String'), isNull);
         await preferences.setString('String', testString2);
         expect(preferences.getString('String'), testString2);
       });
 
-      testWidgets('set and get Bool', (WidgetTester _) async {
+      test('set and get Bool', () async {
         expect(preferences.get('Bool'), isNull);
         await preferences.setBool('Bool', testBool2);
         expect(preferences.getBool('Bool'), testBool2);
       });
 
-      testWidgets('set and get Int', (WidgetTester _) async {
+      test('set and get Int', () async {
         expect(preferences.get('Int'), isNull);
         await preferences.setInt('Int', testInt2);
         expect(preferences.getInt('Int'), testInt2);
       });
 
-      testWidgets('set and get Double', (WidgetTester _) async {
+      test('set and get Double', () async {
         expect(preferences.get('Double'), isNull);
         await preferences.setDouble('Double', testDouble2);
         expect(preferences.getDouble('Double'), testDouble2);
       });
 
-      testWidgets('set and get StringList', (WidgetTester _) async {
+      test('set and get StringList', () async {
         expect(preferences.get('StringList'), isNull);
         await preferences.setStringList('StringList', testList2);
         expect(preferences.getStringList('StringList'), testList2);
       });
 
-      testWidgets('removing', (WidgetTester _) async {
+      test('removing', () async {
         const String key = 'testKey';
         await preferences.setString(key, testString);
         await preferences.remove(key);
         expect(preferences.get('testKey'), isNull);
       });
 
-      testWidgets('clearing', (WidgetTester _) async {
+      test('clearing', () async {
         await preferences.setString('String', testString);
         await preferences.setBool('bool', testBool);
         await preferences.setInt('int', testInt);
@@ -84,7 +84,7 @@ void main() {
         expect(preferences.getStringList('List'), null);
       });
 
-      testWidgets('simultaneous writes', (WidgetTester _) async {
+      test('simultaneous writes', () async {
         final List<Future<bool>> writes = <Future<bool>>[];
         const int writeCount = 100;
         for (int i = 1; i <= writeCount; i++) {
@@ -141,7 +141,7 @@ void main() {
       runAllTests();
     });
 
-    testWidgets('allowList only gets allowed items', (WidgetTester _) async {
+    test('allowList only gets allowed items', () async {
       const String allowedString = 'stringKey';
       const String allowedBool = 'boolKey';
       const String notAllowedDouble = 'doubleKey';
@@ -191,42 +191,42 @@ void main() {
         return preferences;
       }
 
-      testWidgets('set and get String', (WidgetTester _) async {
+      test('set and get String', () async {
         final SharedPreferencesAsync preferences = await getPreferences();
 
         await preferences.setString(stringKey, testString);
         expect(await preferences.getString(stringKey), testString);
       });
 
-      testWidgets('set and get bool', (WidgetTester _) async {
+      test('set and get bool', () async {
         final SharedPreferencesAsync preferences = await getPreferences();
 
         await preferences.setBool(boolKey, testBool);
         expect(await preferences.getBool(boolKey), testBool);
       });
 
-      testWidgets('set and get int', (WidgetTester _) async {
+      test('set and get int', () async {
         final SharedPreferencesAsync preferences = await getPreferences();
 
         await preferences.setInt(intKey, testInt);
         expect(await preferences.getInt(intKey), testInt);
       });
 
-      testWidgets('set and get double', (WidgetTester _) async {
+      test('set and get double', () async {
         final SharedPreferencesAsync preferences = await getPreferences();
 
         await preferences.setDouble(doubleKey, testDouble);
         expect(await preferences.getDouble(doubleKey), testDouble);
       });
 
-      testWidgets('set and get StringList', (WidgetTester _) async {
+      test('set and get StringList', () async {
         final SharedPreferencesAsync preferences = await getPreferences();
 
         await preferences.setStringList(listKey, testList);
         expect(await preferences.getStringList(listKey), testList);
       });
 
-      testWidgets('getStringList returns mutable list', (WidgetTester _) async {
+      test('getStringList returns mutable list', () async {
         final SharedPreferencesAsync preferences = await getPreferences();
 
         await preferences.setStringList(listKey, testList);
@@ -235,7 +235,7 @@ void main() {
         expect(list?.length, testList.length + 1);
       });
 
-      testWidgets('getAll', (WidgetTester _) async {
+      test('getAll', () async {
         final SharedPreferencesAsync preferences = await getPreferences();
         await Future.wait(<Future<void>>[
           preferences.setString(stringKey, testString),
@@ -255,7 +255,7 @@ void main() {
         expect(gotAll[listKey], testList);
       });
 
-      testWidgets('getAll with filter', (WidgetTester _) async {
+      test('getAll with filter', () async {
         final SharedPreferencesAsync preferences = await getPreferences();
         await Future.wait(<Future<void>>[
           preferences.setString(stringKey, testString),
@@ -274,7 +274,7 @@ void main() {
         expect(gotAll[boolKey], testBool);
       });
 
-      testWidgets('getKeys', (WidgetTester _) async {
+      test('getKeys', () async {
         final SharedPreferencesAsync preferences = await getPreferences();
         await Future.wait(<Future<void>>[
           preferences.setString(stringKey, testString),
@@ -294,7 +294,7 @@ void main() {
         expect(keys, contains(listKey));
       });
 
-      testWidgets('getKeys with filter', (WidgetTester _) async {
+      test('getKeys with filter', () async {
         final SharedPreferencesAsync preferences = await getPreferences();
         await Future.wait(<Future<void>>[
           preferences.setString(stringKey, testString),
@@ -313,7 +313,7 @@ void main() {
         expect(keys, contains(boolKey));
       });
 
-      testWidgets('containsKey', (WidgetTester _) async {
+      test('containsKey', () async {
         final SharedPreferencesAsync preferences = await getPreferences();
         const String key = 'testKey';
 
@@ -323,7 +323,7 @@ void main() {
         expect(true, await preferences.containsKey(key));
       });
 
-      testWidgets('clear', (WidgetTester _) async {
+      test('clear', () async {
         final SharedPreferencesAsync preferences = await getPreferences();
         await Future.wait(<Future<void>>[
           preferences.setString(stringKey, testString),
@@ -340,7 +340,7 @@ void main() {
         expect(await preferences.getStringList(listKey), null);
       });
 
-      testWidgets('clear with filter', (WidgetTester _) async {
+      test('clear with filter', () async {
         final SharedPreferencesAsync preferences = await getPreferences();
         await Future.wait(<Future<void>>[
           preferences.setString(stringKey, testString),
@@ -357,9 +357,9 @@ void main() {
         expect(await preferences.getStringList(listKey), testList);
       });
 
-      testWidgets(
+      test(
         'throws TypeError when returned getBool type is incorrect',
-        (WidgetTester _) async {
+        () async {
           final SharedPreferencesAsync preferences = await getPreferences();
           await preferences.setString(stringKey, testString);
 
@@ -369,9 +369,9 @@ void main() {
         },
       );
 
-      testWidgets(
+      test(
         'throws TypeError when returned getString type is incorrect',
-        (WidgetTester _) async {
+        () async {
           final SharedPreferencesAsync preferences = await getPreferences();
           await preferences.setInt(stringKey, testInt);
 
@@ -381,9 +381,9 @@ void main() {
         },
       );
 
-      testWidgets(
+      test(
         'throws TypeError when returned getInt type is incorrect',
-        (WidgetTester _) async {
+        () async {
           final SharedPreferencesAsync preferences = await getPreferences();
           await preferences.setString(stringKey, testString);
 
@@ -393,9 +393,9 @@ void main() {
         },
       );
 
-      testWidgets(
+      test(
         'throws TypeError when returned getDouble type is incorrect',
-        (WidgetTester _) async {
+        () async {
           final SharedPreferencesAsync preferences = await getPreferences();
           await preferences.setString(stringKey, testString);
 
@@ -405,9 +405,9 @@ void main() {
         },
       );
 
-      testWidgets(
+      test(
         'throws TypeError when returned getStringList type is incorrect',
-        (WidgetTester _) async {
+        () async {
           final SharedPreferencesAsync preferences = await getPreferences();
           await preferences.setString(stringKey, testString);
 
@@ -431,7 +431,7 @@ void main() {
         return (preferences, cache);
       }
 
-      testWidgets('set and get String', (WidgetTester _) async {
+      test('set and get String', () async {
         final (SharedPreferencesWithCache preferences, _) =
             await getPreferences();
 
@@ -439,7 +439,7 @@ void main() {
         expect(preferences.getString(stringKey), testString);
       });
 
-      testWidgets('set and get bool', (WidgetTester _) async {
+      test('set and get bool', () async {
         final (SharedPreferencesWithCache preferences, _) =
             await getPreferences();
 
@@ -447,7 +447,7 @@ void main() {
         expect(preferences.getBool(boolKey), testBool);
       });
 
-      testWidgets('set and get int', (WidgetTester _) async {
+      test('set and get int', () async {
         final (SharedPreferencesWithCache preferences, _) =
             await getPreferences();
 
@@ -455,7 +455,7 @@ void main() {
         expect(preferences.getInt(intKey), testInt);
       });
 
-      testWidgets('set and get double', (WidgetTester _) async {
+      test('set and get double', () async {
         final (SharedPreferencesWithCache preferences, _) =
             await getPreferences();
 
@@ -463,7 +463,7 @@ void main() {
         expect(preferences.getDouble(doubleKey), testDouble);
       });
 
-      testWidgets('set and get StringList', (WidgetTester _) async {
+      test('set and get StringList', () async {
         final (SharedPreferencesWithCache preferences, _) =
             await getPreferences();
 
@@ -471,7 +471,7 @@ void main() {
         expect(preferences.getStringList(listKey), testList);
       });
 
-      testWidgets('reloading', (WidgetTester _) async {
+      test('reloading', () async {
         final (
           SharedPreferencesWithCache preferences,
           Map<String, Object?> cache,
@@ -487,7 +487,7 @@ void main() {
         expect(preferences.getString(stringKey), testString);
       });
 
-      testWidgets('containsKey', (WidgetTester _) async {
+      test('containsKey', () async {
         final (SharedPreferencesWithCache preferences, _) =
             await getPreferences();
         const String key = 'testKey';
@@ -498,7 +498,7 @@ void main() {
         expect(true, preferences.containsKey(key));
       });
 
-      testWidgets('getKeys', (WidgetTester _) async {
+      test('getKeys', () async {
         final (SharedPreferencesWithCache preferences, _) =
             await getPreferences();
         await Future.wait(<Future<void>>[
@@ -519,7 +519,7 @@ void main() {
         expect(keys, contains(listKey));
       });
 
-      testWidgets('clear', (WidgetTester _) async {
+      test('clear', () async {
         final (SharedPreferencesWithCache preferences, _) =
             await getPreferences();
         await Future.wait(<Future<void>>[
@@ -559,9 +559,9 @@ void main() {
         return (preferences, cache);
       }
 
-      testWidgets(
+      test(
         'throws ArgumentError if key is not included in filter',
-        (WidgetTester _) async {
+        () async {
           final (SharedPreferencesWithCache preferences, _) =
               await getPreferences();
           const String key = 'testKey';
@@ -573,7 +573,7 @@ void main() {
         },
       );
 
-      testWidgets('set and get String', (WidgetTester _) async {
+      test('set and get String', () async {
         final (SharedPreferencesWithCache preferences, _) =
             await getPreferences();
 
@@ -581,7 +581,7 @@ void main() {
         expect(preferences.getString(stringKey), testString);
       });
 
-      testWidgets('set and get bool', (WidgetTester _) async {
+      test('set and get bool', () async {
         final (SharedPreferencesWithCache preferences, _) =
             await getPreferences();
 
@@ -589,7 +589,7 @@ void main() {
         expect(preferences.getBool(boolKey), testBool);
       });
 
-      testWidgets('set and get int', (WidgetTester _) async {
+      test('set and get int', () async {
         final (SharedPreferencesWithCache preferences, _) =
             await getPreferences();
 
@@ -597,7 +597,7 @@ void main() {
         expect(preferences.getInt(intKey), testInt);
       });
 
-      testWidgets('set and get double', (WidgetTester _) async {
+      test('set and get double', () async {
         final (SharedPreferencesWithCache preferences, _) =
             await getPreferences();
 
@@ -605,7 +605,7 @@ void main() {
         expect(preferences.getDouble(doubleKey), testDouble);
       });
 
-      testWidgets('set and get StringList', (WidgetTester _) async {
+      test('set and get StringList', () async {
         final (SharedPreferencesWithCache preferences, _) =
             await getPreferences();
 
@@ -613,9 +613,7 @@ void main() {
         expect(preferences.getStringList(listKey), testList);
       });
 
-      testWidgets('get StringList handles List<Object?>', (
-        WidgetTester _,
-      ) async {
+      test('get StringList handles List<Object?>', () async {
         final (
           SharedPreferencesWithCache preferences,
           Map<String, Object?> cache,
@@ -625,7 +623,7 @@ void main() {
         expect(preferences.getStringList(listKey), listObject);
       });
 
-      testWidgets('reloading', (WidgetTester _) async {
+      test('reloading', () async {
         final (
           SharedPreferencesWithCache preferences,
           Map<String, Object?> cache,
@@ -641,7 +639,7 @@ void main() {
         expect(preferences.getString(stringKey), testString);
       });
 
-      testWidgets('containsKey', (WidgetTester _) async {
+      test('containsKey', () async {
         final (SharedPreferencesWithCache preferences, _) =
             await getPreferences();
 
@@ -651,7 +649,7 @@ void main() {
         expect(true, preferences.containsKey(stringKey));
       });
 
-      testWidgets('getKeys', (WidgetTester _) async {
+      test('getKeys', () async {
         final (SharedPreferencesWithCache preferences, _) =
             await getPreferences();
         await Future.wait(<Future<void>>[
@@ -672,7 +670,7 @@ void main() {
         expect(keys, contains(listKey));
       });
 
-      testWidgets('clear', (WidgetTester _) async {
+      test('clear', () async {
         final (SharedPreferencesWithCache preferences, _) =
             await getPreferences();
         await Future.wait(<Future<void>>[
@@ -768,9 +766,7 @@ void runTests(
     await SharedPreferencesAsync().clear();
   });
 
-  testWidgets('data is successfully transferred to new system', (
-    WidgetTester _,
-  ) async {
+  test('data is successfully transferred to new system', () async {
     final SharedPreferences preferences = await SharedPreferences.getInstance();
     await migrateLegacySharedPreferencesToSharedPreferencesAsyncIfNecessary(
       legacySharedPreferencesInstance: preferences,
@@ -787,7 +783,7 @@ void runTests(
     expect(await asyncPreferences.getStringList(listKey), testList);
   });
 
-  testWidgets('migrationCompleted key is set', (WidgetTester _) async {
+  test('migrationCompleted key is set', () async {
     final SharedPreferences preferences = await SharedPreferences.getInstance();
     await migrateLegacySharedPreferencesToSharedPreferencesAsyncIfNecessary(
       legacySharedPreferencesInstance: preferences,
@@ -800,9 +796,9 @@ void runTests(
     expect(await asyncPreferences.getBool(migrationCompletedKey), true);
   });
 
-  testWidgets(
+  test(
     're-running migration tool does not overwrite data',
-    (WidgetTester _) async {
+    () async {
       final SharedPreferences preferences =
           await SharedPreferences.getInstance();
       await migrateLegacySharedPreferencesToSharedPreferencesAsyncIfNecessary(

--- a/packages/tizen_app_control/CHANGELOG.md
+++ b/packages/tizen_app_control/CHANGELOG.md
@@ -4,6 +4,7 @@
 * Update code format.
 * Add YouTube app launch to the example.
 * Update integration tests.
+* Update integration tests.
 
 ## 0.2.3
 

--- a/packages/tizen_app_control/example/integration_test/tizen_app_control_test.dart
+++ b/packages/tizen_app_control/example/integration_test/tizen_app_control_test.dart
@@ -16,14 +16,14 @@ const Timeout kTimeout = Timeout(Duration(seconds: 10));
 void main() {
   IntegrationTestWidgetsFlutterBinding.ensureInitialized();
 
-  testWidgets('Can receive request from platform', (WidgetTester _) async {
+  test('Can receive request from platform', () async {
     // The very first message is a launch request from the platform.
     final ReceivedAppControl received = await AppControl.onAppControl.first;
     expect(received.appId, kAppId);
     expect(received.operation, 'http://tizen.org/appcontrol/operation/default');
   }, timeout: kTimeout);
 
-  testWidgets('Can find matching applications', (WidgetTester _) async {
+  test('Can find matching applications', () async {
     final AppControl request = AppControl(
       operation: 'http://tizen.org/appcontrol/operation/view',
       uri: 'file:///opt/usr/globalapps/$kAppId/shared/res/ic_launcher.png',
@@ -33,7 +33,7 @@ void main() {
     expect(matches.length, greaterThanOrEqualTo(0));
   }, timeout: kTimeout);
 
-  testWidgets('Can send and receive request', (WidgetTester _) async {
+  test('Can send and receive request', () async {
     // Send a request to this app (the test runner itself).
     final AppControl request = AppControl(
       appId: kAppId,
@@ -52,8 +52,7 @@ void main() {
     expect(received.shouldReply, isFalse);
   }, timeout: kTimeout);
 
-  testWidgets('Can send and receive request with uri and mime',
-      (WidgetTester _) async {
+  test('Can send and receive request with uri and mime', () async {
     final AppControl request = AppControl(
       appId: kAppId,
       operation: 'operation_3',
@@ -67,7 +66,7 @@ void main() {
     expect(received.mime, 'text/plain');
   }, timeout: kTimeout);
 
-  testWidgets('Omit invalid extra data', (WidgetTester _) async {
+  test('Omit invalid extra data', () async {
     final AppControl request = AppControl(
       appId: kAppId,
       extraData: <String, Object?>{
@@ -84,7 +83,7 @@ void main() {
     expect(received.extraData['STRING_LIST_DATA'], <String>['string', 'list']);
   }, timeout: kTimeout);
 
-  testWidgets('Can send and receive reply', (WidgetTester _) async {
+  test('Can send and receive reply', () async {
     // This time, the request is sent to the service app instead of the test
     // runner, because the platform doesn't allow sending a reply back when
     // caller = callee.
@@ -93,18 +92,15 @@ void main() {
       operation: 'operation_2',
     );
     await request.sendLaunchRequest(
-      replyCallback: (
-        AppControl request,
-        AppControl reply,
-        AppControlReplyResult result,
-      ) {
+      replyCallback:
+          (AppControl request, AppControl reply, AppControlReplyResult result) {
         expect(result, AppControlReplyResult.canceled);
         expect(reply.extraData['STRING_DATA'], 'string');
       },
     );
   }, timeout: kTimeout);
 
-  testWidgets('Cannot find target applications', (WidgetTester _) async {
+  test('Cannot find target applications', () async {
     final AppControl request1 = AppControl(appId: 'unknown_app');
     expect(
       request1.sendLaunchRequest,

--- a/packages/tizen_audio_manager/CHANGELOG.md
+++ b/packages/tizen_audio_manager/CHANGELOG.md
@@ -6,6 +6,7 @@
 * Add a 3-second delay in integration_test to support the media volume reset
   feature of the Tizen Volume app for hearing protection.
 * Add 2 integration test cases.
+* Update integration tests.
 
 ## 0.1.1
 

--- a/packages/tizen_audio_manager/example/integration_test/audio_manager_test.dart
+++ b/packages/tizen_audio_manager/example/integration_test/audio_manager_test.dart
@@ -11,63 +11,63 @@ import 'package:tizen_audio_manager/tizen_audio_manager.dart';
 void main() {
   IntegrationTestWidgetsFlutterBinding.ensureInitialized();
 
-  testWidgets('test alarm max level', (WidgetTester tester) async {
+  test('test alarm max level', () async {
     final int result = await AudioManager.volumeController.getMaxLevel(
       AudioVolumeType.alarm,
     );
     expect(result, isNonNegative);
   });
 
-  testWidgets('test call max level', (WidgetTester tester) async {
+  test('test call max level', () async {
     final int result = await AudioManager.volumeController.getMaxLevel(
       AudioVolumeType.call,
     );
     expect(result, isNonNegative);
   });
 
-  testWidgets('test media max level', (WidgetTester tester) async {
+  test('test media max level', () async {
     final int result = await AudioManager.volumeController.getMaxLevel(
       AudioVolumeType.media,
     );
     expect(result, isNonNegative);
   });
 
-  testWidgets('test notification max level', (WidgetTester tester) async {
+  test('test notification max level', () async {
     final int result = await AudioManager.volumeController.getMaxLevel(
       AudioVolumeType.notification,
     );
     expect(result, isNonNegative);
   });
 
-  testWidgets('test ringtone max level', (WidgetTester tester) async {
+  test('test ringtone max level', () async {
     final int result = await AudioManager.volumeController.getMaxLevel(
       AudioVolumeType.ringtone,
     );
     expect(result, isNonNegative);
   });
 
-  testWidgets('test system max level', (WidgetTester tester) async {
+  test('test system max level', () async {
     final int result = await AudioManager.volumeController.getMaxLevel(
       AudioVolumeType.system,
     );
     expect(result, isNonNegative);
   });
 
-  testWidgets('test voice max level', (WidgetTester tester) async {
+  test('test voice max level', () async {
     final int result = await AudioManager.volumeController.getMaxLevel(
       AudioVolumeType.voice,
     );
     expect(result, isNonNegative);
   });
 
-  testWidgets('test voip max level', (WidgetTester tester) async {
+  test('test voip max level', () async {
     final int result = await AudioManager.volumeController.getMaxLevel(
       AudioVolumeType.voip,
     );
     expect(result, isNonNegative);
   });
 
-  testWidgets('test alarm set level', (WidgetTester tester) async {
+  test('test alarm set level', () async {
     final int max = await AudioManager.volumeController.getMaxLevel(
       AudioVolumeType.alarm,
     );
@@ -82,7 +82,7 @@ void main() {
     expect(level, equals(0));
   });
 
-  testWidgets('test call set level', (WidgetTester tester) async {
+  test('test call set level', () async {
     final int max = await AudioManager.volumeController.getMaxLevel(
       AudioVolumeType.call,
     );
@@ -97,7 +97,7 @@ void main() {
     expect(level, equals(0));
   });
 
-  testWidgets('test media set level', (WidgetTester tester) async {
+  test('test media set level', () async {
     final int max = await AudioManager.volumeController.getMaxLevel(
       AudioVolumeType.media,
     );
@@ -120,7 +120,7 @@ void main() {
     expect(level, equals(0));
   });
 
-  testWidgets('test notification set level', (WidgetTester tester) async {
+  test('test notification set level', () async {
     final int max = await AudioManager.volumeController.getMaxLevel(
       AudioVolumeType.notification,
     );
@@ -143,7 +143,7 @@ void main() {
     expect(level, equals(0));
   });
 
-  testWidgets('test ringtone set level', (WidgetTester tester) async {
+  test('test ringtone set level', () async {
     final int max = await AudioManager.volumeController.getMaxLevel(
       AudioVolumeType.ringtone,
     );
@@ -160,7 +160,7 @@ void main() {
     expect(level, equals(0));
   });
 
-  testWidgets('test system set level', (WidgetTester tester) async {
+  test('test system set level', () async {
     final int max = await AudioManager.volumeController.getMaxLevel(
       AudioVolumeType.system,
     );
@@ -177,7 +177,7 @@ void main() {
     expect(level, equals(0));
   });
 
-  testWidgets('test voice set level', (WidgetTester tester) async {
+  test('test voice set level', () async {
     final int max = await AudioManager.volumeController.getMaxLevel(
       AudioVolumeType.voice,
     );
@@ -192,7 +192,7 @@ void main() {
     expect(level, equals(0));
   });
 
-  testWidgets('test voip set level', (WidgetTester tester) async {
+  test('test voip set level', () async {
     final int max = await AudioManager.volumeController.getMaxLevel(
       AudioVolumeType.voip,
     );
@@ -207,15 +207,13 @@ void main() {
     expect(level, equals(0));
   });
 
-  testWidgets('currentPlaybackType returns a valid AudioVolumeType',
-      (WidgetTester tester) async {
+  test('currentPlaybackType returns a valid AudioVolumeType', () async {
     final AudioVolumeType type =
         await AudioManager.volumeController.currentPlaybackType;
     expect(AudioVolumeType.values, contains(type));
   });
 
-  testWidgets('onChanged emits VolumeChangedEvent when volume is changed',
-      (WidgetTester tester) async {
+  test('onChanged emits VolumeChangedEvent when volume is changed', () async {
     final int originalLevel =
         await AudioManager.volumeController.getLevel(AudioVolumeType.system);
     final int maxLevel =

--- a/packages/tizen_bundle/CHANGELOG.md
+++ b/packages/tizen_bundle/CHANGELOG.md
@@ -1,3 +1,7 @@
+## NEXT
+
+* Update integration tests.
+
 ## 0.1.3
 
 * Update code format.

--- a/packages/tizen_bundle/example/integration_test/tizen_bundle_test.dart
+++ b/packages/tizen_bundle/example/integration_test/tizen_bundle_test.dart
@@ -13,30 +13,22 @@ void main() {
   // Bundle() — default constructor
   // ---------------------------------------------------------------------------
   group('Bundle() default constructor', () {
-    testWidgets('creates an empty bundle with length 0', (
-      WidgetTester _,
-    ) async {
+    test('creates an empty bundle with length 0', () async {
       final Bundle bundle = Bundle();
       expect(bundle.length, 0);
     });
 
-    testWidgets('isEmpty returns true for a newly created bundle', (
-      WidgetTester _,
-    ) async {
+    test('isEmpty returns true for a newly created bundle', () async {
       final Bundle bundle = Bundle();
       expect(bundle.isEmpty, true);
     });
 
-    testWidgets('isNotEmpty returns false for a newly created bundle', (
-      WidgetTester _,
-    ) async {
+    test('isNotEmpty returns false for a newly created bundle', () async {
       final Bundle bundle = Bundle();
       expect(bundle.isNotEmpty, false);
     });
 
-    testWidgets('keys returns empty iterable for an empty bundle', (
-      WidgetTester _,
-    ) async {
+    test('keys returns empty iterable for an empty bundle', () async {
       final Bundle bundle = Bundle();
       expect(bundle.keys, isEmpty);
     });
@@ -46,18 +38,14 @@ void main() {
   // Bundle.fromMap — factory constructor
   // ---------------------------------------------------------------------------
   group('Bundle.fromMap', () {
-    testWidgets('creates an empty bundle from an empty map', (
-      WidgetTester _,
-    ) async {
+    test('creates an empty bundle from an empty map', () async {
       final Bundle bundle = Bundle.fromMap(<String, Object>{});
       expect(bundle.length, 0);
       expect(bundle.isEmpty, true);
     });
 
-    testWidgets(
-        'creates a bundle with String, List<String>, and Uint8List entries', (
-      WidgetTester _,
-    ) async {
+    test('creates a bundle with String, List<String>, and Uint8List entries',
+        () async {
       final Bundle bundle = Bundle.fromMap(<String, Object>{
         'stringKey': 'stringValue',
         'stringsKey': <String>['value1', 'value2'],
@@ -74,9 +62,9 @@ void main() {
   // Bundle.fromBundle — copy constructor independence
   // ---------------------------------------------------------------------------
   group('Bundle.fromBundle copy independence', () {
-    testWidgets(
+    test(
       'mutating the original after copy does not affect the copy',
-      (WidgetTester _) async {
+      () async {
         final Bundle original = Bundle();
         original['key'] = 'originalValue';
 
@@ -88,11 +76,9 @@ void main() {
       },
     );
 
-    testWidgets(
+    test(
         'copy has independent entries — adding to copy does not affect original',
-        (
-      WidgetTester _,
-    ) async {
+        () async {
       final Bundle original = Bundle();
       original['key'] = 'value';
 
@@ -107,9 +93,7 @@ void main() {
   // Bundle.decode — constructor from encoded string
   // ---------------------------------------------------------------------------
   group('Bundle.decode', () {
-    testWidgets('round-trips a List<String> value through encode/decode', (
-      WidgetTester _,
-    ) async {
+    test('round-trips a List<String> value through encode/decode', () async {
       final Bundle bundle = Bundle();
       bundle['stringsKey'] = <String>['alpha', 'beta', 'gamma'];
       final String encoded = bundle.encode();
@@ -117,9 +101,7 @@ void main() {
       expect(decoded['stringsKey'], <String>['alpha', 'beta', 'gamma']);
     });
 
-    testWidgets('round-trips a Uint8List value through encode/decode', (
-      WidgetTester _,
-    ) async {
+    test('round-trips a Uint8List value through encode/decode', () async {
       final Bundle bundle = Bundle();
       bundle['bytesKey'] = Uint8List.fromList(<int>[0x00, 0x7f, 0xff]);
       final String encoded = bundle.encode();
@@ -127,9 +109,7 @@ void main() {
       expect(decoded['bytesKey'], Uint8List.fromList(<int>[0x00, 0x7f, 0xff]));
     });
 
-    testWidgets('round-trips multiple keys of mixed types', (
-      WidgetTester _,
-    ) async {
+    test('round-trips multiple keys of mixed types', () async {
       final Bundle bundle = Bundle();
       bundle['s'] = 'hello';
       bundle['ss'] = <String>['x', 'y'];
@@ -147,31 +127,27 @@ void main() {
   // operator[] — get
   // ---------------------------------------------------------------------------
   group('operator[] (get)', () {
-    testWidgets('returns null for a missing key', (WidgetTester _) async {
+    test('returns null for a missing key', () async {
       final Bundle bundle = Bundle();
       expect(bundle['nonExistentKey'], isNull);
     });
 
-    testWidgets('returns null when key is null', (WidgetTester _) async {
+    test('returns null when key is null', () async {
       final Bundle bundle = Bundle();
       bundle['someKey'] = 'someValue';
       // The implementation accepts Object? key and returns null for null.
       expect(bundle[null], isNull);
     });
 
-    testWidgets('returns the correct value after key is overwritten', (
-      WidgetTester _,
-    ) async {
+    test('returns the correct value after key is overwritten', () async {
       final Bundle bundle = Bundle();
       bundle['key'] = 'first';
       bundle['key'] = 'second';
       expect(bundle['key'], 'second');
     });
 
-    testWidgets(
-        'same read-only call twice returns identical results (idempotency)', (
-      WidgetTester _,
-    ) async {
+    test('same read-only call twice returns identical results (idempotency)',
+        () async {
       final Bundle bundle = Bundle();
       bundle['key'] = 'value';
       expect(bundle['key'], bundle['key']);
@@ -182,9 +158,7 @@ void main() {
   // operator[]= — set (error path)
   // ---------------------------------------------------------------------------
   group('operator[]= (set)', () {
-    testWidgets('throws ArgumentError for an unsupported value type', (
-      WidgetTester _,
-    ) async {
+    test('throws ArgumentError for an unsupported value type', () async {
       final Bundle bundle = Bundle();
       expect(
         () => bundle['key'] = 42,
@@ -192,28 +166,26 @@ void main() {
       );
     });
 
-    testWidgets('stores an empty string value', (WidgetTester _) async {
+    test('stores an empty string value', () async {
       final Bundle bundle = Bundle();
       bundle['emptyString'] = '';
       expect(bundle['emptyString'], '');
     });
 
-    testWidgets('stores a single-element List<String>', (WidgetTester _) async {
+    test('stores a single-element List<String>', () async {
       final Bundle bundle = Bundle();
       bundle['single'] = <String>['only'];
       expect(bundle['single'], <String>['only']);
     });
 
-    testWidgets('stores an empty Uint8List', (WidgetTester _) async {
+    test('stores an empty Uint8List', () async {
       final Bundle bundle = Bundle();
       bundle['emptyBytes'] = Uint8List(0);
       final Uint8List result = bundle['emptyBytes']! as Uint8List;
       expect(result.length, 0);
     });
 
-    testWidgets('preserves full byte range 0x00–0xff in Uint8List', (
-      WidgetTester _,
-    ) async {
+    test('preserves full byte range 0x00–0xff in Uint8List', () async {
       final Bundle bundle = Bundle();
       final Uint8List allBytes =
           Uint8List.fromList(List<int>.generate(256, (int i) => i));
@@ -227,25 +199,19 @@ void main() {
   // remove()
   // ---------------------------------------------------------------------------
   group('remove()', () {
-    testWidgets('remove(null) is a no-op and does not throw', (
-      WidgetTester _,
-    ) async {
+    test('remove(null) is a no-op and does not throw', () async {
       final Bundle bundle = Bundle();
       bundle['key'] = 'value';
       expect(() => bundle.remove(null), returnsNormally);
       expect(bundle.length, 1);
     });
 
-    testWidgets('removing a non-existent key is a no-op', (
-      WidgetTester _,
-    ) async {
+    test('removing a non-existent key is a no-op', () async {
       final Bundle bundle = Bundle();
       expect(() => bundle.remove('doesNotExist'), returnsNormally);
     });
 
-    testWidgets('add then remove then verify gone (state transition)', (
-      WidgetTester _,
-    ) async {
+    test('add then remove then verify gone (state transition)', () async {
       final Bundle bundle = Bundle();
       bundle['key'] = 'value';
       expect(bundle.containsKey('key'), true);
@@ -259,18 +225,14 @@ void main() {
   // clear()
   // ---------------------------------------------------------------------------
   group('clear()', () {
-    testWidgets('clear() on an already-empty bundle is idempotent', (
-      WidgetTester _,
-    ) async {
+    test('clear() on an already-empty bundle is idempotent', () async {
       final Bundle bundle = Bundle();
       bundle.clear();
       expect(bundle.length, 0);
       expect(bundle.isEmpty, true);
     });
 
-    testWidgets('clear() removes all entries including mixed types', (
-      WidgetTester _,
-    ) async {
+    test('clear() removes all entries including mixed types', () async {
       final Bundle bundle = Bundle();
       bundle['s'] = 'hello';
       bundle['ss'] = <String>['a', 'b'];
@@ -285,9 +247,7 @@ void main() {
   // length / isEmpty / isNotEmpty — state after modifications
   // ---------------------------------------------------------------------------
   group('length, isEmpty, isNotEmpty', () {
-    testWidgets('length reflects current entry count correctly', (
-      WidgetTester _,
-    ) async {
+    test('length reflects current entry count correctly', () async {
       final Bundle bundle = Bundle();
       expect(bundle.length, 0);
       bundle['k1'] = 'v1';
@@ -298,18 +258,14 @@ void main() {
       expect(bundle.length, 1);
     });
 
-    testWidgets('isNotEmpty becomes true after adding an entry', (
-      WidgetTester _,
-    ) async {
+    test('isNotEmpty becomes true after adding an entry', () async {
       final Bundle bundle = Bundle();
       expect(bundle.isNotEmpty, false);
       bundle['key'] = 'value';
       expect(bundle.isNotEmpty, true);
     });
 
-    testWidgets('isEmpty becomes true after removing the last entry', (
-      WidgetTester _,
-    ) async {
+    test('isEmpty becomes true after removing the last entry', () async {
       final Bundle bundle = Bundle();
       bundle['key'] = 'value';
       expect(bundle.isEmpty, false);
@@ -322,24 +278,18 @@ void main() {
   // Inherited MapMixin members
   // ---------------------------------------------------------------------------
   group('inherited MapMixin members', () {
-    testWidgets('containsKey returns true for existing key', (
-      WidgetTester _,
-    ) async {
+    test('containsKey returns true for existing key', () async {
       final Bundle bundle = Bundle();
       bundle['key'] = 'value';
       expect(bundle.containsKey('key'), true);
     });
 
-    testWidgets('containsKey returns false for missing key', (
-      WidgetTester _,
-    ) async {
+    test('containsKey returns false for missing key', () async {
       final Bundle bundle = Bundle();
       expect(bundle.containsKey('missing'), false);
     });
 
-    testWidgets('keys of different bundles are independent', (
-      WidgetTester _,
-    ) async {
+    test('keys of different bundles are independent', () async {
       final Bundle bundle1 = Bundle();
       bundle1['a'] = 'v1';
       final Iterable<String> keys1 = bundle1.keys;
@@ -351,9 +301,7 @@ void main() {
       expect(keys1, equals(<String>['a']));
     });
 
-    testWidgets('keys and values return all stored entries', (
-      WidgetTester _,
-    ) async {
+    test('keys and values return all stored entries', () async {
       final Bundle bundle = Bundle.fromMap(<String, String>{
         'key1': 'value1',
         'key2': 'value2',
@@ -366,25 +314,19 @@ void main() {
       );
     });
 
-    testWidgets('containsValue returns true for existing string value', (
-      WidgetTester _,
-    ) async {
+    test('containsValue returns true for existing string value', () async {
       final Bundle bundle = Bundle();
       bundle['key'] = 'needle';
       expect(bundle.containsValue('needle'), true);
     });
 
-    testWidgets('containsValue returns false for absent value', (
-      WidgetTester _,
-    ) async {
+    test('containsValue returns false for absent value', () async {
       final Bundle bundle = Bundle();
       bundle['key'] = 'value';
       expect(bundle.containsValue('absent'), false);
     });
 
-    testWidgets('entries exposes key-value pairs correctly', (
-      WidgetTester _,
-    ) async {
+    test('entries exposes key-value pairs correctly', () async {
       final Bundle bundle = Bundle();
       bundle['k'] = 'v';
       final MapEntry<String, Object> entry = bundle.entries.single;
@@ -392,7 +334,7 @@ void main() {
       expect(entry.value, 'v');
     });
 
-    testWidgets('forEach iterates over all entries', (WidgetTester _) async {
+    test('forEach iterates over all entries', () async {
       final Bundle bundle = Bundle();
       bundle['a'] = '1';
       bundle['b'] = '2';
@@ -405,7 +347,7 @@ void main() {
       expect(collected['b'], '2');
     });
 
-    testWidgets('addAll adds all entries from a map', (WidgetTester _) async {
+    test('addAll adds all entries from a map', () async {
       final Bundle bundle = Bundle();
       bundle.addAll(<String, Object>{
         'x': 'valueX',
@@ -416,9 +358,7 @@ void main() {
       expect(bundle['y'], 'valueY');
     });
 
-    testWidgets('putIfAbsent inserts only when key is absent', (
-      WidgetTester _,
-    ) async {
+    test('putIfAbsent inserts only when key is absent', () async {
       final Bundle bundle = Bundle();
       bundle['existing'] = 'original';
 

--- a/packages/tizen_log/CHANGELOG.md
+++ b/packages/tizen_log/CHANGELOG.md
@@ -4,6 +4,7 @@
 * Update minimum Flutter and Dart version to 3.13 and 3.1.
 * Fix new lint warnings.
 * Update code format.
+* Update integration tests.
 
 ## 0.1.2
 

--- a/packages/tizen_log/example/integration_test/tizen_log_test.dart
+++ b/packages/tizen_log/example/integration_test/tizen_log_test.dart
@@ -12,37 +12,35 @@ void main() {
   const String tag = 'TizenLogTest';
 
   group('Log', () {
-    testWidgets('verbose does not throw', (WidgetTester tester) async {
+    test('verbose does not throw', () async {
       expect(() => Log.verbose(tag, 'verbose message'), returnsNormally);
     });
 
-    testWidgets('debug does not throw', (WidgetTester tester) async {
+    test('debug does not throw', () async {
       expect(() => Log.debug(tag, 'debug message'), returnsNormally);
     });
 
-    testWidgets('info does not throw', (WidgetTester tester) async {
+    test('info does not throw', () async {
       expect(() => Log.info(tag, 'info message'), returnsNormally);
     });
 
-    testWidgets('warn does not throw', (WidgetTester tester) async {
+    test('warn does not throw', () async {
       expect(() => Log.warn(tag, 'warn message'), returnsNormally);
     });
 
-    testWidgets('error does not throw', (WidgetTester tester) async {
+    test('error does not throw', () async {
       expect(() => Log.error(tag, 'error message'), returnsNormally);
     });
 
-    testWidgets('fatal does not throw', (WidgetTester tester) async {
+    test('fatal does not throw', () async {
       expect(() => Log.fatal(tag, 'fatal message'), returnsNormally);
     });
 
-    testWidgets('isDebugEnabled is false by default',
-        (WidgetTester tester) async {
+    test('isDebugEnabled is false by default', () async {
       expect(Log.isDebugEnabled, isFalse);
     });
 
-    testWidgets('log with optional file, func, and line does not throw',
-        (WidgetTester tester) async {
+    test('log with optional file, func, and line does not throw', () async {
       expect(
         () => Log.info(
           tag,

--- a/packages/tizen_notification/CHANGELOG.md
+++ b/packages/tizen_notification/CHANGELOG.md
@@ -1,3 +1,7 @@
+## NEXT
+
+* Update integration tests.
+
 ## 0.2.1
 
 * Add regression integration tests.

--- a/packages/tizen_notification/example/integration_test/tizen_notification_test.dart
+++ b/packages/tizen_notification/example/integration_test/tizen_notification_test.dart
@@ -20,42 +20,43 @@ void main() {
   });
 
   group('TizenNotificationPlugin', () {
-    testWidgets('show notification does not throw',
-        (WidgetTester tester) async {
+    test('show notification does not throw', () async {
       await plugin.show(1, title: 'Test Title', body: 'Test Body');
     });
 
-    testWidgets('show notification with default title and body does not throw',
-        (WidgetTester tester) async {
-      await plugin.show(2);
-    });
+    test(
+      'show notification with default title and body does not throw',
+      () async {
+        await plugin.show(2);
+      },
+    );
 
-    testWidgets('cancel notification does not throw',
-        (WidgetTester tester) async {
+    test('cancel notification does not throw', () async {
       await plugin.show(3, title: 'To Cancel');
       await plugin.cancel(3);
     });
 
-    testWidgets('cancelAll does not throw', (WidgetTester tester) async {
+    test('cancelAll does not throw', () async {
       await plugin.show(4, title: 'Notification 1');
       await plugin.show(5, title: 'Notification 2');
       await plugin.cancelAll();
     });
 
-    testWidgets(
-        'show notification with TizenNotificationDetails does not throw',
-        (WidgetTester tester) async {
-      final TizenNotificationDetails details = TizenNotificationDetails(
-        properties: NotificationProperty.disableAutoDelete,
-        style: NotificationStyle.tray,
-      );
-      await plugin.show(
-        6,
-        title: 'Detailed',
-        body: 'With details',
-        notificationDetails: details,
-      );
-      await plugin.cancel(6);
-    });
+    test(
+      'show notification with TizenNotificationDetails does not throw',
+      () async {
+        final TizenNotificationDetails details = TizenNotificationDetails(
+          properties: NotificationProperty.disableAutoDelete,
+          style: NotificationStyle.tray,
+        );
+        await plugin.show(
+          6,
+          title: 'Detailed',
+          body: 'With details',
+          notificationDetails: details,
+        );
+        await plugin.cancel(6);
+      },
+    );
   });
 }

--- a/packages/tizen_package_manager/CHANGELOG.md
+++ b/packages/tizen_package_manager/CHANGELOG.md
@@ -1,3 +1,7 @@
+## NEXT
+
+* Update integration tests.
+
 ## 0.4.3
 
 * Return a null icon path (instead of an empty string) when a package has no

--- a/packages/tizen_package_manager/example/integration_test/tizen_package_manager_test.dart
+++ b/packages/tizen_package_manager/example/integration_test/tizen_package_manager_test.dart
@@ -14,7 +14,7 @@ import 'package:tizen_package_manager_example/main.dart';
 void main() {
   IntegrationTestWidgetsFlutterBinding.ensureInitialized();
 
-  testWidgets('Can get current package info', (WidgetTester tester) async {
+  test('Can get current package info', () async {
     final PackageInfo info = await PackageManager.getPackageInfo(
       currentPackageId,
     );
@@ -27,24 +27,20 @@ void main() {
     expect(info.isRemovable, true);
   });
 
-  testWidgets('Can get current package size info', (WidgetTester tester) async {
+  test('Can get current package size info', () async {
     final PackageSizeInfo info = await PackageManager.getPackageSizeInfo(
       currentPackageId,
     );
     expect(info.appSize, greaterThan(0)); // package size -> 160935936
   });
 
-  testWidgets('Can get all installed packages info', (
-    WidgetTester tester,
-  ) async {
+  test('Can get all installed packages info', () async {
     final List<PackageInfo> infos = await PackageManager.getPackagesInfo();
     expect(infos.isNotEmpty, true);
   });
 
   group('PackageInfo fields', () {
-    testWidgets('iconPath is null or a non-empty string', (
-      WidgetTester tester,
-    ) async {
+    test('iconPath is null or a non-empty string', () async {
       final PackageInfo info =
           await PackageManager.getPackageInfo(currentPackageId);
       expect(info.iconPath, anyOf(isNull, isNotEmpty));
@@ -52,9 +48,7 @@ void main() {
   });
 
   group('PackageSizeInfo fields', () {
-    testWidgets('all size fields are non-negative', (
-      WidgetTester tester,
-    ) async {
+    test('all size fields are non-negative', () async {
       final PackageSizeInfo info =
           await PackageManager.getPackageSizeInfo(currentPackageId);
       expect(info.dataSize, greaterThanOrEqualTo(0));
@@ -67,9 +61,7 @@ void main() {
   });
 
   group('getPackagesInfo list items', () {
-    testWidgets('each PackageInfo item has valid field values', (
-      WidgetTester tester,
-    ) async {
+    test('each PackageInfo item has valid field values', () async {
       final List<PackageInfo> infos = await PackageManager.getPackagesInfo();
       expect(infos, isNotEmpty);
       for (final PackageInfo info in infos) {
@@ -81,9 +73,7 @@ void main() {
       }
     });
 
-    testWidgets('getPackagesInfo contains current package', (
-      WidgetTester tester,
-    ) async {
+    test('getPackagesInfo contains current package', () async {
       final List<PackageInfo> infos = await PackageManager.getPackagesInfo();
       final Iterable<String> ids = infos.map((PackageInfo i) => i.packageId);
       expect(ids, contains(currentPackageId));
@@ -91,18 +81,14 @@ void main() {
   });
 
   group('getPackageInfo error paths', () {
-    testWidgets('throws ArgumentError for empty packageId', (
-      WidgetTester tester,
-    ) async {
+    test('throws ArgumentError for empty packageId', () async {
       await expectLater(
         PackageManager.getPackageInfo(''),
         throwsArgumentError,
       );
     });
 
-    testWidgets('throws PlatformException for invalid packageId', (
-      WidgetTester tester,
-    ) async {
+    test('throws PlatformException for invalid packageId', () async {
       await expectLater(
         PackageManager.getPackageInfo('invalid.package.id.that.does.not.exist'),
         throwsA(isA<PlatformException>()),
@@ -111,9 +97,7 @@ void main() {
   });
 
   group('getPackageSizeInfo error paths', () {
-    testWidgets('throws ArgumentError for empty packageId', (
-      WidgetTester tester,
-    ) async {
+    test('throws ArgumentError for empty packageId', () async {
       await expectLater(
         PackageManager.getPackageSizeInfo(''),
         throwsArgumentError,
@@ -127,17 +111,13 @@ void main() {
   });
 
   group('install error paths', () {
-    testWidgets('throws ArgumentError for empty packagePath', (
-      WidgetTester tester,
-    ) async {
+    test('throws ArgumentError for empty packagePath', () async {
       await expectLater(PackageManager.install(''), throwsArgumentError);
     });
   });
 
   group('uninstall error paths', () {
-    testWidgets('throws ArgumentError for empty packageId', (
-      WidgetTester tester,
-    ) async {
+    test('throws ArgumentError for empty packageId', () async {
       await expectLater(PackageManager.uninstall(''), throwsArgumentError);
     });
   });
@@ -146,25 +126,19 @@ void main() {
   // throw. Actually exercising an event requires installing/uninstalling/
   // updating a real package on the device, which is out of scope here.
   group('event streams', () {
-    testWidgets('can subscribe to onInstallProgressChanged and cancel', (
-      WidgetTester tester,
-    ) async {
+    test('can subscribe to onInstallProgressChanged and cancel', () async {
       final StreamSubscription<PackageEvent> subscription =
           PackageManager.onInstallProgressChanged.listen(null);
       await subscription.cancel();
     });
 
-    testWidgets('can subscribe to onUninstallProgressChanged and cancel', (
-      WidgetTester tester,
-    ) async {
+    test('can subscribe to onUninstallProgressChanged and cancel', () async {
       final StreamSubscription<PackageEvent> subscription =
           PackageManager.onUninstallProgressChanged.listen(null);
       await subscription.cancel();
     });
 
-    testWidgets('can subscribe to onUpdateProgressChanged and cancel', (
-      WidgetTester tester,
-    ) async {
+    test('can subscribe to onUpdateProgressChanged and cancel', () async {
       final StreamSubscription<PackageEvent> subscription =
           PackageManager.onUpdateProgressChanged.listen(null);
       await subscription.cancel();

--- a/packages/tizen_rpc_port/CHANGELOG.md
+++ b/packages/tizen_rpc_port/CHANGELOG.md
@@ -1,3 +1,7 @@
+## NEXT
+
+* Update integration tests.
+
 ## 0.1.7
 
 * Guard Tizen 10.0+ specific Parcel APIs (`reader`, `dataSize`, and `reserve`) to throw `UnsupportedError` on unsupported versions of Tizen instead of crashing.

--- a/packages/tizen_rpc_port/example/client/integration_test/tizen_rpc_port_test.dart
+++ b/packages/tizen_rpc_port/example/client/integration_test/tizen_rpc_port_test.dart
@@ -43,7 +43,7 @@ void main() {
   // Existing tests — preserved unchanged
   // ---------------------------------------------------------------------------
 
-  testWidgets('Parcel test', (WidgetTester tester) async {
+  test('Parcel test', () async {
     final Parcel parcel = Parcel();
     parcel.writeBool(false);
     parcel.writeInt32(123);
@@ -64,25 +64,25 @@ void main() {
 
   group('Parcel', () {
     group('writeInt16 / readInt16', () {
-      testWidgets('round-trips positive value', (WidgetTester _) async {
+      test('round-trips positive value', () async {
         final Parcel parcel = Parcel();
         parcel.writeInt16(32767);
         expect(parcel.readInt16(), 32767);
       });
 
-      testWidgets('round-trips negative value', (WidgetTester _) async {
+      test('round-trips negative value', () async {
         final Parcel parcel = Parcel();
         parcel.writeInt16(-1);
         expect(parcel.readInt16(), -1);
       });
 
-      testWidgets('round-trips minimum value', (WidgetTester _) async {
+      test('round-trips minimum value', () async {
         final Parcel parcel = Parcel();
         parcel.writeInt16(-32768);
         expect(parcel.readInt16(), -32768);
       });
 
-      testWidgets('masks value to 16 bits', (WidgetTester _) async {
+      test('masks value to 16 bits', () async {
         final Parcel parcel = Parcel();
         // 0x10042 & 0xffff == 0x0042 == 66
         parcel.writeInt16(0x10042);
@@ -91,21 +91,21 @@ void main() {
     });
 
     group('writeInt64 / readInt64', () {
-      testWidgets('round-trips large positive value', (WidgetTester _) async {
+      test('round-trips large positive value', () async {
         final Parcel parcel = Parcel();
         const int value = 9007199254740992; // 2^53
         parcel.writeInt64(value);
         expect(parcel.readInt64(), value);
       });
 
-      testWidgets('round-trips maximum value', (WidgetTester _) async {
+      test('round-trips maximum value', () async {
         final Parcel parcel = Parcel();
         const int value = 9223372036854775807; // int64 max
         parcel.writeInt64(value);
         expect(parcel.readInt64(), value);
       });
 
-      testWidgets('round-trips minimum value', (WidgetTester _) async {
+      test('round-trips minimum value', () async {
         final Parcel parcel = Parcel();
         const int value = -9223372036854775808; // int64 min
         parcel.writeInt64(value);
@@ -114,28 +114,26 @@ void main() {
     });
 
     group('writeByte / readByte', () {
-      testWidgets('round-trips a value', (WidgetTester _) async {
+      test('round-trips a value', () async {
         final Parcel parcel = Parcel();
         parcel.writeByte(0xab);
         expect(parcel.readByte(), 0xab);
       });
 
-      testWidgets('round-trips maximum unsigned value', (WidgetTester _) async {
+      test('round-trips maximum unsigned value', () async {
         final Parcel parcel = Parcel();
         parcel.writeByte(255);
         expect(parcel.readByte(), 255);
       });
 
-      testWidgets('reads a negative input back as an unsigned byte', (
-        WidgetTester _,
-      ) async {
+      test('reads a negative input back as an unsigned byte', () async {
         final Parcel parcel = Parcel();
         // -1 is written as 0xff and must read back as the unsigned byte 255.
         parcel.writeByte(-1);
         expect(parcel.readByte(), 255);
       });
 
-      testWidgets('masks value to 8 bits', (WidgetTester _) async {
+      test('masks value to 8 bits', () async {
         final Parcel parcel = Parcel();
         // 0x142 & 0xff == 0x42 == 66
         parcel.writeByte(0x142);
@@ -144,7 +142,7 @@ void main() {
     });
 
     group('writeArrayCount / readArrayCount', () {
-      testWidgets('round-trips a count', (WidgetTester _) async {
+      test('round-trips a count', () async {
         final Parcel parcel = Parcel();
         parcel.writeArrayCount(42);
         expect(parcel.readArrayCount(), 42);
@@ -152,7 +150,7 @@ void main() {
     });
 
     group('write / read (burst byte array)', () {
-      testWidgets('round-trips byte array', (WidgetTester _) async {
+      test('round-trips byte array', () async {
         final Parcel parcel = Parcel();
         final Uint8List bytes = Uint8List.fromList(<int>[
           0x00,
@@ -168,9 +166,7 @@ void main() {
     });
 
     group('Parcel.fromRaw', () {
-      testWidgets('reconstructed parcel reads back original values', (
-        WidgetTester _,
-      ) async {
+      test('reconstructed parcel reads back original values', () async {
         final Parcel original = Parcel();
         original.writeInt32(99);
         original.writeString('raw');
@@ -186,9 +182,7 @@ void main() {
     });
 
     group('writeBundle / readBundle', () {
-      testWidgets('round-trips a Bundle with string entries', (
-        WidgetTester _,
-      ) async {
+      test('round-trips a Bundle with string entries', () async {
         final Bundle bundle = Bundle();
         bundle['key1'] = 'value1';
         bundle['key2'] = 'value2';
@@ -201,7 +195,7 @@ void main() {
         expect(restored['key2'], 'value2');
       });
 
-      testWidgets('round-trips an empty Bundle', (WidgetTester _) async {
+      test('round-trips an empty Bundle', () async {
         final Parcel parcel = Parcel();
         parcel.writeBundle(Bundle());
         final Bundle restored = parcel.readBundle();
@@ -210,32 +204,28 @@ void main() {
     });
 
     group('header', () {
-      testWidgets('tag can be set and retrieved', (WidgetTester _) async {
+      test('tag can be set and retrieved', () async {
         final Parcel parcel = Parcel();
         final ParcelHeader header = parcel.header;
         header.tag = '1.2.3';
         expect(parcel.header.tag, '1.2.3');
       });
 
-      testWidgets('sequenceNumber can be set and retrieved', (
-        WidgetTester _,
-      ) async {
+      test('sequenceNumber can be set and retrieved', () async {
         final Parcel parcel = Parcel();
         final ParcelHeader header = parcel.header;
         header.sequenceNumber = 7;
         expect(parcel.header.sequenceNumber, 7);
       });
 
-      testWidgets('tag defaults to empty string', (WidgetTester _) async {
+      test('tag defaults to empty string', () async {
         final Parcel parcel = Parcel();
         expect(parcel.header.tag, isEmpty);
       });
     });
 
     group('Parcelable', () {
-      testWidgets('custom Parcelable serializes and deserializes correctly', (
-        WidgetTester _,
-      ) async {
+      test('custom Parcelable serializes and deserializes correctly', () async {
         final Parcel parcel = Parcel();
         final _Point original = _Point(x: 10, y: 20);
         original.serialize(parcel);
@@ -253,9 +243,7 @@ void main() {
   // ---------------------------------------------------------------------------
 
   group('PortType', () {
-    testWidgets('has exactly the main and callback values', (
-      WidgetTester _,
-    ) async {
+    test('has exactly the main and callback values', () async {
       expect(
         PortType.values,
         unorderedEquals(<PortType>[PortType.main, PortType.callback]),
@@ -268,16 +256,12 @@ void main() {
   // ---------------------------------------------------------------------------
 
   group('ProxyBase', () {
-    testWidgets('isConnected is false before connecting', (
-      WidgetTester _,
-    ) async {
+    test('isConnected is false before connecting', () async {
       final _TestProxy proxy = _TestProxy();
       expect(proxy.isConnected, isFalse);
     });
 
-    testWidgets('appid and portName are set from constructor', (
-      WidgetTester _,
-    ) async {
+    test('appid and portName are set from constructor', () async {
       final _TestProxy proxy = _TestProxy();
       expect(proxy.appid, 'org.tizen.nonexistent_app_for_rpc_test');
       expect(proxy.portName, 'TestPort');
@@ -289,7 +273,7 @@ void main() {
   // ---------------------------------------------------------------------------
 
   group('Tizen 10.0+ Parcel APIs', () {
-    testWidgets('reader getter/setter', (WidgetTester _) async {
+    test('reader getter/setter', () async {
       final Parcel parcel = Parcel();
       try {
         parcel.reader = 10;
@@ -299,7 +283,7 @@ void main() {
       }
     });
 
-    testWidgets('dataSize getter/setter', (WidgetTester _) async {
+    test('dataSize getter/setter', () async {
       final Parcel parcel = Parcel();
       try {
         parcel.dataSize = 20;
@@ -309,7 +293,7 @@ void main() {
       }
     });
 
-    testWidgets('reserve', (WidgetTester _) async {
+    test('reserve', () async {
       final Parcel parcel = Parcel();
       try {
         parcel.reserve(100);

--- a/packages/tizen_rpc_port/example/server/integration_test/tizen_rpc_port_test.dart
+++ b/packages/tizen_rpc_port/example/server/integration_test/tizen_rpc_port_test.dart
@@ -39,22 +39,18 @@ void main() {
   // ---------------------------------------------------------------------------
 
   group('StubBase', () {
-    testWidgets('portName is set from constructor', (WidgetTester _) async {
+    test('portName is set from constructor', () async {
       final _TestStub stub = _TestStub();
       expect(stub.portName, 'TestStubPort');
     });
 
-    testWidgets('setTrusted can be called without listen', (
-      WidgetTester _,
-    ) async {
+    test('setTrusted can be called without listen', () async {
       final _TestStub stub = _TestStub();
       stub.setTrusted(true);
       stub.setTrusted(false);
     });
 
-    testWidgets('addPrivilege can be called without listen', (
-      WidgetTester _,
-    ) async {
+    test('addPrivilege can be called without listen', () async {
       final _TestStub stub = _TestStub();
       stub.addPrivilege('http://tizen.org/privilege/datasharing');
     });
@@ -65,7 +61,7 @@ void main() {
   // ---------------------------------------------------------------------------
 
   group('Message', () {
-    testWidgets('portName is Message', (WidgetTester _) async {
+    test('portName is Message', () async {
       final Message server = Message(
         serviceBuilder: (String sender, String instance) =>
             _NoopService(sender, instance),
@@ -73,7 +69,7 @@ void main() {
       expect(server.portName, 'Message');
     });
 
-    testWidgets('services list is initially empty', (WidgetTester _) async {
+    test('services list is initially empty', () async {
       final Message server = Message(
         serviceBuilder: (String sender, String instance) =>
             _NoopService(sender, instance),

--- a/packages/tizen_window_manager/CHANGELOG.md
+++ b/packages/tizen_window_manager/CHANGELOG.md
@@ -1,3 +1,7 @@
+## NEXT
+
+* Update integration tests.
+
 ## 0.1.0
 
 * Initial release.

--- a/packages/tizen_window_manager/example/integration_test/tizen_window_manager_test.dart
+++ b/packages/tizen_window_manager/example/integration_test/tizen_window_manager_test.dart
@@ -10,7 +10,7 @@ import 'package:tizen_window_manager/tizen_window_manager.dart';
 void main() {
   IntegrationTestWidgetsFlutterBinding.ensureInitialized();
 
-  testWidgets('Can get window geometry info', (WidgetTester tester) async {
+  test('Can get window geometry info', () async {
     final Map<String, int> geometry = await WindowManager.getGeometry();
     expect(geometry['x'], 100);
     expect(geometry['y'], 100);
@@ -18,7 +18,7 @@ void main() {
     expect(geometry['height'], 700);
   });
 
-  testWidgets('Control lower/activate window', (WidgetTester tester) async {
+  test('Control lower/activate window', () async {
     await WindowManager.lower();
     await Future<void>.delayed(const Duration(seconds: 2));
 

--- a/packages/tizen_window_manager/example/integration_test/tizen_window_manager_test.dart
+++ b/packages/tizen_window_manager/example/integration_test/tizen_window_manager_test.dart
@@ -18,7 +18,7 @@ void main() {
     expect(geometry['height'], 700);
   });
 
-  test('Control lower/activate window', () async {
+  testWidgets('Control lower/activate window', (WidgetTester tester) async {
     await WindowManager.lower();
     await Future<void>.delayed(const Duration(seconds: 2));
 

--- a/packages/url_launcher/CHANGELOG.md
+++ b/packages/url_launcher/CHANGELOG.md
@@ -1,3 +1,7 @@
+## NEXT
+
+* Update integration tests.
+
 ## 2.1.5
 
 * Update url_launcher to 6.3.2.

--- a/packages/url_launcher/example/integration_test/url_launcher_test.dart
+++ b/packages/url_launcher/example/integration_test/url_launcher_test.dart
@@ -12,7 +12,7 @@ import 'package:url_launcher/url_launcher.dart';
 void main() {
   IntegrationTestWidgetsFlutterBinding.ensureInitialized();
 
-  testWidgets('canLaunch', (WidgetTester _) async {
+  test('canLaunch', () async {
     expect(
       await canLaunchUrl(Uri(scheme: 'randomscheme', path: 'a_path')),
       false,

--- a/packages/video_player/CHANGELOG.md
+++ b/packages/video_player/CHANGELOG.md
@@ -1,3 +1,7 @@
+## NEXT
+
+* Update integration tests.
+
 ## 2.5.12
 
 * Remove Ecore API.

--- a/packages/video_player/example/integration_test/video_player_test.dart
+++ b/packages/video_player/example/integration_test/video_player_test.dart
@@ -43,7 +43,7 @@ void main() {
       controller = VideoPlayerController.asset(_videoAssetKey);
     });
 
-    testWidgets('can be initialized', (WidgetTester tester) async {
+    test('can be initialized', () async {
       await controller.initialize();
 
       expect(controller.value.isInitialized, true);
@@ -56,7 +56,7 @@ void main() {
       );
     });
 
-    testWidgets('live stream duration != 0', (WidgetTester tester) async {
+    test('live stream duration != 0', () async {
       final VideoPlayerController
       networkController = VideoPlayerController.networkUrl(
         Uri.parse(
@@ -90,7 +90,7 @@ void main() {
       );
     });
 
-    testWidgets('can seek', (WidgetTester tester) async {
+    test('can seek', () async {
       await controller.initialize();
 
       await controller.seekTo(const Duration(seconds: 3));
@@ -259,17 +259,19 @@ void main() {
       controller = VideoPlayerController.file(file);
     });
 
-    testWidgets('test video player using static file() method as constructor', (
-      WidgetTester tester,
-    ) async {
-      await controller.initialize();
+    test(
+      'test video player using static file() method as constructor',
+      () async {
+        await controller.initialize();
 
-      await controller.play();
-      expect(controller.value.isPlaying, true);
+        await controller.play();
+        expect(controller.value.isPlaying, true);
 
-      await controller.pause();
-      expect(controller.value.isPlaying, false);
-    }, skip: kIsWeb);
+        await controller.pause();
+        expect(controller.value.isPlaying, false);
+      },
+      skip: kIsWeb,
+    );
   });
 
   group('network videos', () {
@@ -324,7 +326,7 @@ void main() {
       controller = VideoPlayerController.asset('assets/Audio.mp3');
     });
 
-    testWidgets('can be initialized', (WidgetTester tester) async {
+    test('can be initialized', () async {
       await controller.initialize();
 
       expect(controller.value.isInitialized, true);
@@ -357,7 +359,7 @@ void main() {
       );
     });
 
-    testWidgets('can seek', (WidgetTester tester) async {
+    test('can seek', () async {
       await controller.initialize();
       await controller.seekTo(const Duration(seconds: 3));
 

--- a/packages/wakelock_plus/CHANGELOG.md
+++ b/packages/wakelock_plus/CHANGELOG.md
@@ -1,3 +1,7 @@
+## NEXT
+
+* Update integration tests.
+
 ## 2.1.1
 
 * Remove Ecore API.

--- a/packages/wakelock_plus/example/integration_test/wakelock_plus_test.dart
+++ b/packages/wakelock_plus/example/integration_test/wakelock_plus_test.dart
@@ -6,7 +6,7 @@ import 'package:wakelock_plus/wakelock_plus.dart';
 void main() {
   IntegrationTestWidgetsFlutterBinding.ensureInitialized();
 
-  testWidgets('enabling and disabling wakelock', (WidgetTester tester) async {
+  test('enabling and disabling wakelock', () async {
     final wakelockEnabled = await WakelockPlus.enabled;
 
     // The wakelock should initially be disabled.
@@ -18,7 +18,7 @@ void main() {
     expect(await WakelockPlus.enabled, isFalse);
   });
 
-  testWidgets('toggling wakelock', (WidgetTester tester) async {
+  test('toggling wakelock', () async {
     await WakelockPlus.toggle(enable: true);
     expect(await WakelockPlus.enabled, isTrue);
     await WakelockPlus.toggle(enable: false);


### PR DESCRIPTION
- Convert testWidgets to test for tests that don't use WidgetTester, resolving FocusManager lifecycle conflicts in integration tests
- Applied across 30+ packages (video_player, wakelock_plus, camera, geolocator, etc.)