### PR TITLE
[device_info_plus] Add duid getter

### DIFF
--- a/packages/device_info_plus/CHANGELOG.md
+++ b/packages/device_info_plus/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 1.4.3
+
+* Add `DeviceInfoPluginTizen.duid` to retrieve the device's DUID (Device Unique ID).
+* Add 2 integration test cases.
+
 ## 1.4.2
 
 * Add an `implements` entry to the pubspec to improve discoverability on pub.dev.

--- a/packages/device_info_plus/README.md
+++ b/packages/device_info_plus/README.md
@@ -10,7 +10,7 @@ Add `device_info_plus_tizen` as a dependency in your `pubspec.yaml` file.
 
 ```yaml
 dependencies:
-  device_info_plus_tizen: ^1.4.2
+  device_info_plus_tizen: ^1.4.3
 ```
 
 Then you can import `device_info_plus_tizen` in your Dart code.

--- a/packages/device_info_plus/README.md
+++ b/packages/device_info_plus/README.md
@@ -26,31 +26,32 @@ String modelName = tizenInfo.modelName;
 
 ## Supported properties
 
-| Property | Feature or system key |
-|-|-|
-| `modelName` | `http://tizen.org/system/model_name` |
-| `cpuArch` | `http://tizen.org/feature/platform.core.cpu.arch` |
-| `nativeApiVersion` | `http://tizen.org/feature/platform.native.api.version` |
-| `platformVersion` | `http://tizen.org/feature/platform.version` |
-| `webApiVersion` | `http://tizen.org/feature/platform.web.api.version` |
-| `profile` | `http://tizen.org/feature/profile` |
-| `buildDate` | `http://tizen.org/system/build.date` |
-| `buildId` | `http://tizen.org/system/build.id` |
-| `buildString` | `http://tizen.org/system/build.string` |
-| `buildTime` | `http://tizen.org/system/build.time` |
-| `buildType` | `http://tizen.org/system/build.type` |
-| `buildVariant` | `http://tizen.org/system/build.variant` |
-| `buildRelease` | `http://tizen.org/system/build.release` |
-| `deviceType` | `http://tizen.org/system/device_type` |
-| `manufacturer` | `http://tizen.org/system/manufacturer` |
-| `platformName` | `http://tizen.org/system/platform.name` |
-| `platformProcessor` | `http://tizen.org/system/platform.processor` |
-| `tizenId` | `http://tizen.org/system/tizenid` |
-| `freeDiskSize` | `storage_get_internal_memory_size()` |
-| `totalDiskSize` | `storage_get_internal_memory_size()` |
-| `physicalRamSize` | `runtime_info_get_system_memory_info()` |
-| `availableRamSize` | `runtime_info_get_system_memory_info()` |
-| `screenWidth` | `http://tizen.org/feature/screen.width` |
-| `screenHeight` | `http://tizen.org/feature/screen.height` |
+| Property | Feature or system key | TV only |
+|-|-|-|
+| `modelName` | `http://tizen.org/system/model_name` | |
+| `cpuArch` | `http://tizen.org/feature/platform.core.cpu.arch` | |
+| `nativeApiVersion` | `http://tizen.org/feature/platform.native.api.version` | |
+| `platformVersion` | `http://tizen.org/feature/platform.version` | |
+| `webApiVersion` | `http://tizen.org/feature/platform.web.api.version` | |
+| `profile` | `http://tizen.org/feature/profile` | |
+| `buildDate` | `http://tizen.org/system/build.date` | |
+| `buildId` | `http://tizen.org/system/build.id` | |
+| `buildString` | `http://tizen.org/system/build.string` | |
+| `buildTime` | `http://tizen.org/system/build.time` | |
+| `buildType` | `http://tizen.org/system/build.type` | |
+| `buildVariant` | `http://tizen.org/system/build.variant` | |
+| `buildRelease` | `http://tizen.org/system/build.release` | |
+| `deviceType` | `http://tizen.org/system/device_type` | |
+| `manufacturer` | `http://tizen.org/system/manufacturer` | |
+| `platformName` | `http://tizen.org/system/platform.name` | |
+| `platformProcessor` | `http://tizen.org/system/platform.processor` | |
+| `tizenId` | `http://tizen.org/system/tizenid` | |
+| `freeDiskSize` | `storage_get_internal_memory_size()` | |
+| `totalDiskSize` | `storage_get_internal_memory_size()` | |
+| `physicalRamSize` | `runtime_info_get_system_memory_info()` | |
+| `availableRamSize` | `runtime_info_get_system_memory_info()` | |
+| `screenWidth` | `http://tizen.org/feature/screen.width` | |
+| `screenHeight` | `http://tizen.org/feature/screen.height` | |
+| `duid` | `db/comss/duid` (vconf) | ✅ |
 
 For descriptions of the `system_info` keys in the list, see https://docs.tizen.org/application/native/guides/device/system.

--- a/packages/device_info_plus/example/integration_test/device_info_plus_test.dart
+++ b/packages/device_info_plus/example/integration_test/device_info_plus_test.dart
@@ -85,6 +85,7 @@ void main() {
   }, skip: !Platform.isLinux);
 
   test('duid is consistent and cached across repeated calls', () async {
+    // Repeated calls on the same instance return the cached instance.
     final plugin1 = DeviceInfoPluginTizen();
     final first = await plugin1.duid;
     final second = await plugin1.duid;
@@ -93,6 +94,7 @@ void main() {
       expect(second, same(first));
     }
 
+    // A new instance triggers a fresh native call that must yield the same data.
     final plugin2 = DeviceInfoPluginTizen();
     final third = await plugin2.duid;
     expect(third, first);

--- a/packages/device_info_plus/example/integration_test/device_info_plus_test.dart
+++ b/packages/device_info_plus/example/integration_test/device_info_plus_test.dart
@@ -77,4 +77,25 @@ void main() {
     expect(rebuilt.screenWidth, tizenInfo.screenWidth);
     expect(rebuilt.totalDiskSize, tizenInfo.totalDiskSize);
   }, skip: !Platform.isLinux);
+
+  // Tizen-only: duid has no upstream counterpart in device_info_plus.
+  test('duid does not throw and is a nullable string', () async {
+    final deviceInfoPlugin = DeviceInfoPluginTizen();
+    final duid = await deviceInfoPlugin.duid;
+    expect(duid, anyOf(isNull, isA<String>()));
+  }, skip: !Platform.isLinux);
+
+  test('duid is consistent and cached across repeated calls', () async {
+    final plugin1 = DeviceInfoPluginTizen();
+    final first = await plugin1.duid;
+    final second = await plugin1.duid;
+    expect(second, first);
+    if (first != null) {
+      expect(second, same(first));
+    }
+
+    final plugin2 = DeviceInfoPluginTizen();
+    final third = await plugin2.duid;
+    expect(third, first);
+  }, skip: !Platform.isLinux);
 }

--- a/packages/device_info_plus/example/integration_test/device_info_plus_test.dart
+++ b/packages/device_info_plus/example/integration_test/device_info_plus_test.dart
@@ -79,10 +79,9 @@ void main() {
   }, skip: !Platform.isLinux);
 
   // Tizen-only: duid has no upstream counterpart in device_info_plus.
-  test('duid does not throw and is a nullable string', () async {
+  test('duid does not throw', () async {
     final deviceInfoPlugin = DeviceInfoPluginTizen();
-    final duid = await deviceInfoPlugin.duid;
-    expect(duid, anyOf(isNull, isA<String>()));
+    await deviceInfoPlugin.duid;
   }, skip: !Platform.isLinux);
 
   test('duid is consistent and cached across repeated calls', () async {

--- a/packages/device_info_plus/example/lib/main.dart
+++ b/packages/device_info_plus/example/lib/main.dart
@@ -44,6 +44,7 @@ class _MyAppState extends State<MyApp> {
 
     try {
       deviceData = _readTizenDeviceInfo(await deviceInfoPlugin.tizenInfo);
+      deviceData['duid'] = await deviceInfoPlugin.duid;
     } on PlatformException {
       deviceData = <String, dynamic>{
         'Error:': 'Failed to get platform version.',

--- a/packages/device_info_plus/lib/device_info_plus_tizen.dart
+++ b/packages/device_info_plus/lib/device_info_plus_tizen.dart
@@ -165,6 +165,11 @@ class _MethodChannelDeviceInfo {
       )).cast<String, dynamic>(),
     );
   }
+
+  /// The DUID (Device Unique ID) of this device.
+  Future<String?> getDuid() async {
+    return channel.invokeMethod<String>('getDuid');
+  }
 }
 
 /// Provides device and operating system information of a Tizen device.
@@ -183,4 +188,13 @@ class DeviceInfoPluginTizen {
   /// See: https://docs.tizen.org/application/native/guides/device/system
   Future<TizenDeviceInfo> get tizenInfo async =>
       _cachedTizenDeviceInfo ??= await _platform.tizenInfo();
+
+  /// This information does not change from call to call. Cache it.
+  String? _cachedDuid;
+
+  /// The DUID (Device Unique ID) that uniquely identifies this device.
+  ///
+  /// Returns `null` if the DUID is unavailable, for example because the
+  /// underlying `db/comss/duid` vconf key could not be read.
+  Future<String?> get duid async => _cachedDuid ??= await _platform.getDuid();
 }

--- a/packages/device_info_plus/lib/device_info_plus_tizen.dart
+++ b/packages/device_info_plus/lib/device_info_plus_tizen.dart
@@ -190,11 +190,11 @@ class DeviceInfoPluginTizen {
       _cachedTizenDeviceInfo ??= await _platform.tizenInfo();
 
   /// This information does not change from call to call. Cache it.
-  Future<String?>? _cachedDuid;
+  String? _cachedDuid;
 
   /// The DUID (Device Unique ID) that uniquely identifies this device.
   ///
-  /// Returns `null` if the DUID is unavailable, for example because the
-  /// underlying `db/comss/duid` vconf key could not be read.
-  Future<String?> get duid => _cachedDuid ??= _platform.getDuid();
+  /// Empty if the device isn't running the TV profile. Null if the
+  /// underlying vconf key couldn't be read (retrying may succeed).
+  Future<String?> get duid async => _cachedDuid ??= await _platform.getDuid();
 }

--- a/packages/device_info_plus/lib/device_info_plus_tizen.dart
+++ b/packages/device_info_plus/lib/device_info_plus_tizen.dart
@@ -190,11 +190,11 @@ class DeviceInfoPluginTizen {
       _cachedTizenDeviceInfo ??= await _platform.tizenInfo();
 
   /// This information does not change from call to call. Cache it.
-  String? _cachedDuid;
+  Future<String?>? _cachedDuid;
 
   /// The DUID (Device Unique ID) that uniquely identifies this device.
   ///
   /// Returns `null` if the DUID is unavailable, for example because the
   /// underlying `db/comss/duid` vconf key could not be read.
-  Future<String?> get duid async => _cachedDuid ??= await _platform.getDuid();
+  Future<String?> get duid => _cachedDuid ??= _platform.getDuid();
 }

--- a/packages/device_info_plus/pubspec.yaml
+++ b/packages/device_info_plus/pubspec.yaml
@@ -3,7 +3,7 @@ description: Flutter plugin providing detailed information about Tizen device
   (make, model, etc.) the app is running on.
 homepage: https://github.com/flutter-tizen/plugins
 repository: https://github.com/flutter-tizen/plugins/tree/main/packages/device_info_plus
-version: 1.4.2
+version: 1.4.3
 
 environment:
   sdk: ^3.7.0

--- a/packages/device_info_plus/tizen/src/device_info_plus_tizen_plugin.cc
+++ b/packages/device_info_plus/tizen/src/device_info_plus_tizen_plugin.cc
@@ -16,6 +16,7 @@
 #include <cstdint>
 #include <map>
 #include <memory>
+#include <optional>
 #include <string>
 
 #include "log.h"
@@ -24,27 +25,52 @@ namespace {
 
 constexpr int64_t kUnknownMetric = -1;
 
-std::string GetDuid() {
+bool IsTvProfile() {
+  char *profile = nullptr;
+  int ret = system_info_get_platform_string("http://tizen.org/feature/profile",
+                                            &profile);
+  if (ret != SYSTEM_INFO_ERROR_NONE) {
+    LOG_ERROR("Failed to get the platform profile: %s", get_error_message(ret));
+    return false;
+  }
+  std::string profile_str(profile);
+  free(profile);
+  return profile_str == "tv";
+}
+
+// Returns nullopt only for a transient vconf read failure; a non-TV profile
+// (permanent, not transient) returns an empty string instead.
+std::optional<std::string> GetDuid() {
+  if (!IsTvProfile()) {
+    return std::string();
+  }
+
   using FuncVconfGetStr = char *(*)(const char *);
 
-  void *handle = dlopen("libvconf.so.0.3.1", RTLD_LAZY);
+  void *handle = dlopen("libvconf.so.0", RTLD_LAZY);
   if (!handle) {
-    LOG_ERROR("Failed to open libvconf.so.0.3.1.");
-    return "";
+    LOG_ERROR("Failed to open libvconf.so.0.");
+    return std::nullopt;
   }
 
-  std::string duid;
   auto vconf_get_str =
       reinterpret_cast<FuncVconfGetStr>(dlsym(handle, "vconf_get_str"));
-  if (vconf_get_str) {
-    if (char *value = vconf_get_str("db/comss/duid")) {
-      duid = value;
-      free(value);
-    }
-  } else {
+  if (!vconf_get_str) {
     LOG_ERROR("Failed to find the vconf_get_str symbol.");
+    dlclose(handle);
+    return std::nullopt;
   }
+
+  char *value = vconf_get_str("db/comss/duid");
   dlclose(handle);
+  if (!value) {
+    LOG_ERROR("Failed to read db/comss/duid.");
+    return std::nullopt;
+  }
+  std::string duid = value;
+  free(value);
+
+  LOG_ERROR("##### duid: %s", duid.data());
   return duid;
 }
 
@@ -79,11 +105,11 @@ class DeviceInfoPlusTizenPlugin : public flutter::Plugin {
     if (method_name == "getTizenDeviceInfo") {
       result->Success(flutter::EncodableValue(GetTizenDeviceInfo()));
     } else if (method_name == "getDuid") {
-      std::string duid = GetDuid();
-      if (duid.empty()) {
-        result->Success(flutter::EncodableValue());
+      std::optional<std::string> duid = GetDuid();
+      if (duid.has_value()) {
+        result->Success(flutter::EncodableValue(*duid));
       } else {
-        result->Success(flutter::EncodableValue(duid));
+        result->Success(flutter::EncodableValue());
       }
     } else {
       result->NotImplemented();

--- a/packages/device_info_plus/tizen/src/device_info_plus_tizen_plugin.cc
+++ b/packages/device_info_plus/tizen/src/device_info_plus_tizen_plugin.cc
@@ -4,6 +4,7 @@
 
 #include "device_info_plus_tizen_plugin.h"
 
+#include <dlfcn.h>
 #include <flutter/method_channel.h>
 #include <flutter/plugin_registrar.h>
 #include <flutter/standard_method_codec.h>
@@ -22,6 +23,30 @@
 namespace {
 
 constexpr int64_t kUnknownMetric = -1;
+
+std::string GetDuid() {
+  using FuncVconfGetStr = char *(*)(const char *);
+
+  void *handle = dlopen("libvconf.so.0.3.1", RTLD_LAZY);
+  if (!handle) {
+    LOG_ERROR("Failed to open libvconf.so.0.3.1.");
+    return "";
+  }
+
+  std::string duid;
+  auto vconf_get_str =
+      reinterpret_cast<FuncVconfGetStr>(dlsym(handle, "vconf_get_str"));
+  if (vconf_get_str) {
+    if (char *value = vconf_get_str("db/comss/duid")) {
+      duid = value;
+      free(value);
+    }
+  } else {
+    LOG_ERROR("Failed to find the vconf_get_str symbol.");
+  }
+  dlclose(handle);
+  return duid;
+}
 
 class DeviceInfoPlusTizenPlugin : public flutter::Plugin {
  public:
@@ -53,6 +78,13 @@ class DeviceInfoPlusTizenPlugin : public flutter::Plugin {
 
     if (method_name == "getTizenDeviceInfo") {
       result->Success(flutter::EncodableValue(GetTizenDeviceInfo()));
+    } else if (method_name == "getDuid") {
+      std::string duid = GetDuid();
+      if (duid.empty()) {
+        result->Success(flutter::EncodableValue());
+      } else {
+        result->Success(flutter::EncodableValue(duid));
+      }
     } else {
       result->NotImplemented();
     }

--- a/packages/device_info_plus/tizen/src/device_info_plus_tizen_plugin.cc
+++ b/packages/device_info_plus/tizen/src/device_info_plus_tizen_plugin.cc
@@ -4,7 +4,9 @@
 
 #include "device_info_plus_tizen_plugin.h"
 
+#ifdef TV_PROFILE
 #include <dlfcn.h>
+#endif
 #include <flutter/method_channel.h>
 #include <flutter/plugin_registrar.h>
 #include <flutter/standard_method_codec.h>
@@ -25,26 +27,12 @@ namespace {
 
 constexpr int64_t kUnknownMetric = -1;
 
-bool IsTvProfile() {
-  char *profile = nullptr;
-  int ret = system_info_get_platform_string("http://tizen.org/feature/profile",
-                                            &profile);
-  if (ret != SYSTEM_INFO_ERROR_NONE) {
-    LOG_ERROR("Failed to get the platform profile: %s", get_error_message(ret));
-    return false;
-  }
-  std::string profile_str(profile);
-  free(profile);
-  return profile_str == "tv";
-}
-
 // Returns nullopt only for a transient vconf read failure; a non-TV profile
 // (permanent, not transient) returns an empty string instead.
 std::optional<std::string> GetDuid() {
-  if (!IsTvProfile()) {
-    return std::string();
-  }
-
+#ifndef TV_PROFILE
+  return std::string();
+#else
   using FuncVconfGetStr = char *(*)(const char *);
 
   void *handle = dlopen("libvconf.so.0", RTLD_LAZY);
@@ -69,9 +57,8 @@ std::optional<std::string> GetDuid() {
   }
   std::string duid = value;
   free(value);
-
-  LOG_ERROR("##### duid: %s", duid.data());
   return duid;
+#endif
 }
 
 class DeviceInfoPlusTizenPlugin : public flutter::Plugin {


### PR DESCRIPTION
Add DeviceInfoPluginTizen.duid to read the device's DUID via vconf. This is a Tizen-specific API with no upstream counterpart in device_info_plus.