### PR TITLE
[path_provider_tizen] Update to 2.1.6

### DIFF
--- a/packages/path_provider/CHANGELOG.md
+++ b/packages/path_provider/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## 2.3.3
 
-Update path_provider to 2.1.6.
-Updates minimum supported SDK version to Flutter 3.38/Dart 3.10.0.
+* Update path_provider to 2.1.6.
+* Updates minimum supported SDK version to Flutter 3.38/Dart 3.10.0.
 
 ## 2.3.2
 

--- a/packages/path_provider/CHANGELOG.md
+++ b/packages/path_provider/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 2.3.3
+
+Update path_provider to 2.1.6.
+Updates minimum supported SDK version to Flutter 3.38/Dart 3.10.0.
+
 ## 2.3.2
 
 * Add an `implements` entry to the pubspec to improve discoverability on pub.dev.

--- a/packages/path_provider/README.md
+++ b/packages/path_provider/README.md
@@ -10,8 +10,8 @@ This package is not an _endorsed_ implementation of `path_provider`. Therefore, 
 
 ```yaml
 dependencies:
-  path_provider: ^2.1.5
-  path_provider_tizen: ^2.3.2
+  path_provider: ^2.1.6
+  path_provider_tizen: ^2.3.3
 ```
 
 Then you can import `path_provider` in your Dart code:

--- a/packages/path_provider/README.md
+++ b/packages/path_provider/README.md
@@ -32,7 +32,7 @@ For detailed usage, see https://pub.dev/packages/path_provider#usage.
 - [x] `getExternalStorageDirectory` (requires an SD card)
 - [x] `getExternalCacheDirectories` (requires an SD card)
 - [x] `getExternalStorageDirectories` (returns shared media library paths such as `/home/owner/media/Music`)
-- [x] `getDownloadsDirectory` (returns the shared downloads directory path)
+- [x] `getDownloadsDirectory` (returns the shared downloads directory path, or `null` if the directory is unavailable on the device)
 
 ## Required privileges
 

--- a/packages/path_provider/example/lib/main.dart
+++ b/packages/path_provider/example/lib/main.dart
@@ -77,8 +77,9 @@ class _MyHomePageState extends State<MyHomePage> {
       if (snapshot.hasError) {
         text = Text('Error: ${snapshot.error}');
       } else if (snapshot.hasData) {
-        final String combined =
-            snapshot.data!.map((Directory d) => d.path).join(', ');
+        final String combined = snapshot.data!
+            .map((Directory d) => d.path)
+            .join(', ');
         text = Text('paths: $combined');
       } else {
         text = const Text('path unavailable');
@@ -192,8 +193,9 @@ class _MyHomePageState extends State<MyHomePage> {
                 Padding(
                   padding: const EdgeInsets.all(16.0),
                   child: ElevatedButton(
-                    onPressed:
-                        Platform.isAndroid ? null : _requestAppLibraryDirectory,
+                    onPressed: Platform.isAndroid
+                        ? null
+                        : _requestAppLibraryDirectory,
                     child: Text(
                       Platform.isAndroid
                           ? 'Application Library Directory unavailable'

--- a/packages/path_provider/example/pubspec.yaml
+++ b/packages/path_provider/example/pubspec.yaml
@@ -3,13 +3,13 @@ description: Demonstrates how to use the path_provider_tizen plugin.
 publish_to: "none"
 
 environment:
-  sdk: ^3.3.0
-  flutter: ">=3.19.0"
+  sdk: ^3.10.0
+  flutter: ">=3.38.0"
 
 dependencies:
   flutter:
     sdk: flutter
-  path_provider: ^2.1.5
+  path_provider: ^2.1.6
   path_provider_tizen:
     path: ../
 

--- a/packages/path_provider/pubspec.yaml
+++ b/packages/path_provider/pubspec.yaml
@@ -19,5 +19,5 @@ dependencies:
   ffi: ^2.0.1
   flutter:
     sdk: flutter
-  path_provider_platform_interface: ^2.1.0
+  path_provider_platform_interface: ^2.1.3
   tizen_interop: ^0.3.0

--- a/packages/path_provider/pubspec.yaml
+++ b/packages/path_provider/pubspec.yaml
@@ -2,11 +2,11 @@ name: path_provider_tizen
 description: Tizen implementation of the path_provider plugin.
 homepage: https://github.com/flutter-tizen/plugins
 repository: https://github.com/flutter-tizen/plugins/tree/main/packages/path_provider
-version: 2.3.2
+version: 2.3.3
 
 environment:
-  sdk: ^3.3.0
-  flutter: ">=3.19.0"
+  sdk: ^3.10.0
+  flutter: ">=3.38.0"
 
 flutter:
   plugin:
@@ -19,5 +19,5 @@ dependencies:
   ffi: ^2.0.1
   flutter:
     sdk: flutter
-  path_provider_platform_interface: ^2.1.2
+  path_provider_platform_interface: ^2.1.0
   tizen_interop: ^0.3.0


### PR DESCRIPTION
Fix https://github.com/flutter-tizen/plugins/issues/1109

2.1.6 
- Updates minimum supported SDK version to Flutter 3.38/Dart 3.10.
- Updates README to reflect currently supported OS versions for the latest versions of the endorsed platform implementations.
- Applications built with older versions of Flutter will continue to use compatible versions of the platform implementations.
- Documents the difference between a null return and an UnsupportedError from getDownloadsDirectory.