### PR TITLE
[tizen_window_manager] Add tizen-core-wl window backend

### DIFF
--- a/packages/tizen_window_manager/CHANGELOG.md
+++ b/packages/tizen_window_manager/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.1.2
+
+* Add tizen-core-wl window backend for Tizen 11.0 and later.
+
 ## 0.1.1
 
 * Update integration tests.

--- a/packages/tizen_window_manager/pubspec.yaml
+++ b/packages/tizen_window_manager/pubspec.yaml
@@ -2,7 +2,7 @@ name: tizen_window_manager
 description: Tizen window APIs.
 homepage: https://github.com/flutter-tizen/plugins
 repository: https://github.com/flutter-tizen/plugins/tree/main/packages/tizen_window_manager
-version: 0.1.1
+version: 0.1.2
 
 environment:
   sdk: ">=3.1.0 <4.0.0"

--- a/packages/tizen_window_manager/tizen/src/ecore_wl2_window_proxy.cc
+++ b/packages/tizen_window_manager/tizen/src/ecore_wl2_window_proxy.cc
@@ -28,9 +28,8 @@ EcoreWl2WindowProxy::~EcoreWl2WindowProxy() {
   }
 }
 
-void EcoreWl2WindowProxy::ecore_wl2_window_geometry_get(void *window, int *x,
-                                                        int *y, int *width,
-                                                        int *height) {
+void EcoreWl2WindowProxy::GetGeometry(void *window, int *x, int *y, int *width,
+                                      int *height) {
   if (!ecore_wl2_window_handle_) {
     LOG_ERROR("ecore_wl2_window_handle_ not valid");
     return;
@@ -46,7 +45,7 @@ void EcoreWl2WindowProxy::ecore_wl2_window_geometry_get(void *window, int *x,
   ecore_wl2_window_geometry_get(window, x, y, width, height);
 }
 
-void EcoreWl2WindowProxy::ecore_wl2_window_activate(void *window) {
+void EcoreWl2WindowProxy::Activate(void *window) {
   if (!ecore_wl2_window_handle_) {
     LOG_ERROR("ecore_wl2_window_handle_ not valid");
     return;
@@ -62,7 +61,7 @@ void EcoreWl2WindowProxy::ecore_wl2_window_activate(void *window) {
   ecore_wl2_window_activate(window);
 }
 
-void EcoreWl2WindowProxy::ecore_wl2_window_lower(void *window) {
+void EcoreWl2WindowProxy::Lower(void *window) {
   if (!ecore_wl2_window_handle_) {
     LOG_ERROR("ecore_wl2_window_handle_ not valid");
     return;

--- a/packages/tizen_window_manager/tizen/src/tizen_core_wl_window_proxy.cc
+++ b/packages/tizen_window_manager/tizen/src/tizen_core_wl_window_proxy.cc
@@ -1,0 +1,62 @@
+// Copyright 2025 Samsung Electronics Co., Ltd. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "tizen_core_wl_window_proxy.h"
+
+#include <dlfcn.h>
+
+#include "log.h"
+
+TizenCoreWlWindowProxy::TizenCoreWlWindowProxy() {
+  handle_ = dlopen("libtizen-core-wl.so.0", RTLD_LAZY);
+  if (handle_ == nullptr) {
+    LOG_ERROR("Failed to open tizen-core-wl.");
+    return;
+  }
+
+  get_geometry_ = reinterpret_cast<FuncGetGeometry>(
+      dlsym(handle_, "tizen_core_wl_window_get_geometry"));
+  activate_ = reinterpret_cast<FuncActivate>(
+      dlsym(handle_, "tizen_core_wl_window_activate"));
+  lower_ =
+      reinterpret_cast<FuncLower>(dlsym(handle_, "tizen_core_wl_window_lower"));
+
+  if (!get_geometry_ || !activate_ || !lower_) {
+    LOG_ERROR("Failed to resolve tizen-core-wl symbols.");
+    dlclose(handle_);
+    handle_ = nullptr;
+  }
+}
+
+TizenCoreWlWindowProxy::~TizenCoreWlWindowProxy() {
+  if (handle_) {
+    dlclose(handle_);
+    handle_ = nullptr;
+  }
+}
+
+void TizenCoreWlWindowProxy::GetGeometry(void *window, int *x, int *y,
+                                         int *width, int *height) {
+  if (!handle_) {
+    LOG_ERROR("tizen-core-wl handle not valid");
+    return;
+  }
+  get_geometry_(window, x, y, width, height);
+}
+
+void TizenCoreWlWindowProxy::Activate(void *window) {
+  if (!handle_) {
+    LOG_ERROR("tizen-core-wl handle not valid");
+    return;
+  }
+  activate_(window);
+}
+
+void TizenCoreWlWindowProxy::Lower(void *window) {
+  if (!handle_) {
+    LOG_ERROR("tizen-core-wl handle not valid");
+    return;
+  }
+  lower_(window);
+}

--- a/packages/tizen_window_manager/tizen/src/tizen_core_wl_window_proxy.cc
+++ b/packages/tizen_window_manager/tizen/src/tizen_core_wl_window_proxy.cc
@@ -5,6 +5,7 @@
 #include "tizen_core_wl_window_proxy.h"
 
 #include <dlfcn.h>
+#include <tizen_error.h>
 
 #include "log.h"
 
@@ -42,7 +43,11 @@ void TizenCoreWlWindowProxy::GetGeometry(void *window, int *x, int *y,
     LOG_ERROR("tizen-core-wl handle not valid");
     return;
   }
-  get_geometry_(window, x, y, width, height);
+  int ret = get_geometry_(window, x, y, width, height);
+  if (ret != TIZEN_ERROR_NONE) {
+    LOG_ERROR("tizen_core_wl_window_get_geometry failed: %s",
+              get_error_message(ret));
+  }
 }
 
 void TizenCoreWlWindowProxy::Activate(void *window) {
@@ -50,7 +55,11 @@ void TizenCoreWlWindowProxy::Activate(void *window) {
     LOG_ERROR("tizen-core-wl handle not valid");
     return;
   }
-  activate_(window);
+  int ret = activate_(window);
+  if (ret != TIZEN_ERROR_NONE) {
+    LOG_ERROR("tizen_core_wl_window_activate failed: %s",
+              get_error_message(ret));
+  }
 }
 
 void TizenCoreWlWindowProxy::Lower(void *window) {
@@ -58,5 +67,8 @@ void TizenCoreWlWindowProxy::Lower(void *window) {
     LOG_ERROR("tizen-core-wl handle not valid");
     return;
   }
-  lower_(window);
+  int ret = lower_(window);
+  if (ret != TIZEN_ERROR_NONE) {
+    LOG_ERROR("tizen_core_wl_window_lower failed: %s", get_error_message(ret));
+  }
 }

--- a/packages/tizen_window_manager/tizen/src/tizen_core_wl_window_proxy.h
+++ b/packages/tizen_window_manager/tizen/src/tizen_core_wl_window_proxy.h
@@ -1,0 +1,34 @@
+// Copyright 2025 Samsung Electronics Co., Ltd. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef FLUTTER_PLUGIN_TIZEN_CORE_WL_WINDOW_PROXY_H_
+#define FLUTTER_PLUGIN_TIZEN_CORE_WL_WINDOW_PROXY_H_
+
+#include "window_proxy_interface.h"
+
+class TizenCoreWlWindowProxy : public WindowProxyInterface {
+ public:
+  TizenCoreWlWindowProxy();
+  ~TizenCoreWlWindowProxy() override;
+
+  bool IsValid() const { return handle_ != nullptr; }
+
+  void GetGeometry(void *window, int *x, int *y, int *width,
+                   int *height) override;
+  void Activate(void *window) override;
+  void Lower(void *window) override;
+
+ private:
+  typedef int (*FuncGetGeometry)(void *window, int *x, int *y, int *width,
+                                 int *height);
+  typedef int (*FuncActivate)(void *window);
+  typedef int (*FuncLower)(void *window);
+
+  void *handle_ = nullptr;
+  FuncGetGeometry get_geometry_ = nullptr;
+  FuncActivate activate_ = nullptr;
+  FuncLower lower_ = nullptr;
+};
+
+#endif  // FLUTTER_PLUGIN_TIZEN_CORE_WL_WINDOW_PROXY_H_

--- a/packages/tizen_window_manager/tizen/src/tizen_window_manager.cc
+++ b/packages/tizen_window_manager/tizen/src/tizen_window_manager.cc
@@ -9,11 +9,11 @@
 
 #include <memory>
 
-#include "ecore_wl2_window_proxy.h"
 #include "log.h"
+#include "window_proxy.h"
 
 TizenWindowManager::TizenWindowManager(void* handle)
-    : window_handle_(handle), proxy_(std::make_unique<EcoreWl2WindowProxy>()) {}
+    : window_handle_(handle), proxy_(std::make_unique<WindowProxy>()) {}
 
 TizenWindowManager::~TizenWindowManager() {}
 
@@ -22,7 +22,7 @@ void TizenWindowManager::Activate() {
     LOG_ERROR("Window handle is null");
   }
 
-  proxy_->ecore_wl2_window_activate(window_handle_);
+  proxy_->Activate(window_handle_);
 }
 
 void TizenWindowManager::Lower() {
@@ -30,7 +30,7 @@ void TizenWindowManager::Lower() {
     LOG_ERROR("Window handle is null");
   }
 
-  proxy_->ecore_wl2_window_lower(window_handle_);
+  proxy_->Lower(window_handle_);
 }
 
 flutter::EncodableMap TizenWindowManager::GetGeometry() {
@@ -46,8 +46,7 @@ flutter::EncodableMap TizenWindowManager::GetGeometry() {
   }
 
   int x, y, width, height;
-  proxy_->ecore_wl2_window_geometry_get(window_handle_, &x, &y, &width,
-                                        &height);
+  proxy_->GetGeometry(window_handle_, &x, &y, &width, &height);
 
   geometry[flutter::EncodableValue("x")] = flutter::EncodableValue(x);
   geometry[flutter::EncodableValue("y")] = flutter::EncodableValue(y);

--- a/packages/tizen_window_manager/tizen/src/tizen_window_manager.cc
+++ b/packages/tizen_window_manager/tizen/src/tizen_window_manager.cc
@@ -45,7 +45,7 @@ flutter::EncodableMap TizenWindowManager::GetGeometry() {
     return geometry;
   }
 
-  int x, y, width, height;
+  int x = 0, y = 0, width = 0, height = 0;
   proxy_->GetGeometry(window_handle_, &x, &y, &width, &height);
 
   geometry[flutter::EncodableValue("x")] = flutter::EncodableValue(x);

--- a/packages/tizen_window_manager/tizen/src/tizen_window_manager.h
+++ b/packages/tizen_window_manager/tizen/src/tizen_window_manager.h
@@ -10,7 +10,7 @@
 
 #include <memory>
 
-class EcoreWl2WindowProxy;
+class WindowProxy;
 
 class TizenWindowManager {
  public:
@@ -23,7 +23,7 @@ class TizenWindowManager {
 
  private:
   void* window_handle_;
-  std::unique_ptr<EcoreWl2WindowProxy> proxy_;
+  std::unique_ptr<WindowProxy> proxy_;
 };
 
 #endif  // FLUTTER_PLUGIN_TIZEN_WINDOW_MANAGER_H_

--- a/packages/tizen_window_manager/tizen/src/window_proxy.cc
+++ b/packages/tizen_window_manager/tizen/src/window_proxy.cc
@@ -1,0 +1,57 @@
+// Copyright 2025 Samsung Electronics Co., Ltd. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "window_proxy.h"
+
+#include <system_info.h>
+
+#include <cstdlib>
+#include <memory>
+#include <utility>
+
+#include "ecore_wl2_window_proxy.h"
+#include "log.h"
+#include "tizen_core_wl_window_proxy.h"
+
+namespace {
+
+constexpr int kTizenCoreWlMinMajorVersion = 11;
+
+int GetPlatformMajorVersion() {
+  char *version = nullptr;
+  int ret = system_info_get_platform_string(
+      "http://tizen.org/feature/platform.version", &version);
+  if (ret != SYSTEM_INFO_ERROR_NONE || version == nullptr) {
+    LOG_ERROR("Failed to get platform version. error: %d", ret);
+    return 0;
+  }
+
+  int major = std::atoi(version);
+  free(version);
+  return major;
+}
+
+}  // namespace
+
+WindowProxy::WindowProxy() {
+  if (GetPlatformMajorVersion() >= kTizenCoreWlMinMajorVersion) {
+    auto proxy = std::make_unique<TizenCoreWlWindowProxy>();
+    if (proxy->IsValid()) {
+      LOG_INFO("Using tizen-core-wl backend.");
+      impl_ = std::move(proxy);
+      return;
+    }
+    LOG_INFO("tizen-core-wl unavailable, falling back to ecore_wl2 backend.");
+  }
+  impl_ = std::make_unique<EcoreWl2WindowProxy>();
+}
+
+void WindowProxy::GetGeometry(void *window, int *x, int *y, int *width,
+                              int *height) {
+  impl_->GetGeometry(window, x, y, width, height);
+}
+
+void WindowProxy::Activate(void *window) { impl_->Activate(window); }
+
+void WindowProxy::Lower(void *window) { impl_->Lower(window); }

--- a/packages/tizen_window_manager/tizen/src/window_proxy.h
+++ b/packages/tizen_window_manager/tizen/src/window_proxy.h
@@ -2,15 +2,17 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-#ifndef FLUTTER_PLUGIN_ECORE_WL2_WINDOW_PROXY_H_
-#define FLUTTER_PLUGIN_ECORE_WL2_WINDOW_PROXY_H_
+#ifndef FLUTTER_PLUGIN_WINDOW_PROXY_H_
+#define FLUTTER_PLUGIN_WINDOW_PROXY_H_
+
+#include <memory>
 
 #include "window_proxy_interface.h"
 
-class EcoreWl2WindowProxy : public WindowProxyInterface {
+class WindowProxy : public WindowProxyInterface {
  public:
-  EcoreWl2WindowProxy();
-  ~EcoreWl2WindowProxy() override;
+  WindowProxy();
+  ~WindowProxy() override = default;
 
   void GetGeometry(void *window, int *x, int *y, int *width,
                    int *height) override;
@@ -18,7 +20,7 @@ class EcoreWl2WindowProxy : public WindowProxyInterface {
   void Lower(void *window) override;
 
  private:
-  void *ecore_wl2_window_handle_ = nullptr;
+  std::unique_ptr<WindowProxyInterface> impl_;
 };
 
-#endif  // FLUTTER_PLUGIN_ECORE_WL2_WINDOW_PROXY_H_
+#endif  // FLUTTER_PLUGIN_WINDOW_PROXY_H_

--- a/packages/tizen_window_manager/tizen/src/window_proxy_interface.h
+++ b/packages/tizen_window_manager/tizen/src/window_proxy_interface.h
@@ -1,0 +1,18 @@
+// Copyright 2025 Samsung Electronics Co., Ltd. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef FLUTTER_PLUGIN_WINDOW_PROXY_INTERFACE_H_
+#define FLUTTER_PLUGIN_WINDOW_PROXY_INTERFACE_H_
+
+class WindowProxyInterface {
+ public:
+  virtual ~WindowProxyInterface() = default;
+
+  virtual void GetGeometry(void *window, int *x, int *y, int *width,
+                           int *height) = 0;
+  virtual void Activate(void *window) = 0;
+  virtual void Lower(void *window) = 0;
+};
+
+#endif  // FLUTTER_PLUGIN_WINDOW_PROXY_INTERFACE_H_


### PR DESCRIPTION
Introduce a WindowProxyInterface abstraction with two backends selected at runtime by WindowProxy:
  - TizenCoreWlWindowProxy (tizen-core-wl) on Tizen API version >= 11.0 when the library is available
  - EcoreWl2WindowProxy (ecore_wl2) otherwise, including as a fallback when tizen-core-wl cannot be loaded on 11.0+

Both backends implement WindowProxyInterface (GetGeometry/Activate/Lower) and resolve their symbols at runtime via dlopen/dlsym. TizenWindowManager constructs WindowProxy, which picks the backend by querying the platform version at startup.