### PR TITLE
[in_app_purchase_tizen] Upgrade from 3.2.3 to 3.3.0

### DIFF
--- a/packages/in_app_purchase/CHANGELOG.md
+++ b/packages/in_app_purchase/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.1.8
+
+* Update in_app_purchase to 3.3.0
+* Updates minimum supported SDK version to Flutter 3.38/Dart 3.10.0.
+
 ## 0.1.7
 
 * Add an `implements` entry to the pubspec to improve discoverability on pub.dev.

--- a/packages/in_app_purchase/README.md
+++ b/packages/in_app_purchase/README.md
@@ -34,8 +34,8 @@ This package is not an _endorsed_ implementation of `in_app_purchase`. Therefore
 
 ```yaml
 dependencies:
-  in_app_purchase: ^3.2.3
-  in_app_purchase_tizen: ^0.1.7
+  in_app_purchase: ^3.3.0
+  in_app_purchase_tizen: ^0.1.8
 ```
 
 Then you can import `in_app_purchase` and `in_app_purchase_tizen` in your Dart code:

--- a/packages/in_app_purchase/example/lib/main.dart
+++ b/packages/in_app_purchase/example/lib/main.dart
@@ -85,8 +85,8 @@ class _MyAppState extends State<_MyApp> {
 
     // The `identifiers` argument is not used on Tizen.
     // Use `InAppPurchaseTizenPlatformAddition.setRequestParameters` instead.
-    final ProductDetailsResponse productDetailResponse =
-        await _inAppPurchase.queryProductDetails(<String>{});
+    final ProductDetailsResponse productDetailResponse = await _inAppPurchase
+        .queryProductDetails(<String>{});
     if (productDetailResponse.error != null) {
       setState(() {
         _queryProductError = productDetailResponse.error!.message;
@@ -173,8 +173,9 @@ class _MyAppState extends State<_MyApp> {
     final Widget storeHeader = ListTile(
       leading: Icon(
         _isAvailable ? Icons.check : Icons.block,
-        color:
-            _isAvailable ? Colors.green : ThemeData.light().colorScheme.error,
+        color: _isAvailable
+            ? Colors.green
+            : ThemeData.light().colorScheme.error,
       ),
       title: Text(
         'The store is ${_isAvailable ? 'available' : 'unavailable'}.',

--- a/packages/in_app_purchase/example/pubspec.yaml
+++ b/packages/in_app_purchase/example/pubspec.yaml
@@ -3,13 +3,13 @@ description: Demonstrates how to use the in_app_purchase_tizen plugin.
 publish_to: "none"
 
 environment:
-  sdk: ^3.5.0
-  flutter: ">=3.24.0"
+  sdk: ^3.10.0
+  flutter: ">=3.38.0"
 
 dependencies:
   flutter:
     sdk: flutter
-  in_app_purchase: ^3.2.3
+  in_app_purchase: ^3.3.0
   in_app_purchase_tizen:
     path: ../
 

--- a/packages/in_app_purchase/lib/src/billing_manager.dart
+++ b/packages/in_app_purchase/lib/src/billing_manager.dart
@@ -20,7 +20,7 @@ import 'messages.g.dart';
 class BillingManager {
   /// Creates a billing manager.
   BillingManager({@visibleForTesting InAppPurchaseApi? hostApi})
-      : _hostApi = hostApi ?? InAppPurchaseApi();
+    : _hostApi = hostApi ?? InAppPurchaseApi();
 
   late RequestParameters _requestParameters;
 
@@ -391,19 +391,19 @@ class SamsungCheckoutPurchaseDetails extends PurchaseDetails {
   ) {
     final SamsungCheckoutPurchaseDetails purchaseDetails =
         SamsungCheckoutPurchaseDetails(
-      purchaseID: invoiceDetails.invoiceId,
-      productID: invoiceDetails.itemId,
-      verificationData: PurchaseVerificationData(
-        localVerificationData: invoiceDetails.invoiceId,
-        serverVerificationData: invoiceDetails.invoiceId,
-        source: kIAPSource,
-      ),
-      transactionDate: invoiceDetails.orderTime,
-      status: const PurchaseStateConverter().toPurchaseStatus(
-        invoiceDetails.cancelStatus,
-      ),
-      invoiceDetails: invoiceDetails,
-    );
+          purchaseID: invoiceDetails.invoiceId,
+          productID: invoiceDetails.itemId,
+          verificationData: PurchaseVerificationData(
+            localVerificationData: invoiceDetails.invoiceId,
+            serverVerificationData: invoiceDetails.invoiceId,
+            source: kIAPSource,
+          ),
+          transactionDate: invoiceDetails.orderTime,
+          status: const PurchaseStateConverter().toPurchaseStatus(
+            invoiceDetails.cancelStatus,
+          ),
+          invoiceDetails: invoiceDetails,
+        );
 
     if (purchaseDetails.status == PurchaseStatus.error) {
       purchaseDetails.error = IAPError(

--- a/packages/in_app_purchase/lib/src/in_app_purchase_tizen_platform.dart
+++ b/packages/in_app_purchase/lib/src/in_app_purchase_tizen_platform.dart
@@ -39,7 +39,7 @@ class InAppPurchaseTizenPlatform extends InAppPurchasePlatform {
   }
 
   static final StreamController<List<PurchaseDetails>>
-      _purchaseUpdatedController =
+  _purchaseUpdatedController =
       StreamController<List<PurchaseDetails>>.broadcast();
 
   @override
@@ -59,12 +59,12 @@ class InAppPurchaseTizenPlatform extends InAppPurchasePlatform {
 
   /// Converts integer to [ItemType].
   static ItemType _intToEnum(int number) => switch (number) {
-        1 => ItemType.consumable,
-        2 => ItemType.nonComsumabel,
-        3 => ItemType.limitedPeriod,
-        4 => ItemType.subscription,
-        _ => ItemType.none,
-      };
+    1 => ItemType.consumable,
+    2 => ItemType.nonComsumabel,
+    3 => ItemType.limitedPeriod,
+    4 => ItemType.subscription,
+    _ => ItemType.none,
+  };
 
   /// Converts Map<Object?, Object?>? to the list of [ItemDetails].
   List<ItemDetails> _getItemDetails(ProductsListApiResult response) {
@@ -130,17 +130,17 @@ class InAppPurchaseTizenPlatform extends InAppPurchasePlatform {
 
     final ProductDetailsResponse productDetailsResponse =
         ProductDetailsResponse(
-      productDetails: productDetailsList,
-      notFoundIDs: invalidMessage,
-      error: exception == null
-          ? null
-          : IAPError(
-              source: kIAPSource,
-              code: exception.code,
-              message: exception.message ?? '',
-              details: exception.details,
-            ),
-    );
+          productDetails: productDetailsList,
+          notFoundIDs: invalidMessage,
+          error: exception == null
+              ? null
+              : IAPError(
+                  source: kIAPSource,
+                  code: exception.code,
+                  message: exception.message ?? '',
+                  details: exception.details,
+                ),
+        );
     return productDetailsResponse;
   }
 
@@ -195,20 +195,22 @@ class InAppPurchaseTizenPlatform extends InAppPurchasePlatform {
       billingManager.requestPurchases(),
     ]);
 
-    final List<PurchaseDetails> pastPurchases =
-        responses.expand((GetUserPurchaseListAPIResult response) {
-      if (response.cpStatus == '100000') {
-        return _getInvoiceDetails(response);
-      } else {
-        return <InvoiceDetails>[];
-      }
-    }).map((InvoiceDetails purchaseWrapper) {
-      final SamsungCheckoutPurchaseDetails purchaseDetails =
-          SamsungCheckoutPurchaseDetails.fromPurchase(purchaseWrapper);
+    final List<PurchaseDetails> pastPurchases = responses
+        .expand((GetUserPurchaseListAPIResult response) {
+          if (response.cpStatus == '100000') {
+            return _getInvoiceDetails(response);
+          } else {
+            return <InvoiceDetails>[];
+          }
+        })
+        .map((InvoiceDetails purchaseWrapper) {
+          final SamsungCheckoutPurchaseDetails purchaseDetails =
+              SamsungCheckoutPurchaseDetails.fromPurchase(purchaseWrapper);
 
-      purchaseDetails.status = PurchaseStatus.restored;
-      return purchaseDetails;
-    }).toList();
+          purchaseDetails.status = PurchaseStatus.restored;
+          return purchaseDetails;
+        })
+        .toList();
     _purchaseUpdatedController.add(pastPurchases);
   }
 
@@ -229,33 +231,38 @@ class InAppPurchaseTizenPlatform extends InAppPurchasePlatform {
         billingManager
             .requestPurchases()
             .then((GetUserPurchaseListAPIResult responses) {
-          for (int i = 0; i < responses.invoiceDetails.length; i++) {
-            if (_getInvoiceDetails(responses)[i].invoiceId == invoiceId) {
-              final List<PurchaseDetails> purchases = <PurchaseDetails>[];
-              purchases.add(
-                PurchaseDetails(
-                  purchaseID: _getInvoiceDetails(responses)[i].invoiceId,
-                  productID: _getInvoiceDetails(responses)[i].itemId,
-                  verificationData: PurchaseVerificationData(
-                    localVerificationData:
-                        _getInvoiceDetails(responses)[i].invoiceId,
-                    serverVerificationData:
-                        _getInvoiceDetails(responses)[i].invoiceId,
-                    source: kIAPSource,
-                  ),
-                  transactionDate: _getInvoiceDetails(responses)[i].orderTime,
-                  status: const PurchaseStateConverter().toPurchaseStatus(
-                    _getInvoiceDetails(responses)[i].cancelStatus,
-                  ),
-                ),
-              );
+              for (int i = 0; i < responses.invoiceDetails.length; i++) {
+                if (_getInvoiceDetails(responses)[i].invoiceId == invoiceId) {
+                  final List<PurchaseDetails> purchases = <PurchaseDetails>[];
+                  purchases.add(
+                    PurchaseDetails(
+                      purchaseID: _getInvoiceDetails(responses)[i].invoiceId,
+                      productID: _getInvoiceDetails(responses)[i].itemId,
+                      verificationData: PurchaseVerificationData(
+                        localVerificationData: _getInvoiceDetails(
+                          responses,
+                        )[i].invoiceId,
+                        serverVerificationData: _getInvoiceDetails(
+                          responses,
+                        )[i].invoiceId,
+                        source: kIAPSource,
+                      ),
+                      transactionDate: _getInvoiceDetails(
+                        responses,
+                      )[i].orderTime,
+                      status: const PurchaseStateConverter().toPurchaseStatus(
+                        _getInvoiceDetails(responses)[i].cancelStatus,
+                      ),
+                    ),
+                  );
 
-              _purchaseUpdatedController.add(purchases);
-            }
-          }
-        }).catchError((Object error) {
-          _purchaseUpdatedController.addError(error);
-        }),
+                  _purchaseUpdatedController.add(purchases);
+                }
+              }
+            })
+            .catchError((Object error) {
+              _purchaseUpdatedController.addError(error);
+            }),
       );
 
       return true;

--- a/packages/in_app_purchase/lib/src/messages.g.dart
+++ b/packages/in_app_purchase/lib/src/messages.g.dart
@@ -58,8 +58,8 @@ class ProductsListApiResult {
       cpResult: result[1] as String?,
       totalCount: result[2]! as int,
       checkValue: result[3]! as String,
-      itemDetails:
-          (result[4] as List<Object?>?)!.cast<Map<Object?, Object?>?>(),
+      itemDetails: (result[4] as List<Object?>?)!
+          .cast<Map<Object?, Object?>?>(),
     );
   }
 }
@@ -112,8 +112,8 @@ class GetUserPurchaseListAPIResult {
       cpResult: result[1] as String?,
       totalCount: result[2]! as int,
       checkValue: result[3]! as String,
-      invoiceDetails:
-          (result[4] as List<Object?>?)!.cast<Map<Object?, Object?>?>(),
+      invoiceDetails: (result[4] as List<Object?>?)!
+          .cast<Map<Object?, Object?>?>(),
     );
   }
 }
@@ -478,9 +478,10 @@ class InAppPurchaseApi {
   InAppPurchaseApi({
     BinaryMessenger? binaryMessenger,
     String messageChannelSuffix = '',
-  })  : pigeonVar_binaryMessenger = binaryMessenger,
-        pigeonVar_messageChannelSuffix =
-            messageChannelSuffix.isNotEmpty ? '.$messageChannelSuffix' : '';
+  }) : pigeonVar_binaryMessenger = binaryMessenger,
+       pigeonVar_messageChannelSuffix = messageChannelSuffix.isNotEmpty
+           ? '.$messageChannelSuffix'
+           : '';
   final BinaryMessenger? pigeonVar_binaryMessenger;
 
   static const MessageCodec<Object?> pigeonChannelCodec = _PigeonCodec();
@@ -493,10 +494,10 @@ class InAppPurchaseApi {
         'dev.flutter.pigeon.in_app_purchase_tizen.InAppPurchaseApi.getProductsList$pigeonVar_messageChannelSuffix';
     final BasicMessageChannel<Object?> pigeonVar_channel =
         BasicMessageChannel<Object?>(
-      pigeonVar_channelName,
-      pigeonChannelCodec,
-      binaryMessenger: pigeonVar_binaryMessenger,
-    );
+          pigeonVar_channelName,
+          pigeonChannelCodec,
+          binaryMessenger: pigeonVar_binaryMessenger,
+        );
     final List<Object?>? pigeonVar_replyList =
         await pigeonVar_channel.send(<Object?>[product]) as List<Object?>?;
     if (pigeonVar_replyList == null) {
@@ -525,10 +526,10 @@ class InAppPurchaseApi {
         'dev.flutter.pigeon.in_app_purchase_tizen.InAppPurchaseApi.getUserPurchaseList$pigeonVar_messageChannelSuffix';
     final BasicMessageChannel<Object?> pigeonVar_channel =
         BasicMessageChannel<Object?>(
-      pigeonVar_channelName,
-      pigeonChannelCodec,
-      binaryMessenger: pigeonVar_binaryMessenger,
-    );
+          pigeonVar_channelName,
+          pigeonChannelCodec,
+          binaryMessenger: pigeonVar_binaryMessenger,
+        );
     final List<Object?>? pigeonVar_replyList =
         await pigeonVar_channel.send(<Object?>[purchase]) as List<Object?>?;
     if (pigeonVar_replyList == null) {
@@ -556,10 +557,10 @@ class InAppPurchaseApi {
         'dev.flutter.pigeon.in_app_purchase_tizen.InAppPurchaseApi.buyItem$pigeonVar_messageChannelSuffix';
     final BasicMessageChannel<Object?> pigeonVar_channel =
         BasicMessageChannel<Object?>(
-      pigeonVar_channelName,
-      pigeonChannelCodec,
-      binaryMessenger: pigeonVar_binaryMessenger,
-    );
+          pigeonVar_channelName,
+          pigeonChannelCodec,
+          binaryMessenger: pigeonVar_binaryMessenger,
+        );
     final List<Object?>? pigeonVar_replyList =
         await pigeonVar_channel.send(<Object?>[buyInfo]) as List<Object?>?;
     if (pigeonVar_replyList == null) {
@@ -586,10 +587,10 @@ class InAppPurchaseApi {
         'dev.flutter.pigeon.in_app_purchase_tizen.InAppPurchaseApi.verifyInvoice$pigeonVar_messageChannelSuffix';
     final BasicMessageChannel<Object?> pigeonVar_channel =
         BasicMessageChannel<Object?>(
-      pigeonVar_channelName,
-      pigeonChannelCodec,
-      binaryMessenger: pigeonVar_binaryMessenger,
-    );
+          pigeonVar_channelName,
+          pigeonChannelCodec,
+          binaryMessenger: pigeonVar_binaryMessenger,
+        );
     final List<Object?>? pigeonVar_replyList =
         await pigeonVar_channel.send(<Object?>[invoice]) as List<Object?>?;
     if (pigeonVar_replyList == null) {
@@ -616,10 +617,10 @@ class InAppPurchaseApi {
         'dev.flutter.pigeon.in_app_purchase_tizen.InAppPurchaseApi.isServiceAvailable$pigeonVar_messageChannelSuffix';
     final BasicMessageChannel<Object?> pigeonVar_channel =
         BasicMessageChannel<Object?>(
-      pigeonVar_channelName,
-      pigeonChannelCodec,
-      binaryMessenger: pigeonVar_binaryMessenger,
-    );
+          pigeonVar_channelName,
+          pigeonChannelCodec,
+          binaryMessenger: pigeonVar_binaryMessenger,
+        );
     final List<Object?>? pigeonVar_replyList =
         await pigeonVar_channel.send(null) as List<Object?>?;
     if (pigeonVar_replyList == null) {
@@ -645,10 +646,10 @@ class InAppPurchaseApi {
         'dev.flutter.pigeon.in_app_purchase_tizen.InAppPurchaseApi.getCustomId$pigeonVar_messageChannelSuffix';
     final BasicMessageChannel<Object?> pigeonVar_channel =
         BasicMessageChannel<Object?>(
-      pigeonVar_channelName,
-      pigeonChannelCodec,
-      binaryMessenger: pigeonVar_binaryMessenger,
-    );
+          pigeonVar_channelName,
+          pigeonChannelCodec,
+          binaryMessenger: pigeonVar_binaryMessenger,
+        );
     final List<Object?>? pigeonVar_replyList =
         await pigeonVar_channel.send(null) as List<Object?>?;
     if (pigeonVar_replyList == null) {
@@ -674,10 +675,10 @@ class InAppPurchaseApi {
         'dev.flutter.pigeon.in_app_purchase_tizen.InAppPurchaseApi.getCountryCode$pigeonVar_messageChannelSuffix';
     final BasicMessageChannel<Object?> pigeonVar_channel =
         BasicMessageChannel<Object?>(
-      pigeonVar_channelName,
-      pigeonChannelCodec,
-      binaryMessenger: pigeonVar_binaryMessenger,
-    );
+          pigeonVar_channelName,
+          pigeonChannelCodec,
+          binaryMessenger: pigeonVar_binaryMessenger,
+        );
     final List<Object?>? pigeonVar_replyList =
         await pigeonVar_channel.send(null) as List<Object?>?;
     if (pigeonVar_replyList == null) {

--- a/packages/in_app_purchase/pigeons/messages.dart
+++ b/packages/in_app_purchase/pigeons/messages.dart
@@ -12,7 +12,6 @@ import 'package:pigeon/pigeon.dart';
     cppSourceOut: 'tizen/src/messages.cc',
   ),
 )
-
 /// Dart wrapper around [`ProductsListApiResult`] in (https://developer.samsung.com/smarttv/develop/api-references/samsung-product-api-references/billing-api.html).
 ///
 /// Defines a dictionary for product list data returned by the getProductsList API.

--- a/packages/in_app_purchase/pubspec.yaml
+++ b/packages/in_app_purchase/pubspec.yaml
@@ -2,11 +2,11 @@ name: in_app_purchase_tizen
 description: Tizen implementation of the in_app_purchase plugin for Samsung Smart TV.
 homepage: https://github.com/flutter-tizen/plugins
 repository: https://github.com/flutter-tizen/plugins/tree/main/packages/in_app_purchase
-version: 0.1.7
+version: 0.1.8
 
 environment:
-  sdk: ^3.5.0
-  flutter: ">=3.24.0"
+  sdk: ^3.10.0
+  flutter: ">=3.38.0"
 
 flutter:
   plugin:


### PR DESCRIPTION
Fix https://github.com/flutter-tizen/plugins/issues/1096
3.3.0 

- Updates in_app_purchase_android dependency to ^0.5.0.

3.2.4 

- Bump org.json:json from 20251224 to 20260522 in example.
- Updates minimum supported SDK version to Flutter 3.38/Dart 3.10.
- Updates README to reflect currently supported OS versions for the latest versions of the endorsed platform implementations.
- Applications built with older versions of Flutter will continue to use compatible versions of the platform implementations.
- Clarifies completePurchase usage and the consequences of unfinished transactions in the README and docstrings.