### PR TITLE
[wakelock_plus] Update wakelock_plus to 1.8.0

### DIFF
--- a/packages/wakelock_plus/CHANGELOG.md
+++ b/packages/wakelock_plus/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 2.1.5
+
+* Update wakelock_plus to 1.8.0.
+* Update wakelock_plus_platform_interface to 1.7.0.
+* Update minimum Flutter and Dart version to 3.44 and 3.12.
+
 ## 2.1.4
 
 * Update wakelock_plus to 1.7.0.

--- a/packages/wakelock_plus/README.md
+++ b/packages/wakelock_plus/README.md
@@ -10,8 +10,8 @@ This package is not an _endorsed_ implementation of `wakelock_plus`. Therefore, 
 
 ```yaml
 dependencies:
-  wakelock_plus: ^1.7.0
-  wakelock_plus_tizen: ^2.1.4
+  wakelock_plus: ^1.8.0
+  wakelock_plus_tizen: ^2.1.5
 ```
 
 Then you can import `wakelock_plus` in your Dart code:

--- a/packages/wakelock_plus/example/pubspec.yaml
+++ b/packages/wakelock_plus/example/pubspec.yaml
@@ -3,13 +3,13 @@ description: Demonstrates how to use the wakelock_plus_tizen plugin.
 publish_to: "none"
 
 environment:
-  sdk: ">=3.11.0 <4.0.0"
-  flutter: ">=3.41.0"
+  sdk: ">=3.12.0 <4.0.0"
+  flutter: ">=3.44.0"
 
 dependencies:
   flutter:
     sdk: flutter
-  wakelock_plus: ^1.7.0
+  wakelock_plus: ^1.8.0
   wakelock_plus_tizen:
     path: ../
 

--- a/packages/wakelock_plus/pubspec.yaml
+++ b/packages/wakelock_plus/pubspec.yaml
@@ -2,11 +2,11 @@ name: wakelock_plus_tizen
 description: Tizen implementation of the wakelock_plus plugin.
 homepage: https://github.com/flutter-tizen/plugins
 repository: https://github.com/flutter-tizen/plugins/tree/main/packages/wakelock_plus
-version: 2.1.4
+version: 2.1.5
 
 environment:
-  sdk: ">=3.11.0 <4.0.0"
-  flutter: ">=3.41.0"
+  sdk: ">=3.12.0 <4.0.0"
+  flutter: ">=3.44.0"
 
 flutter:
   plugin:
@@ -20,7 +20,7 @@ flutter:
 dependencies:
   flutter:
     sdk: flutter
-  wakelock_plus_platform_interface: ^1.6.0
+  wakelock_plus_platform_interface: ^1.7.0
 
 dev_dependencies:
   flutter_lints: ^3.0.2


### PR DESCRIPTION
* Update wakelock_plus to 1.8.0.
* Update wakelock_plus_platform_interface to 1.7.0.
* Update minimum Flutter and Dart version to 3.44 and 3.12.