### PR TITLE
Add an `implements` entry to federated platform packages

### DIFF
--- a/packages/audioplayers/CHANGELOG.md
+++ b/packages/audioplayers/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 3.1.7
+
+* Add an `implements` entry to the pubspec to improve discoverability on pub.dev.
+
 ## 3.1.6
 
 * Update analysis_options.yaml for Flutter 3.47.0.

--- a/packages/audioplayers/README.md
+++ b/packages/audioplayers/README.md
@@ -11,7 +11,7 @@ This package is not an _endorsed_ implementation of `audioplayers`. Therefore, y
 ```yaml
 dependencies:
   audioplayers: ^6.6.0
-  audioplayers_tizen: ^3.1.6
+  audioplayers_tizen: ^3.1.7
 
 ```
 

--- a/packages/audioplayers/pubspec.yaml
+++ b/packages/audioplayers/pubspec.yaml
@@ -2,7 +2,7 @@ name: audioplayers_tizen
 description: Tizen implementation of the audioplayers plugin.
 homepage: https://github.com/flutter-tizen/plugins
 repository: https://github.com/flutter-tizen/plugins/tree/main/packages/audioplayers
-version: 3.1.6
+version: 3.1.7
 
 environment:
   sdk: ^3.6.0
@@ -10,6 +10,7 @@ environment:
 
 flutter:
   plugin:
+    implements: audioplayers
     platforms:
       tizen:
         pluginClass: AudioplayersTizenPlugin

--- a/packages/connectivity_plus/CHANGELOG.md
+++ b/packages/connectivity_plus/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.3.2
+
+* Add an `implements` entry to the pubspec to improve discoverability on pub.dev.
+
 ## 1.3.1
 
 * Update analysis_options.yaml for Flutter 3.47.0.

--- a/packages/connectivity_plus/README.md
+++ b/packages/connectivity_plus/README.md
@@ -11,7 +11,7 @@ This package is not an _endorsed_ implementation of `connectivity_plus`. Therefo
 ```yaml
 dependencies:
   connectivity_plus: ^7.1.0
-  connectivity_plus_tizen: ^1.3.1
+  connectivity_plus_tizen: ^1.3.2
 ```
 
 Then you can import `connectivity_plus` in your Dart code:

--- a/packages/connectivity_plus/pubspec.yaml
+++ b/packages/connectivity_plus/pubspec.yaml
@@ -2,7 +2,7 @@ name: connectivity_plus_tizen
 description: Tizen implementation of the connectivity_plus plugin.
 homepage: https://github.com/flutter-tizen/plugins
 repository: https://github.com/flutter-tizen/plugins/tree/main/packages/connectivity_plus
-version: 1.3.1
+version: 1.3.2
 
 environment:
   sdk: ">=3.2.0 <4.0.0"
@@ -10,6 +10,7 @@ environment:
 
 flutter:
   plugin:
+    implements: connectivity_plus
     platforms:
       tizen:
         pluginClass: ConnectivityPlusTizenPlugin

--- a/packages/device_info_plus/CHANGELOG.md
+++ b/packages/device_info_plus/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.4.2
+
+* Add an `implements` entry to the pubspec to improve discoverability on pub.dev.
+
 ## 1.4.1
 
 * Update analysis_options.yaml for Flutter 3.47.0.

--- a/packages/device_info_plus/README.md
+++ b/packages/device_info_plus/README.md
@@ -10,7 +10,7 @@ Add `device_info_plus_tizen` as a dependency in your `pubspec.yaml` file.
 
 ```yaml
 dependencies:
-  device_info_plus_tizen: ^1.4.1
+  device_info_plus_tizen: ^1.4.2
 ```
 
 Then you can import `device_info_plus_tizen` in your Dart code.

--- a/packages/device_info_plus/pubspec.yaml
+++ b/packages/device_info_plus/pubspec.yaml
@@ -3,7 +3,7 @@ description: Flutter plugin providing detailed information about Tizen device
   (make, model, etc.) the app is running on.
 homepage: https://github.com/flutter-tizen/plugins
 repository: https://github.com/flutter-tizen/plugins/tree/main/packages/device_info_plus
-version: 1.4.1
+version: 1.4.2
 
 environment:
   sdk: ^3.7.0
@@ -11,6 +11,7 @@ environment:
 
 flutter:
   plugin:
+    implements: device_info_plus
     platforms:
       tizen:
         pluginClass: DeviceInfoPlusTizenPlugin

--- a/packages/firebase_core/CHANGELOG.md
+++ b/packages/firebase_core/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.1.3
+
+* Add an `implements` entry to the pubspec to improve discoverability on pub.dev.
+
 ## 0.1.2
 
 * Update the repository URL to use the `main` branch.

--- a/packages/firebase_core/README.md
+++ b/packages/firebase_core/README.md
@@ -11,7 +11,7 @@ This package is not an _endorsed_ implementation of `firebase_core`. Therefore, 
 ```yaml
 dependencies:
   firebase_core: ^2.4.0
-  firebase_core_tizen: ^0.1.2
+  firebase_core_tizen: ^0.1.3
 ```
 
 Then you can import `firebase_core` in your Dart code:

--- a/packages/firebase_core/pubspec.yaml
+++ b/packages/firebase_core/pubspec.yaml
@@ -2,7 +2,7 @@ name: firebase_core_tizen
 description: Tizen implementation of the firebase_core plugin.
 homepage: https://github.com/flutter-tizen/plugins
 repository: https://github.com/flutter-tizen/plugins/tree/main/packages/firebase_core
-version: 0.1.2
+version: 0.1.3
 
 environment:
   sdk: ">=3.1.0 <4.0.0"
@@ -16,6 +16,7 @@ dependencies:
 
 flutter:
   plugin:
+    implements: firebase_core
     platforms:
       tizen:
         dartPluginClass: FirebaseCore

--- a/packages/flutter_inappwebview/CHANGELOG.md
+++ b/packages/flutter_inappwebview/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.1.3
+
+* Add an `implements` entry to the pubspec to improve discoverability on pub.dev.
+
 ## 0.1.2
 
 * Update analysis_options.yaml for Flutter 3.47.0.

--- a/packages/flutter_inappwebview/README.md
+++ b/packages/flutter_inappwebview/README.md
@@ -26,7 +26,7 @@ Add the internet privilege to the app manifest:
 ```yaml
 dependencies:
   flutter_inappwebview: ^6.1.5
-  flutter_inappwebview_tizen: ^0.1.2
+  flutter_inappwebview_tizen: ^0.1.3
 ```
 
 ```dart

--- a/packages/flutter_inappwebview/pubspec.yaml
+++ b/packages/flutter_inappwebview/pubspec.yaml
@@ -2,7 +2,7 @@ name: flutter_inappwebview_tizen
 description: Tizen implementation of the flutter_inappwebview plugin.
 homepage: https://github.com/flutter-tizen/plugins
 repository: https://github.com/flutter-tizen/plugins/tree/main/packages/flutter_inappwebview
-version: 0.1.2
+version: 0.1.3
 
 environment:
   sdk: ">=3.8.0 <4.0.0"
@@ -10,6 +10,7 @@ environment:
 
 flutter:
   plugin:
+    implements: flutter_inappwebview
     platforms:
       tizen:
         pluginClass: FlutterInappwebviewTizenPlugin

--- a/packages/flutter_secure_storage/CHANGELOG.md
+++ b/packages/flutter_secure_storage/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.1.5
+
+* Add an `implements` entry to the pubspec to improve discoverability on pub.dev.
+
 ## 0.1.4
 
 * Update analysis_options.yaml for Flutter 3.47.0.

--- a/packages/flutter_secure_storage/README.md
+++ b/packages/flutter_secure_storage/README.md
@@ -11,7 +11,7 @@ This package is not an _endorsed_ implementation of `flutter_secure_storage`. Th
 ```yaml
 dependencies:
   flutter_secure_storage: ^10.0.0
-  flutter_secure_storage_tizen: ^0.1.4
+  flutter_secure_storage_tizen: ^0.1.5
 ```
 
 Then you can import `flutter_secure_storage` in your Dart code:

--- a/packages/flutter_secure_storage/pubspec.yaml
+++ b/packages/flutter_secure_storage/pubspec.yaml
@@ -2,7 +2,7 @@ name: flutter_secure_storage_tizen
 description: Tizen implementation of the flutter_secure_storage plugin.
 homepage: https://github.com/flutter-tizen/plugins
 repository: https://github.com/flutter-tizen/plugins/tree/main/packages/flutter_secure_storage
-version: 0.1.4
+version: 0.1.5
 
 environment:
   sdk: ^3.6.0
@@ -10,6 +10,7 @@ environment:
 
 flutter:
   plugin:
+    implements: flutter_secure_storage
     platforms:
       tizen:
         pluginClass: FlutterSecureStorageTizenPlugin

--- a/packages/geolocator/CHANGELOG.md
+++ b/packages/geolocator/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.0.10
+
+* Add an `implements` entry to the pubspec to improve discoverability on pub.dev.
+
 ## 1.0.9
 
 * Update analysis_options.yaml for Flutter 3.47.0.

--- a/packages/geolocator/README.md
+++ b/packages/geolocator/README.md
@@ -11,7 +11,7 @@ The Tizen implementation of [`geolocator`](https://pub.dev/packages/geolocator).
  ```yaml
 dependencies:
   geolocator: ^8.0.0
-  geolocator_tizen: ^1.0.9
+  geolocator_tizen: ^1.0.10
 ```
 
 Then you can import `geolocator` in your Dart code:

--- a/packages/geolocator/pubspec.yaml
+++ b/packages/geolocator/pubspec.yaml
@@ -2,7 +2,7 @@ name: geolocator_tizen
 description: Tizen implementation of the geolocator plugin.
 homepage: https://github.com/flutter-tizen/plugins
 repository: https://github.com/flutter-tizen/plugins/tree/main/packages/geolocator
-version: 1.0.9
+version: 1.0.10
 
 environment:
   sdk: ">=3.1.0 <4.0.0"
@@ -10,6 +10,7 @@ environment:
 
 flutter:
   plugin:
+    implements: geolocator
     platforms:
       tizen:
         pluginClass: GeolocatorTizenPlugin

--- a/packages/google_maps_flutter/CHANGELOG.md
+++ b/packages/google_maps_flutter/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.2.2
+
+* Add an `implements` entry to the pubspec to improve discoverability on pub.dev.
+
 ## 0.2.1
 
 * Update the repository URL to use the `main` branch.

--- a/packages/google_maps_flutter/README.md
+++ b/packages/google_maps_flutter/README.md
@@ -21,7 +21,7 @@ This package is not an _endorsed_ implementation of `google_maps_flutter`. There
 ```yaml
 dependencies:
   google_maps_flutter: ^2.16.0
-  google_maps_flutter_tizen: ^0.2.1
+  google_maps_flutter_tizen: ^0.2.2
 ```
 
 For detailed usage, see https://pub.dev/packages/google_maps_flutter#sample-usage.

--- a/packages/google_maps_flutter/pubspec.yaml
+++ b/packages/google_maps_flutter/pubspec.yaml
@@ -2,7 +2,7 @@ name: google_maps_flutter_tizen
 description: Tizen implementation of the google_maps_flutter plugin.
 homepage: https://github.com/flutter-tizen/plugins
 repository: https://github.com/flutter-tizen/plugins/tree/main/packages/google_maps_flutter
-version: 0.2.1
+version: 0.2.2
 
 environment:
   sdk: ^3.8.0
@@ -10,6 +10,7 @@ environment:
 
 flutter:
   plugin:
+    implements: google_maps_flutter
     platforms:
       tizen:
         dartPluginClass: GoogleMapsPlugin

--- a/packages/google_sign_in/CHANGELOG.md
+++ b/packages/google_sign_in/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.2.2
+
+* Add an `implements` entry to the pubspec to improve discoverability on pub.dev.
+
 ## 0.2.1
 
 * Update integration tests.

--- a/packages/google_sign_in/README.md
+++ b/packages/google_sign_in/README.md
@@ -11,7 +11,7 @@ This package is not an _endorsed_ implementation of `google_sign_in`. Therefore,
 ```yaml
 dependencies:
   google_sign_in: ^7.2.0
-  google_sign_in_tizen: ^0.2.1
+  google_sign_in_tizen: ^0.2.2
 ```
 
 For detailed usage on how to use `google_sign_in`, see https://pub.dev/packages/google_sign_in#usage.

--- a/packages/google_sign_in/pubspec.yaml
+++ b/packages/google_sign_in/pubspec.yaml
@@ -2,7 +2,7 @@ name: google_sign_in_tizen
 description: Tizen implementation of the google_sign_in plugin.
 homepage: https://github.com/flutter-tizen/plugins
 repository: https://github.com/flutter-tizen/plugins/tree/main/packages/google_sign_in
-version: 0.2.1
+version: 0.2.2
 
 environment:
   sdk: ">=3.7.0 <4.0.0"
@@ -10,6 +10,7 @@ environment:
 
 flutter:
   plugin:
+    implements: google_sign_in
     platforms:
       tizen:
         dartPluginClass: GoogleSignInTizen

--- a/packages/in_app_purchase/CHANGELOG.md
+++ b/packages/in_app_purchase/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.1.7
+
+* Add an `implements` entry to the pubspec to improve discoverability on pub.dev.
+
 ## 0.1.6
 
 * Update integration tests.

--- a/packages/in_app_purchase/README.md
+++ b/packages/in_app_purchase/README.md
@@ -35,7 +35,7 @@ This package is not an _endorsed_ implementation of `in_app_purchase`. Therefore
 ```yaml
 dependencies:
   in_app_purchase: ^3.2.3
-  in_app_purchase_tizen: ^0.1.6
+  in_app_purchase_tizen: ^0.1.7
 ```
 
 Then you can import `in_app_purchase` and `in_app_purchase_tizen` in your Dart code:

--- a/packages/in_app_purchase/pubspec.yaml
+++ b/packages/in_app_purchase/pubspec.yaml
@@ -2,7 +2,7 @@ name: in_app_purchase_tizen
 description: Tizen implementation of the in_app_purchase plugin for Samsung Smart TV.
 homepage: https://github.com/flutter-tizen/plugins
 repository: https://github.com/flutter-tizen/plugins/tree/main/packages/in_app_purchase
-version: 0.1.6
+version: 0.1.7
 
 environment:
   sdk: ^3.5.0
@@ -10,6 +10,7 @@ environment:
 
 flutter:
   plugin:
+    implements: in_app_purchase
     platforms:
       tizen:
         pluginClass: InAppPurchaseTizenPlugin

--- a/packages/network_info_plus/CHANGELOG.md
+++ b/packages/network_info_plus/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.1.8
+
+* Add an `implements` entry to the pubspec to improve discoverability on pub.dev.
+
 ## 1.1.7
 
 * Update analysis_options.yaml for Flutter 3.47.0.

--- a/packages/network_info_plus/README.md
+++ b/packages/network_info_plus/README.md
@@ -11,7 +11,7 @@ This package is not an _endorsed_ implementation of `network_info_plus`. Therefo
 ```yaml
 dependencies:
   network_info_plus: ^7.0.0
-  network_info_plus_tizen: ^1.1.7
+  network_info_plus_tizen: ^1.1.8
 ```
 
 Then you can import `network_info_plus` in your Dart code:

--- a/packages/network_info_plus/pubspec.yaml
+++ b/packages/network_info_plus/pubspec.yaml
@@ -2,7 +2,7 @@ name: network_info_plus_tizen
 description: Tizen implementation of the network_info_plus plugin
 homepage: https://github.com/flutter-tizen/plugins
 repository: https://github.com/flutter-tizen/plugins/tree/main/packages/network_info_plus
-version: 1.1.7
+version: 1.1.8
 
 environment:
   sdk: ^3.6.0
@@ -10,6 +10,7 @@ environment:
 
 flutter:
   plugin:
+    implements: network_info_plus
     platforms:
       tizen:
         pluginClass: NetworkInfoPlusTizenPlugin

--- a/packages/package_info_plus/CHANGELOG.md
+++ b/packages/package_info_plus/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.1.2
+
+* Add an `implements` entry to the pubspec to improve discoverability on pub.dev.
+
 ## 1.1.1
 
 * Update analysis_options.yaml for Flutter 3.47.0.

--- a/packages/package_info_plus/README.md
+++ b/packages/package_info_plus/README.md
@@ -11,7 +11,7 @@ This package is not an _endorsed_ implementation of `package_info_plus`. Therefo
 ```yaml
 dependencies:
   package_info_plus: ^9.0.1
-  package_info_plus_tizen: ^1.1.1
+  package_info_plus_tizen: ^1.1.2
 ```
 
 Then you can import `package_info_plus` in your Dart code.

--- a/packages/package_info_plus/pubspec.yaml
+++ b/packages/package_info_plus/pubspec.yaml
@@ -2,7 +2,7 @@ name: package_info_plus_tizen
 description: Tizen implementation of the package_info_plus plugin.
 homepage: https://github.com/flutter-tizen/plugins
 repository: https://github.com/flutter-tizen/plugins/tree/main/packages/package_info_plus
-version: 1.1.1
+version: 1.1.2
 
 environment:
   sdk: ">=3.3.0 <4.0.0"
@@ -10,6 +10,7 @@ environment:
 
 flutter:
   plugin:
+    implements: package_info_plus
     platforms:
       tizen:
         pluginClass: PackageInfoPlusTizenPlugin

--- a/packages/path_provider/CHANGELOG.md
+++ b/packages/path_provider/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.3.2
+
+* Add an `implements` entry to the pubspec to improve discoverability on pub.dev.
+
 ## 2.3.1
 
 * Update integration tests.

--- a/packages/path_provider/README.md
+++ b/packages/path_provider/README.md
@@ -11,7 +11,7 @@ This package is not an _endorsed_ implementation of `path_provider`. Therefore, 
 ```yaml
 dependencies:
   path_provider: ^2.1.5
-  path_provider_tizen: ^2.3.1
+  path_provider_tizen: ^2.3.2
 ```
 
 Then you can import `path_provider` in your Dart code:

--- a/packages/path_provider/pubspec.yaml
+++ b/packages/path_provider/pubspec.yaml
@@ -2,7 +2,7 @@ name: path_provider_tizen
 description: Tizen implementation of the path_provider plugin.
 homepage: https://github.com/flutter-tizen/plugins
 repository: https://github.com/flutter-tizen/plugins/tree/main/packages/path_provider
-version: 2.3.1
+version: 2.3.2
 
 environment:
   sdk: ^3.3.0
@@ -10,6 +10,7 @@ environment:
 
 flutter:
   plugin:
+    implements: path_provider
     platforms:
       tizen:
         dartPluginClass: PathProviderPlugin

--- a/packages/permission_handler/CHANGELOG.md
+++ b/packages/permission_handler/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.4.6
+
+* Add an `implements` entry to the pubspec to improve discoverability on pub.dev.
+
 ## 1.4.5
 
 * Update analysis_options.yaml for Flutter 3.47.0.

--- a/packages/permission_handler/README.md
+++ b/packages/permission_handler/README.md
@@ -21,7 +21,7 @@ You can use this plugin to ask the user for runtime permissions if your app perf
    ```yaml
    dependencies:
      permission_handler: ^12.0.1
-     permission_handler_tizen: ^1.4.5
+     permission_handler_tizen: ^1.4.6
    ```
 
    Then you can import `permission_handler` in your Dart code:

--- a/packages/permission_handler/pubspec.yaml
+++ b/packages/permission_handler/pubspec.yaml
@@ -2,7 +2,7 @@ name: permission_handler_tizen
 description: Tizen implementation of the permission_handler plugin.
 homepage: https://github.com/flutter-tizen/plugins
 repository: https://github.com/flutter-tizen/plugins/tree/main/packages/permission_handler
-version: 1.4.5
+version: 1.4.6
 
 environment:
   sdk: ^3.5.0
@@ -10,6 +10,7 @@ environment:
 
 flutter:
   plugin:
+    implements: permission_handler
     platforms:
       tizen:
         pluginClass: PermissionHandlerTizenPlugin

--- a/packages/shared_preferences/CHANGELOG.md
+++ b/packages/shared_preferences/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.3.5
+
+* Add an `implements` entry to the pubspec to improve discoverability on pub.dev.
+
 ## 2.3.4
 
 * Update the repository URL to use the `main` branch.

--- a/packages/shared_preferences/README.md
+++ b/packages/shared_preferences/README.md
@@ -11,7 +11,7 @@ This package is not an _endorsed_ implementation of `shared_preferences`. Theref
 ```yaml
 dependencies:
   shared_preferences: ^2.5.5
-  shared_preferences_tizen: ^2.3.4
+  shared_preferences_tizen: ^2.3.5
 ```
 
 Then you can import `shared_preferences` in your Dart code:

--- a/packages/shared_preferences/pubspec.yaml
+++ b/packages/shared_preferences/pubspec.yaml
@@ -2,7 +2,7 @@ name: shared_preferences_tizen
 description: Tizen implementation of the shared_preferences plugin.
 homepage: https://github.com/flutter-tizen/plugins
 repository: https://github.com/flutter-tizen/plugins/tree/main/packages/shared_preferences
-version: 2.3.4
+version: 2.3.5
 
 environment:
   sdk: ^3.6.0
@@ -10,6 +10,7 @@ environment:
 
 flutter:
   plugin:
+    implements: shared_preferences
     platforms:
       tizen:
         dartPluginClass: SharedPreferencesPlugin

--- a/packages/url_launcher/CHANGELOG.md
+++ b/packages/url_launcher/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.1.7
+
+* Add an `implements` entry to the pubspec to improve discoverability on pub.dev.
+
 ## 2.1.6
 
 * Update integration tests.

--- a/packages/url_launcher/README.md
+++ b/packages/url_launcher/README.md
@@ -11,7 +11,7 @@ This package is not an _endorsed_ implementation of `url_launcher`. Therefore, y
 ```yaml
 dependencies:
   url_launcher: ^6.3.2
-  url_launcher_tizen: ^2.1.6
+  url_launcher_tizen: ^2.1.7
 ```
 
 Then you can import `url_launcher` in your Dart code:

--- a/packages/url_launcher/pubspec.yaml
+++ b/packages/url_launcher/pubspec.yaml
@@ -2,7 +2,7 @@ name: url_launcher_tizen
 description: Tizen implementation of the url_launcher plugin.
 homepage: https://github.com/flutter-tizen/plugins
 repository: https://github.com/flutter-tizen/plugins/tree/main/packages/url_launcher
-version: 2.1.6
+version: 2.1.7
 
 environment:
   sdk: ^3.6.0
@@ -10,6 +10,7 @@ environment:
 
 flutter:
   plugin:
+    implements: url_launcher
     platforms:
       tizen:
         dartPluginClass: UrlLauncherPlugin

--- a/packages/video_player/CHANGELOG.md
+++ b/packages/video_player/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.5.14
+
+* Add an `implements` entry to the pubspec to improve discoverability on pub.dev.
+
 ## 2.5.13
 
 * Update integration tests.

--- a/packages/video_player/README.md
+++ b/packages/video_player/README.md
@@ -15,7 +15,7 @@ This package is not an _endorsed_ implementation of `video_player`. Therefore, y
 ```yaml
 dependencies:
   video_player: ^2.11.1
-  video_player_tizen: ^2.5.13
+  video_player_tizen: ^2.5.14
 ```
 
 Then you can import `video_player` in your Dart code:

--- a/packages/video_player/pubspec.yaml
+++ b/packages/video_player/pubspec.yaml
@@ -2,7 +2,7 @@ name: video_player_tizen
 description: Tizen implementation of the video_player plugin.
 homepage: https://github.com/flutter-tizen/plugins
 repository: https://github.com/flutter-tizen/plugins/tree/main/packages/video_player
-version: 2.5.13
+version: 2.5.14
 
 environment:
   sdk: ^3.7.0
@@ -10,6 +10,7 @@ environment:
 
 flutter:
   plugin:
+    implements: video_player
     platforms:
       tizen:
         pluginClass: VideoPlayerTizenPlugin

--- a/packages/wakelock_plus/CHANGELOG.md
+++ b/packages/wakelock_plus/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.1.3
+
+* Add an `implements` entry to the pubspec to improve discoverability on pub.dev.
+
 ## 2.1.2
 
 * Update analysis_options.yaml for Flutter 3.47.0.

--- a/packages/wakelock_plus/README.md
+++ b/packages/wakelock_plus/README.md
@@ -11,7 +11,7 @@ This package is not an _endorsed_ implementation of `wakelock_plus`. Therefore, 
 ```yaml
 dependencies:
   wakelock_plus: ^1.6.0
-  wakelock_plus_tizen: ^2.1.2
+  wakelock_plus_tizen: ^2.1.3
 ```
 
 Then you can import `wakelock_plus` in your Dart code:

--- a/packages/wakelock_plus/pubspec.yaml
+++ b/packages/wakelock_plus/pubspec.yaml
@@ -2,7 +2,7 @@ name: wakelock_plus_tizen
 description: Tizen implementation of the wakelock_plus plugin.
 homepage: https://github.com/flutter-tizen/plugins
 repository: https://github.com/flutter-tizen/plugins/tree/main/packages/wakelock_plus
-version: 2.1.2
+version: 2.1.3
 
 environment:
   sdk: ">=3.11.0 <4.0.0"
@@ -10,6 +10,7 @@ environment:
 
 flutter:
   plugin:
+    implements: wakelock_plus
     platforms:
       tizen:
         pluginClass: WakelockPlusTizenPlugin

--- a/packages/webview_flutter/CHANGELOG.md
+++ b/packages/webview_flutter/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.10.3
+
+* Add an `implements` entry to the pubspec to improve discoverability on pub.dev.
+
 ## 0.10.2
 
 * Update the repository URL to use the `main` branch.

--- a/packages/webview_flutter/README.md
+++ b/packages/webview_flutter/README.md
@@ -23,7 +23,7 @@ This package is not an _endorsed_ implementation of `webview_flutter`. Therefore
 ```yaml
 dependencies:
   webview_flutter: ^4.13.1
-  webview_flutter_tizen: ^0.10.2
+  webview_flutter_tizen: ^0.10.3
 ```
 
 ## Example

--- a/packages/webview_flutter/pubspec.yaml
+++ b/packages/webview_flutter/pubspec.yaml
@@ -2,7 +2,7 @@ name: webview_flutter_tizen
 description: Tizen implementation of the webview_flutter plugin.
 homepage: https://github.com/flutter-tizen/plugins
 repository: https://github.com/flutter-tizen/plugins/tree/main/packages/webview_flutter
-version: 0.10.2
+version: 0.10.3
 
 environment:
   sdk: ^3.8.0
@@ -10,6 +10,7 @@ environment:
 
 flutter:
   plugin:
+    implements: webview_flutter
     platforms:
       tizen:
         pluginClass: WebviewFlutterTizenPlugin

--- a/packages/webview_flutter_lwe/CHANGELOG.md
+++ b/packages/webview_flutter_lwe/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.5.5
+
+* Add an `implements` entry to the pubspec to improve discoverability on pub.dev.
+
 ## 0.5.4
 
 * Update the repository URL to use the `main` branch.

--- a/packages/webview_flutter_lwe/README.md
+++ b/packages/webview_flutter_lwe/README.md
@@ -21,7 +21,7 @@ This package is not an _endorsed_ implementation of `webview_flutter`. Therefore
 ```yaml
 dependencies:
   webview_flutter: ^4.13.1
-  webview_flutter_lwe: ^0.5.4
+  webview_flutter_lwe: ^0.5.5
 ```
 
 ## Example

--- a/packages/webview_flutter_lwe/pubspec.yaml
+++ b/packages/webview_flutter_lwe/pubspec.yaml
@@ -2,7 +2,7 @@ name: webview_flutter_lwe
 description: Tizen implementation of the webview_flutter plugin backed by Lightweight Web Engine.
 homepage: https://github.com/flutter-tizen/plugins
 repository: https://github.com/flutter-tizen/plugins/tree/main/packages/webview_flutter_lwe
-version: 0.5.4
+version: 0.5.5
 
 environment:
   sdk: ^3.8.0
@@ -10,6 +10,7 @@ environment:
 
 flutter:
   plugin:
+    implements: webview_flutter
     platforms:
       tizen:
         pluginClass: WebviewFlutterLwePlugin


### PR DESCRIPTION
Declare the app-facing package in each Tizen platform package's pubspec so that pub.dev lists them under "Packages that implement" (the implements-federated-plugin search filter).

Issue: https://github.com/flutter-tizen/plugins/issues/1093