### PR TITLE
[webview_flutter_lwe] Update webview_flutter to 4.14.1

### DIFF
--- a/packages/webview_flutter_lwe/CHANGELOG.md
+++ b/packages/webview_flutter_lwe/CHANGELOG.md
@@ -4,6 +4,7 @@
 * Update webview_flutter_platform_interface to 2.15.1.
 * Update minimum Flutter and Dart version to 3.38 and 3.10.
 * Implement `getCookies` for the cookie manager.
+* Register the cookie manager channel at the plugin level so that it works before a WebView is created or after the last one is disposed.
 * Update limitations in README.
 
 ## 0.5.5

--- a/packages/webview_flutter_lwe/CHANGELOG.md
+++ b/packages/webview_flutter_lwe/CHANGELOG.md
@@ -1,3 +1,11 @@
+## 0.5.6
+
+* Update webview_flutter to 4.14.1.
+* Update webview_flutter_platform_interface to 2.15.1.
+* Update minimum Flutter and Dart version to 3.38 and 3.10.
+* Implement `getCookies` for the cookie manager.
+* Update limitations in README.
+
 ## 0.5.5
 
 * Add an `implements` entry to the pubspec to improve discoverability on pub.dev.

--- a/packages/webview_flutter_lwe/README.md
+++ b/packages/webview_flutter_lwe/README.md
@@ -20,8 +20,8 @@ This package is not an _endorsed_ implementation of `webview_flutter`. Therefore
 
 ```yaml
 dependencies:
-  webview_flutter: ^4.13.1
-  webview_flutter_lwe: ^0.5.5
+  webview_flutter: ^4.14.1
+  webview_flutter_lwe: ^0.5.6
 ```
 
 ## Example
@@ -70,6 +70,10 @@ await controller.setVerticalScrollBarEnabled(false);
 // This will show both vertical and horizontal scrollbars
 await controller.setHorizontalScrollBarEnabled(true);
 ```
+
+### Cookie management
+
+`WebViewCookieManager.getCookies` does not return cookies marked as `HttpOnly`. The Lightweight Web Engine only exposes cookies that are accessible to JavaScript (equivalent to `document.cookie`), so `HttpOnly` cookies sent by a server are stored and used for requests but are not included in the result.
 
 ## Supported devices
 

--- a/packages/webview_flutter_lwe/example/integration_test/webview_flutter_test.dart
+++ b/packages/webview_flutter_lwe/example/integration_test/webview_flutter_test.dart
@@ -27,6 +27,9 @@ Future<void> main() async {
         request.response.writeln('How are you today?');
       } else if (request.uri.path == '/headers') {
         request.response.writeln('${request.headers}');
+      } else if (request.uri.path == '/cookie') {
+        request.response.headers.set(HttpHeaders.setCookieHeader, 'foo=bar');
+        request.response.writeln('Cookie set.');
       } else if (request.uri.path == '/favicon.ico') {
         request.response.statusCode = HttpStatus.notFound;
       } else {
@@ -38,6 +41,7 @@ Future<void> main() async {
   final String prefixUrl = 'http://${server.address.address}:${server.port}';
   final String primaryUrl = '$prefixUrl/hello.txt';
   final String secondaryUrl = '$prefixUrl/secondary.txt';
+  final String cookieUrl = '$prefixUrl/cookie';
 
   testWidgets('loadRequest', (WidgetTester tester) async {
     final Completer<void> pageFinished = Completer<void>();
@@ -56,6 +60,30 @@ Future<void> main() async {
 
     final String? currentUrl = await controller.currentUrl();
     expect(currentUrl, primaryUrl);
+  });
+
+  testWidgets('getCookies', (WidgetTester tester) async {
+    final Completer<void> pageFinished = Completer<void>();
+
+    final WebViewController controller = WebViewController();
+    unawaited(
+      controller.setNavigationDelegate(
+        NavigationDelegate(onPageFinished: (_) => pageFinished.complete()),
+      ),
+    );
+    unawaited(controller.loadRequest(Uri.parse(cookieUrl)));
+
+    await tester.pumpWidget(WebViewWidget(controller: controller));
+
+    await pageFinished.future;
+
+    final List<WebViewCookie> cookies = await WebViewCookieManager().getCookies(
+      domain: Uri.parse(cookieUrl),
+    );
+    expect(
+      cookies.map((WebViewCookie cookie) => '${cookie.name}=${cookie.value}'),
+      contains('foo=bar'),
+    );
   });
 
   testWidgets('runJavaScriptReturningResult', (WidgetTester tester) async {

--- a/packages/webview_flutter_lwe/example/lib/main.dart
+++ b/packages/webview_flutter_lwe/example/lib/main.dart
@@ -410,9 +410,17 @@ class SampleMenu extends StatelessWidget {
   }
 
   Future<void> _onListCookies(BuildContext context) async {
-    final String cookies =
-        await webViewController.runJavaScriptReturningResult('document.cookie')
-            as String;
+    final Uri? domain = Uri.tryParse(
+      (await webViewController.currentUrl()) ?? '',
+    );
+
+    final List<WebViewCookie> cookies;
+    if (domain == null) {
+      cookies = <WebViewCookie>[];
+    } else {
+      cookies = await cookieManager.getCookies(domain: domain);
+    }
+
     if (context.mounted) {
       ScaffoldMessenger.of(context).showSnackBar(
         SnackBar(
@@ -519,13 +527,13 @@ class SampleMenu extends StatelessWidget {
     return webViewController.loadHtmlString(kTransparentBackgroundPage);
   }
 
-  Widget _getCookieList(String cookies) {
-    if (cookies == '""') {
+  Widget _getCookieList(List<WebViewCookie> cookies) {
+    if (cookies.isEmpty) {
       return Container();
     }
-    final List<String> cookieList = cookies.split(';');
-    final Iterable<Text> cookieWidgets = cookieList.map(
-      (String cookie) => Text(cookie),
+
+    final Iterable<Text> cookieWidgets = cookies.map(
+      (WebViewCookie cookie) => Text(cookie.toString()),
     );
     return Column(
       mainAxisAlignment: MainAxisAlignment.end,

--- a/packages/webview_flutter_lwe/example/pubspec.yaml
+++ b/packages/webview_flutter_lwe/example/pubspec.yaml
@@ -3,8 +3,8 @@ description: Demonstrates how to use the webview_flutter_lwe plugin.
 publish_to: "none"
 
 environment:
-  sdk: ^3.8.0
-  flutter: ">=3.32.0"
+  sdk: ^3.10.0
+  flutter: ">=3.38.0"
 
 dependencies:
   flutter:
@@ -12,7 +12,7 @@ dependencies:
   path_provider: ^2.0.7
   path_provider_tizen:
     path: ../../path_provider/
-  webview_flutter: ^4.13.1
+  webview_flutter: ^4.14.1
   webview_flutter_lwe:
     path: ../
 

--- a/packages/webview_flutter_lwe/lib/src/lwe_webview_cookie_manager.dart
+++ b/packages/webview_flutter_lwe/lib/src/lwe_webview_cookie_manager.dart
@@ -23,6 +23,30 @@ class LweWebViewCookieManager extends PlatformWebViewCookieManager {
   }
 
   @override
+  Future<List<WebViewCookie>> getCookies(Uri url) async {
+    final String? cookies = await _cookieManagerChannel.invokeMethod<String>(
+      'getCookies',
+      url.toString(),
+    );
+    if (cookies == null || cookies.isEmpty) {
+      return <WebViewCookie>[];
+    }
+    return cookies
+        .split(';')
+        .map((String cookie) => cookie.trim())
+        .where((String cookie) => cookie.isNotEmpty)
+        .map((String cookie) {
+          final int separator = cookie.indexOf('=');
+          return WebViewCookie(
+            name: separator < 0 ? cookie : cookie.substring(0, separator),
+            value: separator < 0 ? '' : cookie.substring(separator + 1),
+            domain: url.host,
+          );
+        })
+        .toList();
+  }
+
+  @override
   Future<void> setCookie(WebViewCookie cookie) async {
     if (!_isValidPath(cookie.path)) {
       throw ArgumentError(

--- a/packages/webview_flutter_lwe/pubspec.yaml
+++ b/packages/webview_flutter_lwe/pubspec.yaml
@@ -2,11 +2,11 @@ name: webview_flutter_lwe
 description: Tizen implementation of the webview_flutter plugin backed by Lightweight Web Engine.
 homepage: https://github.com/flutter-tizen/plugins
 repository: https://github.com/flutter-tizen/plugins/tree/main/packages/webview_flutter_lwe
-version: 0.5.5
+version: 0.5.6
 
 environment:
-  sdk: ^3.8.0
-  flutter: ">=3.32.0"
+  sdk: ^3.10.0
+  flutter: ">=3.38.0"
 
 flutter:
   plugin:
@@ -21,8 +21,8 @@ dependencies:
   flutter:
     sdk: flutter
   flutter_tizen: ^0.2.1
-  webview_flutter: ^4.13.1
-  webview_flutter_platform_interface: ^2.13.0
+  webview_flutter: ^4.14.1
+  webview_flutter_platform_interface: ^2.15.1
 
 topics:
   - html

--- a/packages/webview_flutter_lwe/tizen/src/webview.cc
+++ b/packages/webview_flutter_lwe/tizen/src/webview.cc
@@ -147,15 +147,6 @@ WebView::WebView(flutter::PluginRegistrar* registrar, int view_id,
       GetPluginRegistrar()->messenger(), GetNavigationDelegateChannelName(),
       &flutter::StandardMethodCodec::GetInstance());
 
-  auto cookie_channel = std::make_unique<FlMethodChannel>(
-      GetPluginRegistrar()->messenger(),
-      "plugins.flutter.io/lwe_cookie_manager",
-      &flutter::StandardMethodCodec::GetInstance());
-  cookie_channel->SetMethodCallHandler(
-      [webview = this](const auto& call, auto result) {
-        webview->HandleCookieMethodCall(call, std::move(result));
-      });
-
   webview_instance_->RegisterOnPageStartedHandler(
       [this](LWE::WebContainer* container, const std::string& url) {
         flutter::EncodableMap args = {
@@ -827,33 +818,6 @@ void WebView::HandleWebViewMethodCall(const FlMethodCall& method_call,
       webview_instance_->SetSettings(settings);
     }
     result->Success();
-  } else {
-    result->NotImplemented();
-  }
-}
-
-void WebView::HandleCookieMethodCall(const FlMethodCall& method_call,
-                                     std::unique_ptr<FlMethodResult> result) {
-  if (!webview_instance_) {
-    result->Error("Invalid operation",
-                  "The webview instance has not been initialized.");
-    return;
-  }
-
-  const std::string& method_name = method_call.method_name();
-
-  if (method_name == "clearCookies") {
-    LWE::CookieManager* cookie = LWE::CookieManager::GetInstance();
-    cookie->ClearCookies();
-    result->Success(flutter::EncodableValue(true));
-  } else if (method_name == "getCookies") {
-    const auto* url = std::get_if<std::string>(method_call.arguments());
-    if (!url) {
-      result->Error("Invalid argument", "The argument must be a string.");
-      return;
-    }
-    LWE::CookieManager* cookie = LWE::CookieManager::GetInstance();
-    result->Success(flutter::EncodableValue(cookie->GetCookie(*url)));
   } else {
     result->NotImplemented();
   }

--- a/packages/webview_flutter_lwe/tizen/src/webview.cc
+++ b/packages/webview_flutter_lwe/tizen/src/webview.cc
@@ -846,6 +846,14 @@ void WebView::HandleCookieMethodCall(const FlMethodCall& method_call,
     LWE::CookieManager* cookie = LWE::CookieManager::GetInstance();
     cookie->ClearCookies();
     result->Success(flutter::EncodableValue(true));
+  } else if (method_name == "getCookies") {
+    const auto* url = std::get_if<std::string>(method_call.arguments());
+    if (!url) {
+      result->Error("Invalid argument", "The argument must be a string.");
+      return;
+    }
+    LWE::CookieManager* cookie = LWE::CookieManager::GetInstance();
+    result->Success(flutter::EncodableValue(cookie->GetCookie(*url)));
   } else {
     result->NotImplemented();
   }

--- a/packages/webview_flutter_lwe/tizen/src/webview.h
+++ b/packages/webview_flutter_lwe/tizen/src/webview.h
@@ -58,8 +58,6 @@ class WebView : public PlatformView {
  private:
   void HandleWebViewMethodCall(const FlMethodCall& method_call,
                                std::unique_ptr<FlMethodResult> result);
-  void HandleCookieMethodCall(const FlMethodCall& method_call,
-                              std::unique_ptr<FlMethodResult> result);
 
   template <typename T>
   void SetBackgroundColor(const T& color);

--- a/packages/webview_flutter_lwe/tizen/src/webview_flutter_lwe_plugin.cc
+++ b/packages/webview_flutter_lwe/tizen/src/webview_flutter_lwe_plugin.cc
@@ -4,27 +4,68 @@
 
 #include "webview_flutter_lwe_plugin.h"
 
+#include <flutter/encodable_value.h>
 #include <flutter/plugin_registrar.h>
+#include <flutter/standard_method_codec.h>
 #include <flutter_tizen.h>
 
 #include <memory>
+#include <string>
+#include <variant>
 
+#include "lwe/LWEWebView.h"
+#include "webview.h"
 #include "webview_factory.h"
 
 namespace {
 
 constexpr char kViewType[] = "plugins.flutter.io/webview";
+constexpr char kCookieManagerChannelName[] =
+    "plugins.flutter.io/lwe_cookie_manager";
 
 class WebviewFlutterLwePlugin : public flutter::Plugin {
  public:
   static void RegisterWithRegistrar(flutter::PluginRegistrar* registrar) {
-    auto plugin = std::make_unique<WebviewFlutterLwePlugin>();
+    auto plugin = std::make_unique<WebviewFlutterLwePlugin>(registrar);
     registrar->AddPlugin(std::move(plugin));
   }
 
-  WebviewFlutterLwePlugin() {}
+  explicit WebviewFlutterLwePlugin(flutter::PluginRegistrar* registrar) {
+    cookie_channel_ = std::make_unique<FlMethodChannel>(
+        registrar->messenger(), kCookieManagerChannelName,
+        &flutter::StandardMethodCodec::GetInstance());
+    cookie_channel_->SetMethodCallHandler(
+        [](const FlMethodCall& call, std::unique_ptr<FlMethodResult> result) {
+          HandleCookieMethodCall(call, std::move(result));
+        });
+  }
 
-  virtual ~WebviewFlutterLwePlugin() {}
+  virtual ~WebviewFlutterLwePlugin() {
+    cookie_channel_->SetMethodCallHandler(nullptr);
+  }
+
+ private:
+  static void HandleCookieMethodCall(const FlMethodCall& method_call,
+                                     std::unique_ptr<FlMethodResult> result) {
+    const std::string& method_name = method_call.method_name();
+
+    if (method_name == "clearCookies") {
+      LWE::CookieManager::GetInstance()->ClearCookies();
+      result->Success(flutter::EncodableValue(true));
+    } else if (method_name == "getCookies") {
+      const auto* url = std::get_if<std::string>(method_call.arguments());
+      if (!url) {
+        result->Error("Invalid argument", "The argument must be a string.");
+        return;
+      }
+      result->Success(flutter::EncodableValue(
+          LWE::CookieManager::GetInstance()->GetCookie(*url)));
+    } else {
+      result->NotImplemented();
+    }
+  }
+
+  std::unique_ptr<FlMethodChannel> cookie_channel_;
 };
 
 }  // namespace


### PR DESCRIPTION
* Update webview_flutter to 4.14.1.
* Update webview_flutter_platform_interface to 2.15.1.
* Update minimum Flutter and Dart version to 3.38 and 3.10.
* Implement `getCookies` for the cookie manager.
* Update limitations in README.

https://github.com/flutter-tizen/plugins/issues/1132