### PR TITLE
Fix CI failures: analysis_options drift and dart_analyze lint issues

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -16,6 +16,13 @@ analyzer:
     # Ignore generated files
     - '**/*.g.dart'
     - '**/*.mocks.dart' # Mockito @GenerateMocks
+    - 'build/**'
+    - 'android/**'
+    - 'ios/**'
+    - 'web/**'
+    - 'windows/**'
+    - 'macos/**'
+    - 'linux/**'
 
 linter:
   rules:

--- a/packages/audioplayers/analysis_options.yaml
+++ b/packages/audioplayers/analysis_options.yaml
@@ -1,1 +1,11 @@
 include: package:flame_lint/analysis_options.yaml
+
+analyzer:
+  exclude:
+    - 'build/**'
+    - 'android/**'
+    - 'ios/**'
+    - 'web/**'
+    - 'windows/**'
+    - 'macos/**'
+    - 'linux/**'

--- a/packages/audioplayers/example/analysis_options.yaml
+++ b/packages/audioplayers/example/analysis_options.yaml
@@ -1,5 +1,15 @@
 include: package:flame_lint/analysis_options.yaml
 
+analyzer:
+  exclude:
+    - 'build/**'
+    - 'android/**'
+    - 'ios/**'
+    - 'web/**'
+    - 'windows/**'
+    - 'macos/**'
+    - 'linux/**'
+
 linter:
   rules:
     do_not_use_environment: false

--- a/packages/battery_plus/analysis_options.yaml
+++ b/packages/battery_plus/analysis_options.yaml
@@ -1,1 +1,11 @@
 include: ../../analysis_options_plus.yaml
+
+analyzer:
+  exclude:
+    - 'build/**'
+    - 'android/**'
+    - 'ios/**'
+    - 'web/**'
+    - 'windows/**'
+    - 'macos/**'
+    - 'linux/**'

--- a/packages/camera/example/lib/main.dart
+++ b/packages/camera/example/lib/main.dart
@@ -888,7 +888,7 @@ class _CameraExampleHomeState extends State<CameraExampleHome>
     }
 
     try {
-      return cameraController.stopVideoRecording();
+      return await cameraController.stopVideoRecording();
     } on CameraException catch (e) {
       _showCameraException(e);
       return null;

--- a/packages/connectivity_plus/analysis_options.yaml
+++ b/packages/connectivity_plus/analysis_options.yaml
@@ -1,1 +1,11 @@
 include: ../../analysis_options_plus.yaml
+
+analyzer:
+  exclude:
+    - 'build/**'
+    - 'android/**'
+    - 'ios/**'
+    - 'web/**'
+    - 'windows/**'
+    - 'macos/**'
+    - 'linux/**'

--- a/packages/device_info_plus/analysis_options.yaml
+++ b/packages/device_info_plus/analysis_options.yaml
@@ -1,1 +1,11 @@
 include: ../../analysis_options_plus.yaml
+
+analyzer:
+  exclude:
+    - 'build/**'
+    - 'android/**'
+    - 'ios/**'
+    - 'web/**'
+    - 'windows/**'
+    - 'macos/**'
+    - 'linux/**'

--- a/packages/flutter_app_badger/example/analysis_options.yaml
+++ b/packages/flutter_app_badger/example/analysis_options.yaml
@@ -1,1 +1,11 @@
 include: package:flutter_lints/flutter.yaml
+
+analyzer:
+  exclude:
+    - 'build/**'
+    - 'android/**'
+    - 'ios/**'
+    - 'web/**'
+    - 'windows/**'
+    - 'macos/**'
+    - 'linux/**'

--- a/packages/flutter_inappwebview/analysis_options.yaml
+++ b/packages/flutter_inappwebview/analysis_options.yaml
@@ -5,3 +5,11 @@ analyzer:
     strict-casts: false
     strict-inference: false
     strict-raw-types: false
+  exclude:
+    - 'build/**'
+    - 'android/**'
+    - 'ios/**'
+    - 'web/**'
+    - 'windows/**'
+    - 'macos/**'
+    - 'linux/**'

--- a/packages/flutter_inappwebview/example/analysis_options.yaml
+++ b/packages/flutter_inappwebview/example/analysis_options.yaml
@@ -17,3 +17,11 @@ analyzer:
     deprecated_member_use_from_same_package: ignore
     unnecessary_cast: ignore
     unnecessary_import: ignore
+  exclude:
+    - 'build/**'
+    - 'android/**'
+    - 'ios/**'
+    - 'web/**'
+    - 'windows/**'
+    - 'macos/**'
+    - 'linux/**'

--- a/packages/flutter_inappwebview/example/lib/chrome_safari_browser_example.screen.dart
+++ b/packages/flutter_inappwebview/example/lib/chrome_safari_browser_example.screen.dart
@@ -12,25 +12,27 @@ import 'main.dart';
 class MyChromeSafariBrowser extends ChromeSafariBrowser {
   @override
   void onOpened() async {
-    print("ChromeSafari browser opened");
+    debugPrint("ChromeSafari browser opened");
   }
 
   @override
   void onCompletedInitialLoad(didLoadSuccessfully) {
-    print("ChromeSafari browser initial load completed");
+    debugPrint("ChromeSafari browser initial load completed");
   }
 
   @override
   void onClosed() {
-    print("ChromeSafari browser closed");
+    debugPrint("ChromeSafari browser closed");
   }
 }
 
 class ChromeSafariBrowserExampleScreen extends StatefulWidget {
+  ChromeSafariBrowserExampleScreen({super.key});
+
   final ChromeSafariBrowser browser = MyChromeSafariBrowser();
 
   @override
-  _ChromeSafariBrowserExampleScreenState createState() =>
+  State<ChromeSafariBrowserExampleScreen> createState() =>
       _ChromeSafariBrowserExampleScreenState();
 }
 
@@ -46,9 +48,9 @@ class _ChromeSafariBrowserExampleScreenState
             description: 'Action Button description',
             icon: actionButtonIcon.buffer.asUint8List(),
             onClick: (url, title) {
-              print('Action Button 1 clicked!');
-              print(url);
-              print(title);
+              debugPrint('Action Button 1 clicked!');
+              debugPrint(url.toString());
+              debugPrint(title);
             },
           ),
         );
@@ -61,9 +63,9 @@ class _ChromeSafariBrowserExampleScreenState
         label: 'Custom item menu 1',
         image: UIImage(systemName: "sun.max"),
         onClick: (url, title) {
-          print('Custom item menu 1 clicked!');
-          print(url);
-          print(title);
+          debugPrint('Custom item menu 1 clicked!');
+          debugPrint(url.toString());
+          debugPrint(title);
         },
       ),
     );
@@ -73,9 +75,9 @@ class _ChromeSafariBrowserExampleScreenState
         label: 'Custom item menu 2',
         image: UIImage(systemName: "pencil"),
         onClick: (url, title) {
-          print('Custom item menu 2 clicked!');
-          print(url);
-          print(title);
+          debugPrint('Custom item menu 2 clicked!');
+          debugPrint(url.toString());
+          debugPrint(title);
         },
       ),
     );
@@ -85,7 +87,7 @@ class _ChromeSafariBrowserExampleScreenState
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: AppBar(title: Text("ChromeSafariBrowser")),
+      appBar: AppBar(title: const Text("ChromeSafariBrowser")),
       drawer: myDrawer(context: context),
       body: Center(
         child: ElevatedButton(
@@ -124,7 +126,7 @@ class _ChromeSafariBrowserExampleScreenState
               ),
             );
           },
-          child: Text("Open Chrome Safari Browser"),
+          child: const Text("Open Chrome Safari Browser"),
         ),
       ),
     );

--- a/packages/flutter_inappwebview/example/lib/headless_in_app_webview.screen.dart
+++ b/packages/flutter_inappwebview/example/lib/headless_in_app_webview.screen.dart
@@ -9,8 +9,10 @@ import 'package:flutter_inappwebview/flutter_inappwebview.dart';
 import 'main.dart';
 
 class HeadlessInAppWebViewExampleScreen extends StatefulWidget {
+  const HeadlessInAppWebViewExampleScreen({super.key});
+
   @override
-  _HeadlessInAppWebViewExampleScreenState createState() =>
+  State<HeadlessInAppWebViewExampleScreen> createState() =>
       _HeadlessInAppWebViewExampleScreenState();
 }
 
@@ -32,10 +34,10 @@ class _HeadlessInAppWebViewExampleScreenState
       initialUrlRequest: URLRequest(url: url),
       initialSettings: InAppWebViewSettings(isInspectable: kDebugMode),
       onWebViewCreated: (controller) {
-        print('HeadlessInAppWebView created!');
+        debugPrint('HeadlessInAppWebView created!');
       },
       onConsoleMessage: (controller, consoleMessage) {
-        print("CONSOLE MESSAGE: " + consoleMessage.message);
+        debugPrint("CONSOLE MESSAGE: ${consoleMessage.message}");
       },
       onLoadStart: (controller, url) async {
         setState(() {
@@ -64,15 +66,15 @@ class _HeadlessInAppWebViewExampleScreenState
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: AppBar(title: Text("HeadlessInAppWebView")),
+      appBar: AppBar(title: const Text("HeadlessInAppWebView")),
       drawer: myDrawer(context: context),
       body: SafeArea(
         child: Column(
           children: <Widget>[
             Container(
-              padding: EdgeInsets.all(20.0),
+              padding: const EdgeInsets.all(20.0),
               child: Text(
-                "CURRENT URL\n${(url.length > 50) ? url.substring(0, 50) + "..." : url}",
+                "CURRENT URL\n${(url.length > 50) ? '${url.substring(0, 50)}...' : url}",
               ),
             ),
             Center(
@@ -81,7 +83,7 @@ class _HeadlessInAppWebViewExampleScreenState
                   await headlessWebView?.dispose();
                   await headlessWebView?.run();
                 },
-                child: Text("Run HeadlessInAppWebView"),
+                child: const Text("Run HeadlessInAppWebView"),
               ),
             ),
             Container(height: 10),
@@ -95,7 +97,7 @@ class _HeadlessInAppWebViewExampleScreenState
                         );
                   } else {
                     ScaffoldMessenger.of(context).showSnackBar(
-                      SnackBar(
+                      const SnackBar(
                         content: Text(
                           'HeadlessInAppWebView is not running. Click on "Run HeadlessInAppWebView"!',
                         ),
@@ -103,7 +105,7 @@ class _HeadlessInAppWebViewExampleScreenState
                     );
                   }
                 },
-                child: Text("Send console.log message"),
+                child: const Text("Send console.log message"),
               ),
             ),
             Container(height: 10),
@@ -112,10 +114,10 @@ class _HeadlessInAppWebViewExampleScreenState
                 onPressed: () {
                   headlessWebView?.dispose();
                   setState(() {
-                    this.url = "";
+                    url = "";
                   });
                 },
-                child: Text("Dispose HeadlessInAppWebView"),
+                child: const Text("Dispose HeadlessInAppWebView"),
               ),
             ),
           ],

--- a/packages/flutter_inappwebview/example/lib/in_app_browser_example.screen.dart
+++ b/packages/flutter_inappwebview/example/lib/in_app_browser_example.screen.dart
@@ -3,7 +3,6 @@
 // Imported from https://pub.dev/packages/flutter_inappwebview.
 
 import 'dart:async';
-import 'dart:collection';
 import 'dart:io';
 
 import 'package:flutter/foundation.dart';
@@ -15,19 +14,14 @@ import 'main.dart';
 
 class MyInAppBrowser extends InAppBrowser {
   MyInAppBrowser({
-    int? windowId,
-    UnmodifiableListView<UserScript>? initialUserScripts,
-    PullToRefreshController? pullToRefreshController,
-  }) : super(
-         windowId: windowId,
-         initialUserScripts: initialUserScripts,
-         pullToRefreshController: pullToRefreshController,
-         webViewEnvironment: webViewEnvironment,
-       );
+    super.windowId,
+    super.initialUserScripts,
+    super.pullToRefreshController,
+  }) : super(webViewEnvironment: webViewEnvironment);
 
   @override
   Future onBrowserCreated() async {
-    print("\n\nBrowser Created!\n\n");
+    debugPrint("\n\nBrowser Created!\n\n");
   }
 
   @override
@@ -39,9 +33,9 @@ class MyInAppBrowser extends InAppBrowser {
   }
 
   @override
-  Future<PermissionResponse> onPermissionRequest(request) async {
+  Future<PermissionResponse> onPermissionRequest(permissionRequest) async {
     return PermissionResponse(
-      resources: request.resources,
+      resources: permissionRequest.resources,
       action: PermissionResponseAction.GRANT,
     );
   }
@@ -60,25 +54,28 @@ class MyInAppBrowser extends InAppBrowser {
 
   @override
   void onExit() {
-    print("\n\nBrowser closed!\n\n");
+    debugPrint("\n\nBrowser closed!\n\n");
   }
 
   @override
   Future<NavigationActionPolicy> shouldOverrideUrlLoading(
     navigationAction,
   ) async {
-    print("\n\nOverride ${navigationAction.request.url}\n\n");
+    debugPrint("\n\nOverride ${navigationAction.request.url}\n\n");
     return NavigationActionPolicy.ALLOW;
   }
 
+  @override
   void onMainWindowWillClose() {
     close();
   }
 }
 
 class InAppBrowserExampleScreen extends StatefulWidget {
+  const InAppBrowserExampleScreen({super.key});
+
   @override
-  _InAppBrowserExampleScreenState createState() =>
+  State<InAppBrowserExampleScreen> createState() =>
       _InAppBrowserExampleScreenState();
 }
 
@@ -117,7 +114,7 @@ class _InAppBrowserExampleScreenState extends State<InAppBrowserExampleScreen> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: AppBar(title: Text("InAppBrowser")),
+      appBar: AppBar(title: const Text("InAppBrowser")),
       drawer: myDrawer(context: context),
       body: Center(
         child: Column(
@@ -140,7 +137,7 @@ class _InAppBrowserExampleScreenState extends State<InAppBrowserExampleScreen> {
                   ),
                 );
               },
-              child: Text("Open In-App Browser"),
+              child: const Text("Open In-App Browser"),
             ),
             Container(height: 40),
             ElevatedButton(
@@ -149,7 +146,7 @@ class _InAppBrowserExampleScreenState extends State<InAppBrowserExampleScreen> {
                   url: WebUri("https://flutter.dev/"),
                 );
               },
-              child: Text("Open System Browser"),
+              child: const Text("Open System Browser"),
             ),
           ],
         ),

--- a/packages/flutter_inappwebview/example/lib/in_app_webiew_example.screen.dart
+++ b/packages/flutter_inappwebview/example/lib/in_app_webiew_example.screen.dart
@@ -13,8 +13,10 @@ import 'package:url_launcher/url_launcher.dart';
 import 'main.dart';
 
 class InAppWebViewExampleScreen extends StatefulWidget {
+  const InAppWebViewExampleScreen({super.key});
+
   @override
-  _InAppWebViewExampleScreenState createState() =>
+  State<InAppWebViewExampleScreen> createState() =>
       _InAppWebViewExampleScreenState();
 }
 
@@ -47,28 +49,25 @@ class _InAppWebViewExampleScreenState extends State<InAppWebViewExampleScreen> {
           id: 1,
           title: "Special",
           action: () async {
-            print("Menu item Special clicked!");
-            print(await webViewController?.getSelectedText());
+            debugPrint("Menu item Special clicked!");
+            debugPrint(await webViewController?.getSelectedText());
             await webViewController?.clearFocus();
           },
         ),
       ],
       settings: ContextMenuSettings(hideDefaultSystemContextMenuItems: false),
       onCreateContextMenu: (hitTestResult) async {
-        print("onCreateContextMenu");
-        print(hitTestResult.extra);
-        print(await webViewController?.getSelectedText());
+        debugPrint("onCreateContextMenu");
+        debugPrint(hitTestResult.extra);
+        debugPrint(await webViewController?.getSelectedText());
       },
       onHideContextMenu: () {
-        print("onHideContextMenu");
+        debugPrint("onHideContextMenu");
       },
       onContextMenuActionItemClicked: (contextMenuItemClicked) async {
         var id = contextMenuItemClicked.id;
-        print(
-          "onContextMenuActionItemClicked: " +
-              id.toString() +
-              " " +
-              contextMenuItemClicked.title,
+        debugPrint(
+          "onContextMenuActionItemClicked: $id ${contextMenuItemClicked.title}",
         );
       },
     );
@@ -104,7 +103,7 @@ class _InAppWebViewExampleScreenState extends State<InAppWebViewExampleScreen> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: AppBar(title: Text("InAppWebView")),
+      appBar: AppBar(title: const Text("InAppWebView")),
       backgroundColor: Colors
           .transparent, // for tizen - entire app transparent for WebView video buffer
       drawer: myDrawer(context: context),
@@ -114,7 +113,9 @@ class _InAppWebViewExampleScreenState extends State<InAppWebViewExampleScreen> {
             ColoredBox(
               color: Theme.of(context).scaffoldBackgroundColor, // for tizen
               child: TextField(
-                decoration: InputDecoration(prefixIcon: Icon(Icons.search)),
+                decoration: const InputDecoration(
+                  prefixIcon: Icon(Icons.search),
+                ),
                 controller: urlController,
                 keyboardType: TextInputType.text,
                 onSubmitted: (value) {
@@ -207,7 +208,7 @@ class _InAppWebViewExampleScreenState extends State<InAppWebViewExampleScreen> {
                       }
                       setState(() {
                         this.progress = progress / 100;
-                        urlController.text = this.url;
+                        urlController.text = url;
                       });
                     },
                     onUpdateVisitedHistory: (controller, url, isReload) {
@@ -217,7 +218,7 @@ class _InAppWebViewExampleScreenState extends State<InAppWebViewExampleScreen> {
                       });
                     },
                     onConsoleMessage: (controller, consoleMessage) {
-                      print(consoleMessage);
+                      debugPrint(consoleMessage.toString());
                     },
                   ),
                   progress < 1.0
@@ -232,22 +233,22 @@ class _InAppWebViewExampleScreenState extends State<InAppWebViewExampleScreen> {
                 alignment: MainAxisAlignment.center,
                 children: <Widget>[
                   ElevatedButton(
-                    child: Icon(Icons.arrow_back),
                     onPressed: () {
                       webViewController?.goBack();
                     },
+                    child: const Icon(Icons.arrow_back),
                   ),
                   ElevatedButton(
-                    child: Icon(Icons.arrow_forward),
                     onPressed: () {
                       webViewController?.goForward();
                     },
+                    child: const Icon(Icons.arrow_forward),
                   ),
                   ElevatedButton(
-                    child: Icon(Icons.refresh),
                     onPressed: () {
                       webViewController?.reload();
                     },
+                    child: const Icon(Icons.refresh),
                   ),
                 ],
               ),

--- a/packages/flutter_inappwebview/example/lib/main.dart
+++ b/packages/flutter_inappwebview/example/lib/main.dart
@@ -55,31 +55,31 @@ Future main() async {
 PointerInterceptor myDrawer({required BuildContext context}) {
   var children = [
     ListTile(
-      title: Text('InAppWebView'),
+      title: const Text('InAppWebView'),
       onTap: () {
         Navigator.pushReplacementNamed(context, '/');
       },
     ),
     ListTile(
-      title: Text('InAppBrowser'),
+      title: const Text('InAppBrowser'),
       onTap: () {
         Navigator.pushReplacementNamed(context, '/InAppBrowser');
       },
     ),
     ListTile(
-      title: Text('ChromeSafariBrowser'),
+      title: const Text('ChromeSafariBrowser'),
       onTap: () {
         Navigator.pushReplacementNamed(context, '/ChromeSafariBrowser');
       },
     ),
     ListTile(
-      title: Text('WebAuthenticationSession'),
+      title: const Text('WebAuthenticationSession'),
       onTap: () {
         Navigator.pushReplacementNamed(context, '/WebAuthenticationSession');
       },
     ),
     ListTile(
-      title: Text('HeadlessInAppWebView'),
+      title: const Text('HeadlessInAppWebView'),
       onTap: () {
         Navigator.pushReplacementNamed(context, '/HeadlessInAppWebView');
       },
@@ -88,7 +88,7 @@ PointerInterceptor myDrawer({required BuildContext context}) {
   if (kIsWeb) {
     children = [
       ListTile(
-        title: Text('InAppWebView'),
+        title: const Text('InAppWebView'),
         onTap: () {
           Navigator.pushReplacementNamed(context, '/');
         },
@@ -97,25 +97,25 @@ PointerInterceptor myDrawer({required BuildContext context}) {
   } else if (defaultTargetPlatform == TargetPlatform.macOS) {
     children = [
       ListTile(
-        title: Text('InAppWebView'),
+        title: const Text('InAppWebView'),
         onTap: () {
           Navigator.pushReplacementNamed(context, '/');
         },
       ),
       ListTile(
-        title: Text('InAppBrowser'),
+        title: const Text('InAppBrowser'),
         onTap: () {
           Navigator.pushReplacementNamed(context, '/InAppBrowser');
         },
       ),
       ListTile(
-        title: Text('WebAuthenticationSession'),
+        title: const Text('WebAuthenticationSession'),
         onTap: () {
           Navigator.pushReplacementNamed(context, '/WebAuthenticationSession');
         },
       ),
       ListTile(
-        title: Text('HeadlessInAppWebView'),
+        title: const Text('HeadlessInAppWebView'),
         onTap: () {
           Navigator.pushReplacementNamed(context, '/HeadlessInAppWebView');
         },
@@ -125,19 +125,19 @@ PointerInterceptor myDrawer({required BuildContext context}) {
       defaultTargetPlatform == TargetPlatform.linux) {
     children = [
       ListTile(
-        title: Text('InAppWebView'),
+        title: const Text('InAppWebView'),
         onTap: () {
           Navigator.pushReplacementNamed(context, '/');
         },
       ),
       ListTile(
-        title: Text('InAppBrowser'),
+        title: const Text('InAppBrowser'),
         onTap: () {
           Navigator.pushReplacementNamed(context, '/InAppBrowser');
         },
       ),
       ListTile(
-        title: Text('HeadlessInAppWebView'),
+        title: const Text('HeadlessInAppWebView'),
         onTap: () {
           Navigator.pushReplacementNamed(context, '/HeadlessInAppWebView');
         },
@@ -150,7 +150,7 @@ PointerInterceptor myDrawer({required BuildContext context}) {
   if (flutter_tizen.isTizen) {
     children = [
       ListTile(
-        title: Text('InAppWebView'),
+        title: const Text('InAppWebView'),
         onTap: () {
           Navigator.pushReplacementNamed(context, '/');
         },
@@ -163,8 +163,8 @@ PointerInterceptor myDrawer({required BuildContext context}) {
         padding: EdgeInsets.zero,
         children: <Widget>[
           DrawerHeader(
-            child: Text('flutter_inappwebview example'),
-            decoration: BoxDecoration(color: Colors.blue),
+            decoration: const BoxDecoration(color: Colors.blue),
+            child: const Text('flutter_inappwebview example'),
           ),
           ...children,
         ],
@@ -174,8 +174,10 @@ PointerInterceptor myDrawer({required BuildContext context}) {
 }
 
 class MyApp extends StatefulWidget {
+  const MyApp({super.key});
+
   @override
-  _MyAppState createState() => _MyAppState();
+  State<MyApp> createState() => _MyAppState();
 }
 
 class _MyAppState extends State<MyApp> {
@@ -194,7 +196,7 @@ class _MyAppState extends State<MyApp> {
     if (kIsWeb) {
       return MaterialApp(
         initialRoute: '/',
-        routes: {'/': (context) => InAppWebViewExampleScreen()},
+        routes: {'/': (context) => const InAppWebViewExampleScreen()},
       );
     }
     // TIZENFIX: Only register the InAppWebView route on Tizen. The other
@@ -203,19 +205,19 @@ class _MyAppState extends State<MyApp> {
     if (flutter_tizen.isTizen) {
       return MaterialApp(
         initialRoute: '/',
-        routes: {'/': (context) => InAppWebViewExampleScreen()},
+        routes: {'/': (context) => const InAppWebViewExampleScreen()},
       );
     }
     if (defaultTargetPlatform == TargetPlatform.macOS) {
       return MaterialApp(
         initialRoute: '/',
         routes: {
-          '/': (context) => InAppWebViewExampleScreen(),
-          '/InAppBrowser': (context) => InAppBrowserExampleScreen(),
+          '/': (context) => const InAppWebViewExampleScreen(),
+          '/InAppBrowser': (context) => const InAppBrowserExampleScreen(),
           '/HeadlessInAppWebView': (context) =>
-              HeadlessInAppWebViewExampleScreen(),
+              const HeadlessInAppWebViewExampleScreen(),
           '/WebAuthenticationSession': (context) =>
-              WebAuthenticationSessionExampleScreen(),
+              const WebAuthenticationSessionExampleScreen(),
         },
       );
     } else if (defaultTargetPlatform == TargetPlatform.windows ||
@@ -223,23 +225,23 @@ class _MyAppState extends State<MyApp> {
       return MaterialApp(
         initialRoute: '/',
         routes: {
-          '/': (context) => InAppWebViewExampleScreen(),
-          '/InAppBrowser': (context) => InAppBrowserExampleScreen(),
+          '/': (context) => const InAppWebViewExampleScreen(),
+          '/InAppBrowser': (context) => const InAppBrowserExampleScreen(),
           '/HeadlessInAppWebView': (context) =>
-              HeadlessInAppWebViewExampleScreen(),
+              const HeadlessInAppWebViewExampleScreen(),
         },
       );
     }
     return MaterialApp(
       initialRoute: '/',
       routes: {
-        '/': (context) => InAppWebViewExampleScreen(),
-        '/InAppBrowser': (context) => InAppBrowserExampleScreen(),
+        '/': (context) => const InAppWebViewExampleScreen(),
+        '/InAppBrowser': (context) => const InAppBrowserExampleScreen(),
         '/ChromeSafariBrowser': (context) => ChromeSafariBrowserExampleScreen(),
         '/HeadlessInAppWebView': (context) =>
-            HeadlessInAppWebViewExampleScreen(),
+            const HeadlessInAppWebViewExampleScreen(),
         '/WebAuthenticationSession': (context) =>
-            WebAuthenticationSessionExampleScreen(),
+            const WebAuthenticationSessionExampleScreen(),
       },
     );
   }

--- a/packages/flutter_inappwebview/example/lib/web_authentication_session_example.screen.dart
+++ b/packages/flutter_inappwebview/example/lib/web_authentication_session_example.screen.dart
@@ -9,8 +9,10 @@ import 'package:flutter_inappwebview/flutter_inappwebview.dart';
 import 'main.dart';
 
 class WebAuthenticationSessionExampleScreen extends StatefulWidget {
+  const WebAuthenticationSessionExampleScreen({super.key});
+
   @override
-  _WebAuthenticationSessionExampleScreenState createState() =>
+  State<WebAuthenticationSessionExampleScreen> createState() =>
       _WebAuthenticationSessionExampleScreenState();
 }
 
@@ -33,14 +35,14 @@ class _WebAuthenticationSessionExampleScreenState
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: AppBar(title: Text("WebAuthenticationSession")),
+      appBar: AppBar(title: const Text("WebAuthenticationSession")),
       drawer: myDrawer(context: context),
       body: SafeArea(
         child: Column(
           children: <Widget>[
             Center(
               child: Container(
-                padding: EdgeInsets.all(20.0),
+                padding: const EdgeInsets.all(20.0),
                 child: Text("Token: $token"),
               ),
             ),
@@ -69,8 +71,9 @@ class _WebAuthenticationSessionExampleScreenState
                           );
                           setState(() {});
                         } else {
+                          if (!mounted) return;
                           ScaffoldMessenger.of(context).showSnackBar(
-                            SnackBar(
+                            const SnackBar(
                               content: Text(
                                 'Cannot create Web Authentication Session!',
                               ),
@@ -78,7 +81,7 @@ class _WebAuthenticationSessionExampleScreenState
                           );
                         }
                       },
-                      child: Text("Create Web Auth Session"),
+                      child: const Text("Create Web Auth Session"),
                     ),
                   ),
             session == null
@@ -91,8 +94,9 @@ class _WebAuthenticationSessionExampleScreenState
                           started = await session?.start() ?? false;
                         }
                         if (!started) {
+                          if (!mounted) return;
                           ScaffoldMessenger.of(context).showSnackBar(
-                            SnackBar(
+                            const SnackBar(
                               content: Text(
                                 'Cannot start Web Authentication Session!',
                               ),
@@ -100,7 +104,7 @@ class _WebAuthenticationSessionExampleScreenState
                           );
                         }
                       },
-                      child: Text("Start Web Auth Session"),
+                      child: const Text("Start Web Auth Session"),
                     ),
                   ),
             session == null
@@ -114,7 +118,7 @@ class _WebAuthenticationSessionExampleScreenState
                           session = null;
                         });
                       },
-                      child: Text("Dispose Web Auth Session"),
+                      child: const Text("Dispose Web Auth Session"),
                     ),
                   ),
           ],

--- a/packages/flutter_secure_storage/analysis_options.yaml
+++ b/packages/flutter_secure_storage/analysis_options.yaml
@@ -1,5 +1,15 @@
 include: package:very_good_analysis/analysis_options.yaml
 
+analyzer:
+  exclude:
+    - 'build/**'
+    - 'android/**'
+    - 'ios/**'
+    - 'web/**'
+    - 'windows/**'
+    - 'macos/**'
+    - 'linux/**'
+
 linter:
   rules:
     remove_deprecations_in_breaking_versions: false # TODO(juliansteenbakker) remove this by v11 release

--- a/packages/flutter_secure_storage/example/analysis_options.yaml
+++ b/packages/flutter_secure_storage/example/analysis_options.yaml
@@ -1,1 +1,11 @@
 include: package:very_good_analysis/analysis_options.yaml
+
+analyzer:
+  exclude:
+    - 'build/**'
+    - 'android/**'
+    - 'ios/**'
+    - 'web/**'
+    - 'windows/**'
+    - 'macos/**'
+    - 'linux/**'

--- a/packages/flutter_tts/analysis_options.yaml
+++ b/packages/flutter_tts/analysis_options.yaml
@@ -3,6 +3,14 @@ analyzer:
     unused_import: error
     unused_local_variable: error
     dead_code: error
+  exclude:
+    - 'build/**'
+    - 'android/**'
+    - 'ios/**'
+    - 'web/**'
+    - 'windows/**'
+    - 'macos/**'
+    - 'linux/**'
 linter:
   rules:
      - avoid_empty_else

--- a/packages/flutter_webrtc/example/flutter_webrtc_demo/analysis_options.yaml
+++ b/packages/flutter_webrtc/example/flutter_webrtc_demo/analysis_options.yaml
@@ -30,6 +30,14 @@ linter:
     - void_checks
   
 analyzer:
+  exclude:
+    - 'build/**'
+    - 'android/**'
+    - 'ios/**'
+    - 'web/**'
+    - 'windows/**'
+    - 'macos/**'
+    - 'linux/**'
   errors:
     # treat missing required parameters as a warning (not a hint)
     missing_required_param: warning

--- a/packages/flutter_webrtc/example/flutter_webrtc_example/analysis_options.yaml
+++ b/packages/flutter_webrtc/example/flutter_webrtc_example/analysis_options.yaml
@@ -30,6 +30,14 @@ linter:
     - void_checks
   
 analyzer:
+  exclude:
+    - 'build/**'
+    - 'android/**'
+    - 'ios/**'
+    - 'web/**'
+    - 'windows/**'
+    - 'macos/**'
+    - 'linux/**'
   errors:
     # treat missing required parameters as a warning (not a hint)
     missing_required_param: warning

--- a/packages/geolocator/analysis_options.yaml
+++ b/packages/geolocator/analysis_options.yaml
@@ -7,6 +7,13 @@ analyzer:
     # Ignore generated files
     - '**/*.g.dart'
     - 'lib/src/generated/*.dart'
+    - 'build/**'
+    - 'android/**'
+    - 'ios/**'
+    - 'web/**'
+    - 'windows/**'
+    - 'macos/**'
+    - 'linux/**'
 linter:
   rules:
     - public_member_api_docs

--- a/packages/google_maps_flutter/example/lib/animate_camera.dart
+++ b/packages/google_maps_flutter/example/lib/animate_camera.dart
@@ -10,8 +10,8 @@ import 'package:google_maps_flutter/google_maps_flutter.dart';
 import 'page.dart';
 
 class AnimateCameraPage extends GoogleMapExampleAppPage {
-  const AnimateCameraPage({Key? key})
-      : super(const Icon(Icons.map), 'Camera control, animated', key: key);
+  const AnimateCameraPage({super.key})
+      : super(const Icon(Icons.map), 'Camera control, animated');
 
   @override
   Widget build(BuildContext context) {

--- a/packages/google_maps_flutter/example/lib/clustering.dart
+++ b/packages/google_maps_flutter/example/lib/clustering.dart
@@ -12,8 +12,8 @@ import 'page.dart';
 /// Page for demonstrating marker clustering support.
 class ClusteringPage extends GoogleMapExampleAppPage {
   /// Default Constructor.
-  const ClusteringPage({Key? key})
-      : super(const Icon(Icons.place), 'Manage clustering', key: key);
+  const ClusteringPage({super.key})
+      : super(const Icon(Icons.place), 'Manage clustering');
 
   @override
   Widget build(BuildContext context) {

--- a/packages/google_maps_flutter/example/lib/ground_overlay.dart
+++ b/packages/google_maps_flutter/example/lib/ground_overlay.dart
@@ -10,8 +10,8 @@ import 'package:google_maps_flutter/google_maps_flutter.dart';
 import 'page.dart';
 
 class GroundOverlayPage extends GoogleMapExampleAppPage {
-  const GroundOverlayPage({Key? key})
-      : super(const Icon(Icons.map), 'Ground overlay', key: key);
+  const GroundOverlayPage({super.key})
+      : super(const Icon(Icons.map), 'Ground overlay');
 
   @override
   Widget build(BuildContext context) {

--- a/packages/google_maps_flutter/example/lib/heatmap.dart
+++ b/packages/google_maps_flutter/example/lib/heatmap.dart
@@ -10,8 +10,8 @@ import 'package:google_maps_flutter/google_maps_flutter.dart';
 import 'page.dart';
 
 class HeatmapPage extends GoogleMapExampleAppPage {
-  const HeatmapPage({Key? key})
-      : super(const Icon(Icons.map), 'Heatmaps', key: key);
+  const HeatmapPage({super.key})
+      : super(const Icon(Icons.map), 'Heatmaps');
 
   @override
   Widget build(BuildContext context) {

--- a/packages/google_maps_flutter/example/lib/lite_mode.dart
+++ b/packages/google_maps_flutter/example/lib/lite_mode.dart
@@ -14,8 +14,8 @@ const CameraPosition _kInitialPosition = CameraPosition(
 );
 
 class LiteModePage extends GoogleMapExampleAppPage {
-  const LiteModePage({Key? key})
-      : super(const Icon(Icons.map), 'Lite mode', key: key);
+  const LiteModePage({super.key})
+      : super(const Icon(Icons.map), 'Lite mode');
 
   @override
   Widget build(BuildContext context) {

--- a/packages/google_maps_flutter/example/lib/map_click.dart
+++ b/packages/google_maps_flutter/example/lib/map_click.dart
@@ -14,8 +14,8 @@ const CameraPosition _kInitialPosition = CameraPosition(
 );
 
 class MapClickPage extends GoogleMapExampleAppPage {
-  const MapClickPage({Key? key})
-      : super(const Icon(Icons.mouse), 'Map click', key: key);
+  const MapClickPage({super.key})
+      : super(const Icon(Icons.mouse), 'Map click');
 
   @override
   Widget build(BuildContext context) {

--- a/packages/google_maps_flutter/example/lib/map_coordinates.dart
+++ b/packages/google_maps_flutter/example/lib/map_coordinates.dart
@@ -14,8 +14,8 @@ const CameraPosition _kInitialPosition = CameraPosition(
 );
 
 class MapCoordinatesPage extends GoogleMapExampleAppPage {
-  const MapCoordinatesPage({Key? key})
-      : super(const Icon(Icons.map), 'Map coordinates', key: key);
+  const MapCoordinatesPage({super.key})
+      : super(const Icon(Icons.map), 'Map coordinates');
 
   @override
   Widget build(BuildContext context) {

--- a/packages/google_maps_flutter/example/lib/map_map_id.dart
+++ b/packages/google_maps_flutter/example/lib/map_map_id.dart
@@ -8,8 +8,8 @@ import 'package:google_maps_flutter/google_maps_flutter.dart';
 import 'page.dart';
 
 class MapIdPage extends GoogleMapExampleAppPage {
-  const MapIdPage({Key? key})
-      : super(const Icon(Icons.map), 'Cloud-based maps styling', key: key);
+  const MapIdPage({super.key})
+      : super(const Icon(Icons.map), 'Cloud-based maps styling');
 
   @override
   Widget build(BuildContext context) {

--- a/packages/google_maps_flutter/example/lib/map_ui.dart
+++ b/packages/google_maps_flutter/example/lib/map_ui.dart
@@ -17,8 +17,8 @@ final LatLngBounds sydneyBounds = LatLngBounds(
 );
 
 class MapUiPage extends GoogleMapExampleAppPage {
-  const MapUiPage({Key? key})
-      : super(const Icon(Icons.map), 'User interface', key: key);
+  const MapUiPage({super.key})
+      : super(const Icon(Icons.map), 'User interface');
 
   @override
   Widget build(BuildContext context) {

--- a/packages/google_maps_flutter/example/lib/marker_icons.dart
+++ b/packages/google_maps_flutter/example/lib/marker_icons.dart
@@ -15,8 +15,8 @@ import 'custom_marker_icon.dart';
 import 'page.dart';
 
 class MarkerIconsPage extends GoogleMapExampleAppPage {
-  const MarkerIconsPage({Key? key})
-      : super(const Icon(Icons.image), 'Marker icons', key: key);
+  const MarkerIconsPage({super.key})
+      : super(const Icon(Icons.image), 'Marker icons');
 
   @override
   Widget build(BuildContext context) {

--- a/packages/google_maps_flutter/example/lib/move_camera.dart
+++ b/packages/google_maps_flutter/example/lib/move_camera.dart
@@ -10,8 +10,8 @@ import 'package:google_maps_flutter/google_maps_flutter.dart';
 import 'page.dart';
 
 class MoveCameraPage extends GoogleMapExampleAppPage {
-  const MoveCameraPage({Key? key})
-      : super(const Icon(Icons.map), 'Camera control', key: key);
+  const MoveCameraPage({super.key})
+      : super(const Icon(Icons.map), 'Camera control');
 
   @override
   Widget build(BuildContext context) {

--- a/packages/google_maps_flutter/example/lib/padding.dart
+++ b/packages/google_maps_flutter/example/lib/padding.dart
@@ -9,8 +9,8 @@ import 'package:google_maps_flutter/google_maps_flutter.dart';
 import 'page.dart';
 
 class PaddingPage extends GoogleMapExampleAppPage {
-  const PaddingPage({Key? key})
-      : super(const Icon(Icons.map), 'Add padding to the map', key: key);
+  const PaddingPage({super.key})
+      : super(const Icon(Icons.map), 'Add padding to the map');
 
   @override
   Widget build(BuildContext context) {

--- a/packages/google_maps_flutter/example/lib/place_circle.dart
+++ b/packages/google_maps_flutter/example/lib/place_circle.dart
@@ -10,8 +10,8 @@ import 'package:google_maps_flutter/google_maps_flutter.dart';
 import 'page.dart';
 
 class PlaceCirclePage extends GoogleMapExampleAppPage {
-  const PlaceCirclePage({Key? key})
-      : super(const Icon(Icons.linear_scale), 'Place circle', key: key);
+  const PlaceCirclePage({super.key})
+      : super(const Icon(Icons.linear_scale), 'Place circle');
 
   @override
   Widget build(BuildContext context) {

--- a/packages/google_maps_flutter/example/lib/place_marker.dart
+++ b/packages/google_maps_flutter/example/lib/place_marker.dart
@@ -15,8 +15,8 @@ import 'custom_marker_icon.dart';
 import 'page.dart';
 
 class PlaceMarkerPage extends GoogleMapExampleAppPage {
-  const PlaceMarkerPage({Key? key})
-      : super(const Icon(Icons.place), 'Place marker', key: key);
+  const PlaceMarkerPage({super.key})
+      : super(const Icon(Icons.place), 'Place marker');
 
   @override
   Widget build(BuildContext context) {

--- a/packages/google_maps_flutter/example/lib/place_polygon.dart
+++ b/packages/google_maps_flutter/example/lib/place_polygon.dart
@@ -10,8 +10,8 @@ import 'package:google_maps_flutter/google_maps_flutter.dart';
 import 'page.dart';
 
 class PlacePolygonPage extends GoogleMapExampleAppPage {
-  const PlacePolygonPage({Key? key})
-      : super(const Icon(Icons.linear_scale), 'Place polygon', key: key);
+  const PlacePolygonPage({super.key})
+      : super(const Icon(Icons.linear_scale), 'Place polygon');
 
   @override
   Widget build(BuildContext context) {

--- a/packages/google_maps_flutter/example/lib/place_polyline.dart
+++ b/packages/google_maps_flutter/example/lib/place_polyline.dart
@@ -11,8 +11,8 @@ import 'package:google_maps_flutter/google_maps_flutter.dart';
 import 'page.dart';
 
 class PlacePolylinePage extends GoogleMapExampleAppPage {
-  const PlacePolylinePage({Key? key})
-      : super(const Icon(Icons.linear_scale), 'Place polyline', key: key);
+  const PlacePolylinePage({super.key})
+      : super(const Icon(Icons.linear_scale), 'Place polyline');
 
   @override
   Widget build(BuildContext context) {

--- a/packages/google_maps_flutter/example/lib/scrolling_map.dart
+++ b/packages/google_maps_flutter/example/lib/scrolling_map.dart
@@ -14,8 +14,8 @@ import 'page.dart';
 const LatLng _center = LatLng(32.080664, 34.9563837);
 
 class ScrollingMapPage extends GoogleMapExampleAppPage {
-  const ScrollingMapPage({Key? key})
-      : super(const Icon(Icons.map), 'Scrolling map', key: key);
+  const ScrollingMapPage({super.key})
+      : super(const Icon(Icons.map), 'Scrolling map');
 
   @override
   Widget build(BuildContext context) {

--- a/packages/google_maps_flutter/example/lib/snapshot.dart
+++ b/packages/google_maps_flutter/example/lib/snapshot.dart
@@ -17,11 +17,10 @@ const CameraPosition _kInitialPosition = CameraPosition(
 );
 
 class SnapshotPage extends GoogleMapExampleAppPage {
-  const SnapshotPage({Key? key})
+  const SnapshotPage({super.key})
       : super(
           const Icon(Icons.camera_alt),
           'Take a snapshot of the map',
-          key: key,
         );
 
   @override

--- a/packages/google_maps_flutter/example/lib/tile_overlay.dart
+++ b/packages/google_maps_flutter/example/lib/tile_overlay.dart
@@ -13,8 +13,8 @@ import 'package:google_maps_flutter/google_maps_flutter.dart';
 import 'page.dart';
 
 class TileOverlayPage extends GoogleMapExampleAppPage {
-  const TileOverlayPage({Key? key})
-      : super(const Icon(Icons.map), 'Tile overlay', key: key);
+  const TileOverlayPage({super.key})
+      : super(const Icon(Icons.map), 'Tile overlay');
 
   @override
   Widget build(BuildContext context) {

--- a/packages/network_info_plus/analysis_options.yaml
+++ b/packages/network_info_plus/analysis_options.yaml
@@ -1,1 +1,11 @@
 include: ../../analysis_options_plus.yaml
+
+analyzer:
+  exclude:
+    - 'build/**'
+    - 'android/**'
+    - 'ios/**'
+    - 'web/**'
+    - 'windows/**'
+    - 'macos/**'
+    - 'linux/**'

--- a/packages/package_info_plus/analysis_options.yaml
+++ b/packages/package_info_plus/analysis_options.yaml
@@ -1,1 +1,11 @@
 include: ../../analysis_options_plus.yaml
+
+analyzer:
+  exclude:
+    - 'build/**'
+    - 'android/**'
+    - 'ios/**'
+    - 'web/**'
+    - 'windows/**'
+    - 'macos/**'
+    - 'linux/**'

--- a/packages/permission_handler/analysis_options.yaml
+++ b/packages/permission_handler/analysis_options.yaml
@@ -1,5 +1,15 @@
 include: package:flutter_lints/flutter.yaml
 
+analyzer:
+  exclude:
+    - 'build/**'
+    - 'android/**'
+    - 'ios/**'
+    - 'web/**'
+    - 'windows/**'
+    - 'macos/**'
+    - 'linux/**'
+
 linter:
   rules:
     - public_member_api_docs

--- a/packages/sensors_plus/analysis_options.yaml
+++ b/packages/sensors_plus/analysis_options.yaml
@@ -1,1 +1,11 @@
 include: ../../analysis_options_plus.yaml
+
+analyzer:
+  exclude:
+    - 'build/**'
+    - 'android/**'
+    - 'ios/**'
+    - 'web/**'
+    - 'windows/**'
+    - 'macos/**'
+    - 'linux/**'

--- a/packages/sqflite/example/analysis_options.yaml
+++ b/packages/sqflite/example/analysis_options.yaml
@@ -15,6 +15,15 @@ analyzer:
     strict-casts: true
     strict-inference: true
 
+  exclude:
+    - 'build/**'
+    - 'android/**'
+    - 'ios/**'
+    - 'web/**'
+    - 'windows/**'
+    - 'macos/**'
+    - 'linux/**'
+
   errors:
     # treat missing required parameters as a warning (not a hint)
     missing_required_param: warning

--- a/packages/tizen_bundle/example/integration_test/tizen_bundle_test.dart
+++ b/packages/tizen_bundle/example/integration_test/tizen_bundle_test.dart
@@ -136,6 +136,7 @@ void main() {
       final Bundle bundle = Bundle();
       bundle['someKey'] = 'someValue';
       // The implementation accepts Object? key and returns null for null.
+      // ignore: collection_methods_unrelated_type
       expect(bundle[null], isNull);
     });
 
@@ -202,6 +203,7 @@ void main() {
     test('remove(null) is a no-op and does not throw', () async {
       final Bundle bundle = Bundle();
       bundle['key'] = 'value';
+      // ignore: collection_methods_unrelated_type
       expect(() => bundle.remove(null), returnsNormally);
       expect(bundle.length, 1);
     });

--- a/packages/tizen_rpc_port/example/client/analysis_options.yaml
+++ b/packages/tizen_rpc_port/example/client/analysis_options.yaml
@@ -1,6 +1,14 @@
 include: ../../../../analysis_options.yaml
 
 analyzer:
+  exclude:
+    - 'build/**'
+    - 'android/**'
+    - 'ios/**'
+    - 'web/**'
+    - 'windows/**'
+    - 'macos/**'
+    - 'linux/**'
 linter:
   rules:
     unawaited_futures: false

--- a/packages/tizen_rpc_port/example/server/analysis_options.yaml
+++ b/packages/tizen_rpc_port/example/server/analysis_options.yaml
@@ -1,6 +1,14 @@
 include: ../../../../analysis_options.yaml
 
 analyzer:
+  exclude:
+    - 'build/**'
+    - 'android/**'
+    - 'ios/**'
+    - 'web/**'
+    - 'windows/**'
+    - 'macos/**'
+    - 'linux/**'
 linter:
   rules:
     unawaited_futures: false

--- a/packages/wakelock_plus/analysis_options.yaml
+++ b/packages/wakelock_plus/analysis_options.yaml
@@ -1,5 +1,15 @@
 include: package:flutter_lints/flutter.yaml
 
+analyzer:
+  exclude:
+    - 'build/**'
+    - 'android/**'
+    - 'ios/**'
+    - 'web/**'
+    - 'windows/**'
+    - 'macos/**'
+    - 'linux/**'
+
 linter:
   rules:
     public_member_api_docs: true

--- a/tools/analysis_options.yaml
+++ b/tools/analysis_options.yaml
@@ -1,5 +1,15 @@
 include: ../analysis_options.yaml
 
+analyzer:
+  exclude:
+    - 'build/**'
+    - 'android/**'
+    - 'ios/**'
+    - 'web/**'
+    - 'windows/**'
+    - 'macos/**'
+    - 'linux/**'
+
 linter:
   rules:
     avoid_print: false


### PR DESCRIPTION
These CI failures started appearing after upgrading to the latest stable Flutter SDK, which now auto-migrates `analysis_options.yaml` on `pub get` and enforces stricter lint rules.

- Exclude build/platform dirs in analysis_options.yaml
- camera: await stopVideoRecording() in try block
- tizen_bundle: ignore false-positive collection_methods_unrelated_type
- google_maps_flutter: use super.key instead of Key? param
- flutter_inappwebview: fix print/const/super-param/mounted-check lint issues