### PR TITLE
[permission_handler] Update permission_handler to 13.0.1

### DIFF
--- a/packages/permission_handler/CHANGELOG.md
+++ b/packages/permission_handler/CHANGELOG.md
@@ -1,3 +1,12 @@
+## 1.4.7
+
+* Update permission_handler to 13.0.1.
+* Update permission_handler_platform_interface to 4.4.0.
+* Update minimum Flutter and Dart version to 3.27 and 3.6.
+* Sync the `Permission` enum with the platform interface.
+* Update README to list the permissions that are not supported yet.
+* Replace the forked baseflow_plugin_template dependency of the example app with the published 2.2.1.
+
 ## 1.4.6
 
 * Add an `implements` entry to the pubspec to improve discoverability on pub.dev.

--- a/packages/permission_handler/README.md
+++ b/packages/permission_handler/README.md
@@ -20,8 +20,8 @@ You can use this plugin to ask the user for runtime permissions if your app perf
 
    ```yaml
    dependencies:
-     permission_handler: ^12.0.1
-     permission_handler_tizen: ^1.4.6
+     permission_handler: ^13.0.1
+     permission_handler_tizen: ^1.4.7
    ```
 
    Then you can import `permission_handler` in your Dart code:
@@ -38,7 +38,7 @@ You can use this plugin to ask the user for runtime permissions if your app perf
 |-|-|-|
 | `Permission.calendar` | Calendar | `http://tizen.org/privilege/calendar.read`<br>`http://tizen.org/privilege/calendar.write` |
 | `Permission.camera` | Camera | `http://tizen.org/privilege/camera` |
-| `Permission.contact` | Contacts | `http://tizen.org/privilege/contact.read`<br>`http://tizen.org/privilege/contact.write` |
+| `Permission.contacts` | Contacts | `http://tizen.org/privilege/contact.read`<br>`http://tizen.org/privilege/contact.write` |
 | `Permission.location`<br>`Permission.locationAlways`<br>`Permission.locationWhenInUse` | Location | `http://tizen.org/privilege/location`<br>`http://tizen.org/privilege/location.coarse` |
 | `Permission.mediaLibrary` | Storage | `http://tizen.org/privilege/mediastorage` |
 | `Permission.microphone` | Microphone | `http://tizen.org/privilege/recorder` |
@@ -49,8 +49,14 @@ You can use this plugin to ask the user for runtime permissions if your app perf
 
 The following permissions are not applicable for Tizen:
 
-- Android-only: `accessMediaLocation`, `accessNotificationPolicy`, `activityRecognition`, `audio`, `bluetoothAdvertise`, `bluetoothConnect`, `bluetoothScan`, `ignoreBatteryOptimizations`, `manageExternalStorage`, `nearbyWifiDevices`, `requestInstallPackages`, `scheduleExactAlarm`, `systemAlertWindow`, `videos`
-- iOS-only: `appTrackingTransparency`, `criticalAlerts`, `photosAddOnly`, `reminders`, `speech`
+- Android-only: `accessLocalNetwork`, `accessMediaLocation`, `accessNotificationPolicy`, `activityRecognition`, `audio`, `bluetoothAdvertise`, `bluetoothConnect`, `bluetoothScan`, `ignoreBatteryOptimizations`, `manageExternalStorage`, `nearbyWifiDevices`, `requestInstallPackages`, `scheduleExactAlarm`, `systemAlertWindow`, `videos`
+- iOS-only: `appTrackingTransparency`, `assistant`, `backgroundRefresh`, `criticalAlerts`, `photosAddOnly`, `reminders`, `speech`
+
+The following permissions are applicable for Tizen but not supported by this plugin yet. They are always reported as granted:
+
+- `calendarFullAccess`, `calendarWriteOnly`: use the deprecated `Permission.calendar` instead.
+- `notification`
+- `photos`
 
 On Tizen, your app can use some security-sensitive features (such as bluetooth) without explicitly acquiring permissions. However, you might need to declare relevant privileges in its `tizen-manifest.xml` file. For detailed information on Tizen privileges, see [Tizen Docs: API Privileges](https://docs.tizen.org/application/dotnet/get-started/api-privileges).
 

--- a/packages/permission_handler/example/lib/main.dart
+++ b/packages/permission_handler/example/lib/main.dart
@@ -66,7 +66,10 @@ class _PermissionHandlerWidgetState extends State<PermissionHandlerWidget> {
                   permission != Permission.nearbyWifiDevices &&
                   permission != Permission.videos &&
                   permission != Permission.audio &&
-                  permission != Permission.scheduleExactAlarm;
+                  permission != Permission.scheduleExactAlarm &&
+                  permission != Permission.assistant &&
+                  permission != Permission.backgroundRefresh &&
+                  permission != Permission.accessLocalNetwork;
             })
             .map((permission) => PermissionWidget(permission))
             .toList(),

--- a/packages/permission_handler/example/pubspec.yaml
+++ b/packages/permission_handler/example/pubspec.yaml
@@ -3,17 +3,14 @@ description: Demonstrates how to use the permission_handler_tizen plugin.
 publish_to: "none"
 
 environment:
-  sdk: ^3.5.0
-  flutter: ">=3.24.0"
+  sdk: ^3.6.0
+  flutter: ">=3.27.0"
 
 dependencies:
-  baseflow_plugin_template:
-    git:
-      url: https://github.com/seungsoo47/baseflow_plugin_template
-      ref: temp_fix
+  baseflow_plugin_template: ^2.2.1
   flutter:
     sdk: flutter
-  permission_handler: ^12.0.1
+  permission_handler: ^13.0.1
   permission_handler_tizen:
     path: ../
   url_launcher: ^6.1.0

--- a/packages/permission_handler/pubspec.yaml
+++ b/packages/permission_handler/pubspec.yaml
@@ -2,11 +2,11 @@ name: permission_handler_tizen
 description: Tizen implementation of the permission_handler plugin.
 homepage: https://github.com/flutter-tizen/plugins
 repository: https://github.com/flutter-tizen/plugins/tree/main/packages/permission_handler
-version: 1.4.6
+version: 1.4.7
 
 environment:
-  sdk: ^3.5.0
-  flutter: ">=3.24.0"
+  sdk: ^3.6.0
+  flutter: ">=3.27.0"
 
 flutter:
   plugin:
@@ -19,7 +19,7 @@ flutter:
 dependencies:
   flutter:
     sdk: flutter
-  permission_handler_platform_interface: ^4.3.0
+  permission_handler_platform_interface: ^4.4.0
 
 dev_dependencies:
   flutter_lints: ^5.0.0

--- a/packages/permission_handler/tizen/src/permissions.h
+++ b/packages/permission_handler/tizen/src/permissions.h
@@ -44,7 +44,12 @@ enum class Permission {
   kVideos = 32,
   kAudio = 33,
   kScheduleExactAlarm = 34,
-  kSensorsAlways = 35
+  kSensorsAlways = 35,
+  kCalendarWriteOnly = 36,
+  kCalendarFullAccess = 37,
+  kAssistant = 38,
+  kBackgroundRefresh = 39,
+  kAccessLocalNetwork = 40
 };
 
 #endif  // FLUTTER_PLUGIN_PERMISSIONS_H_


### PR DESCRIPTION
* Update permission_handler to 13.0.1.
* Update permission_handler_platform_interface to 4.4.0.
* Update minimum Flutter and Dart version to 3.27 and 3.6.
* Sync the `Permission` enum with the platform interface.
* Update README to list the permissions that are not supported yet.
* Replace the forked baseflow_plugin_template dependency of the example app with the published 2.2.1.

Fix https://github.com/flutter-tizen/plugins/issues/1107